### PR TITLE
feat: add `Contains` expectations for `string`

### DIFF
--- a/Source/Testably.Expectations/Collections/QuantifiableCollection.AreEqualConstraint.cs
+++ b/Source/Testably.Expectations/Collections/QuantifiableCollection.AreEqualConstraint.cs
@@ -8,7 +8,7 @@ namespace Testably.Expectations.Collections;
 
 public partial class QuantifiableCollection<TItem>
 {
-	private readonly struct AreEqualConstraint(TItem expected, Quantifier quantifier)
+	private readonly struct AreEqualConstraint(TItem expected, CollectionQuantifier quantifier)
 		: IConstraint<IEnumerable<TItem>>
 	{
 		public ConstraintResult IsMetBy(IEnumerable<TItem> actual)

--- a/Source/Testably.Expectations/Collections/QuantifiableCollection.AreEquivalentToConstraint.cs
+++ b/Source/Testably.Expectations/Collections/QuantifiableCollection.AreEquivalentToConstraint.cs
@@ -8,7 +8,7 @@ namespace Testably.Expectations.Collections;
 
 public partial class QuantifiableCollection<TItem>
 {
-	private readonly struct AreEquivalentToConstraint(TItem expected, Quantifier quantifier)
+	private readonly struct AreEquivalentToConstraint(TItem expected, CollectionQuantifier quantifier)
 		: IConstraint<IEnumerable<TItem>>
 	{
 		public ConstraintResult IsMetBy(IEnumerable<TItem> actual)

--- a/Source/Testably.Expectations/Collections/QuantifiableCollection.SatisfyConstraint.cs
+++ b/Source/Testably.Expectations/Collections/QuantifiableCollection.SatisfyConstraint.cs
@@ -12,7 +12,7 @@ public partial class QuantifiableCollection<TItem>
 	private readonly struct SatisfyConstraint(
 		Func<TItem, bool> predicate,
 		string expression,
-		Quantifier quantifier) : IConstraint<IEnumerable<TItem>>
+		CollectionQuantifier quantifier) : IConstraint<IEnumerable<TItem>>
 	{
 		public ConstraintResult IsMetBy(IEnumerable<TItem> actual)
 		{

--- a/Source/Testably.Expectations/Collections/QuantifiableCollection.cs
+++ b/Source/Testably.Expectations/Collections/QuantifiableCollection.cs
@@ -12,7 +12,7 @@ namespace Testably.Expectations.Collections;
 /// </summary>
 public partial class QuantifiableCollection<TItem>(
 	That<IEnumerable<TItem>> source,
-	Quantifier quantity)
+	CollectionQuantifier quantity)
 {
 	/// <summary>
 	///     ...are equal to <paramref name="expected" />.

--- a/Source/Testably.Expectations/Collections/ThatCollectionExtensions.cs
+++ b/Source/Testably.Expectations/Collections/ThatCollectionExtensions.cs
@@ -19,7 +19,7 @@ public static partial class ThatCollectionExtensions
 	public static QuantifiableCollection<TItem> All<TItem>(this That<IEnumerable<TItem>> source)
 	{
 		source.ExpectationBuilder.AppendExpression(b => b.AppendMethod(nameof(All)));
-		return new QuantifiableCollection<TItem>(source, Quantifier.All);
+		return new QuantifiableCollection<TItem>(source, CollectionQuantifier.All);
 	}
 
 	/// <summary>
@@ -30,7 +30,7 @@ public static partial class ThatCollectionExtensions
 	{
 		source.ExpectationBuilder.AppendExpression(b
 			=> b.AppendMethod(nameof(AtLeast), doNotPopulateThisValue));
-		return new QuantifiableCollection<TItem>(source, Quantifier.AtLeast(minimum));
+		return new QuantifiableCollection<TItem>(source, CollectionQuantifier.AtLeast(minimum));
 	}
 
 	/// <summary>
@@ -41,7 +41,7 @@ public static partial class ThatCollectionExtensions
 	{
 		source.ExpectationBuilder.AppendExpression(b
 			=> b.AppendMethod(nameof(AtMost), doNotPopulateThisValue));
-		return new QuantifiableCollection<TItem>(source, Quantifier.AtMost(maximum));
+		return new QuantifiableCollection<TItem>(source, CollectionQuantifier.AtMost(maximum));
 	}
 
 	/// <summary>
@@ -54,7 +54,7 @@ public static partial class ThatCollectionExtensions
 	{
 		source.ExpectationBuilder.AppendExpression(b
 			=> b.AppendMethod(nameof(Between), doNotPopulateThisValue1, doNotPopulateThisValue2));
-		return new QuantifiableCollection<TItem>(source, Quantifier.Between(minimum, maximum));
+		return new QuantifiableCollection<TItem>(source, CollectionQuantifier.Between(minimum, maximum));
 	}
 
 	/// <summary>
@@ -95,6 +95,6 @@ public static partial class ThatCollectionExtensions
 	public static QuantifiableCollection<TItem> None<TItem>(this That<IEnumerable<TItem>> source)
 	{
 		source.ExpectationBuilder.AppendExpression(b => b.AppendMethod(nameof(None)));
-		return new QuantifiableCollection<TItem>(source, Quantifier.None);
+		return new QuantifiableCollection<TItem>(source, CollectionQuantifier.None);
 	}
 }

--- a/Source/Testably.Expectations/Core/CollectionQuantifier.cs
+++ b/Source/Testably.Expectations/Core/CollectionQuantifier.cs
@@ -1,0 +1,152 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Testably.Expectations.Core;
+
+/// <summary>
+///     Quantifier for collections.
+/// </summary>
+public abstract class CollectionQuantifier
+{
+	/// <summary>
+	///     Matches all items in the collection.
+	/// </summary>
+	public static CollectionQuantifier All => new AllQuantifier();
+
+	/// <summary>
+	///     Matches no items in the collection.
+	/// </summary>
+	public static CollectionQuantifier None => new NoneQuantifier();
+
+	/// <summary>
+	///     Matches at least <paramref name="minimum" /> items.
+	/// </summary>
+	public static CollectionQuantifier AtLeast(int minimum) => new AtLeastQuantifier(minimum);
+
+	/// <summary>
+	///     Matches at most <paramref name="maximum" /> items.
+	/// </summary>
+	public static CollectionQuantifier AtMost(int maximum) => new AtMostQuantifier(maximum);
+
+	/// <summary>
+	///     Matches between <paramref name="minimum" /> and <paramref name="maximum" /> items.
+	/// </summary>
+	public static CollectionQuantifier Between(int minimum, int maximum)
+		=> new BetweenQuantifier(minimum, maximum);
+
+	/// <summary>
+	///     Checks if the number of <paramref name="actual" /> items of the <paramref name="total" /> items match the
+	///     condition.
+	///     <para />
+	///     If not, the <paramref name="error" /> contains the error message.
+	/// </summary>
+	public abstract bool CheckCondition(int total, int actual,
+		[NotNullWhen(false)] out string? error);
+
+	private class NoneQuantifier : CollectionQuantifier
+	{
+		/// <inheritdoc />
+		public override bool CheckCondition(int total, int actual,
+			[NotNullWhen(false)] out string? error)
+		{
+			if (actual == 0)
+			{
+				error = null;
+				return true;
+			}
+
+			error = $"{actual}";
+			return false;
+		}
+
+		/// <inheritdoc />
+		public override string ToString() => "no items";
+	}
+
+	private class AllQuantifier : CollectionQuantifier
+	{
+		/// <inheritdoc />
+		public override bool CheckCondition(int total, int actual,
+			[NotNullWhen(false)] out string? error)
+		{
+			if (actual == total)
+			{
+				error = null;
+				return true;
+			}
+
+			error = $"only {actual} of {total}";
+			return false;
+		}
+
+		/// <inheritdoc />
+		public override string ToString() => "all items";
+	}
+
+	private class AtLeastQuantifier(int minimum) : CollectionQuantifier
+	{
+		/// <inheritdoc />
+		public override bool CheckCondition(int total, int actual,
+			[NotNullWhen(false)] out string? error)
+		{
+			if (actual >= minimum)
+			{
+				error = null;
+				return true;
+			}
+
+			error = $"only {actual} of {total}";
+			return false;
+		}
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> $"at least {minimum} {(minimum == 1 ? "item" : "items")}";
+	}
+
+	private class BetweenQuantifier(int minimum, int maximum) : CollectionQuantifier
+	{
+		/// <inheritdoc />
+		public override bool CheckCondition(int total, int actual,
+			[NotNullWhen(false)] out string? error)
+		{
+			if (actual >= minimum && actual <= maximum)
+			{
+				error = null;
+				return true;
+			}
+
+			if (actual >= minimum)
+			{
+				error = $"{actual}";
+				return false;
+			}
+
+			error = $"only {actual}";
+			return false;
+		}
+
+		/// <inheritdoc />
+		public override string ToString() => $"between {minimum} and {maximum} items";
+	}
+
+	private class AtMostQuantifier(int maximum) : CollectionQuantifier
+	{
+		/// <inheritdoc />
+		public override bool CheckCondition(int total, int actual,
+			[NotNullWhen(false)] out string? error)
+		{
+			if (actual <= maximum)
+			{
+				error = null;
+				return true;
+			}
+
+			error = $"{actual} of {total}";
+			return false;
+		}
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> $"at most {maximum} {(maximum == 1 ? "item" : "items")}";
+	}
+}

--- a/Source/Testably.Expectations/Core/Results/AndOrExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/AndOrExpectationResult.cs
@@ -13,7 +13,8 @@ public class AndOrExpectationResult<TResult, TValue>(
 	IExpectationBuilder expectationBuilder,
 	TValue returnValue)
 	: AndOrExpectationResult<TResult, TValue, AndOrExpectationResult<TResult, TValue>>(
-		expectationBuilder, returnValue);
+		expectationBuilder,
+		returnValue);
 
 /// <summary>
 ///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.

--- a/Source/Testably.Expectations/Core/Results/AndOrWhichExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/AndOrWhichExpectationResult.cs
@@ -9,19 +9,37 @@ namespace Testably.Expectations.Core.Results;
 /// <summary>
 ///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
 ///     <para />
-///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows accessing underlying
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows accessing
+///     underlying
+///     properties with <see cref="AndOrWhichExpectationResult{TResult,TValue,TSelf}.Which{TProperty}" />.
+/// </summary>
+[StackTraceHidden]
+public class AndOrWhichExpectationResult<TResult, TValue>(
+	IExpectationBuilder expectationBuilder,
+	TValue returnValue)
+	: AndOrWhichExpectationResult<TResult, TValue, AndOrWhichExpectationResult<TResult, TValue>>(
+		expectationBuilder, returnValue);
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows accessing
+///     underlying
 ///     properties with <see cref="Which{TProperty}" />.
 /// </summary>
 [StackTraceHidden]
-public class AndOrWhichExpectationResult<TResult, TValue>(IExpectationBuilder expectationBuilder, TValue returnValue)
-	: AndOrExpectationResult<TResult, TValue>(expectationBuilder, returnValue)
+public class AndOrWhichExpectationResult<TResult, TValue, TSelf>(
+	IExpectationBuilder expectationBuilder,
+	TValue returnValue)
+	: AndOrExpectationResult<TResult, TValue, TSelf>(expectationBuilder, returnValue)
+	where TSelf : AndOrWhichExpectationResult<TResult, TValue, TSelf>
 {
 	private readonly IExpectationBuilder _expectationBuilder = expectationBuilder;
 
 	/// <summary>
 	///     Allows specifying expectations on a property of the current value.
 	/// </summary>
-	public AndOrWhichExpectationResult<TResult, TValue> Which<TProperty>(
+	public AndOrWhichExpectationResult<TResult, TValue, TSelf> Which<TProperty>(
 		Expression<Func<TResult, TProperty?>> selector,
 		Action<That<TProperty?>> expectations,
 		[CallerArgumentExpression("selector")] string doNotPopulateThisValue1 = "",

--- a/Source/Testably.Expectations/Core/Results/CountExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/CountExpectationResult.cs
@@ -1,0 +1,114 @@
+﻿using System.Runtime.CompilerServices;
+using Testably.Expectations.Core.Helpers;
+
+namespace Testably.Expectations.Core.Results;
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying
+///     options
+///     on
+///     the <see cref="StringMatcher" />.
+/// </summary>
+public class CountExpectationResult<TResult, TValue>(
+	IExpectationBuilder expectationBuilder,
+	TValue returnValue,
+	Quantifier quantifier)
+	: CountExpectationResult<TResult, TValue,
+		CountExpectationResult<TResult, TValue>>(
+		expectationBuilder,
+		returnValue,
+		quantifier);
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying
+///     options
+///     on
+///     the <see cref="StringMatcher" />.
+/// </summary>
+public class CountExpectationResult<TResult, TValue, TSelf>(
+	IExpectationBuilder expectationBuilder,
+	TValue returnValue,
+	Quantifier quantifier)
+	: AndOrExpectationResult<TResult, TValue, TSelf>(expectationBuilder, returnValue)
+	where TSelf : CountExpectationResult<TResult, TValue, TSelf>
+{
+	private readonly IExpectationBuilder _expectationBuilder = expectationBuilder;
+
+	/// <summary>
+	///     Verifies, that it occurs at least <paramref name="minimum" /> times.
+	/// </summary>
+	public TSelf AtLeast(
+		int minimum,
+		[CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
+	{
+		quantifier.AtLeast(minimum);
+		_expectationBuilder.AppendExpression(b
+			=> b.AppendMethod(nameof(AtLeast), doNotPopulateThisValue));
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Verifies, that it occurs at most <paramref name="maximum" /> times.
+	/// </summary>
+	public TSelf AtMost(
+		int maximum,
+		[CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "")
+	{
+		quantifier.AtMost(maximum);
+		_expectationBuilder.AppendExpression(b
+			=> b.AppendMethod(nameof(AtMost), doNotPopulateThisValue));
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Verifies, that it occurs between <paramref name="minimum" /> and <paramref name="maximum" /> times.
+	/// </summary>
+	public TSelf Between(
+		int minimum,
+		int maximum,
+		[CallerArgumentExpression("minimum")] string doNotPopulateThisValue1 = "",
+		[CallerArgumentExpression("maximum")] string doNotPopulateThisValue2 = "")
+	{
+		quantifier.Between(minimum, maximum);
+		_expectationBuilder.AppendExpression(b
+			=> b.AppendMethod(nameof(Between), doNotPopulateThisValue1, doNotPopulateThisValue2));
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Verifies, that it occurs exactly <paramref name="expected" /> times.
+	/// </summary>
+	public TSelf Exactly(
+		int expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		quantifier.Exactly(expected);
+		_expectationBuilder.AppendExpression(b
+			=> b.AppendMethod(nameof(Exactly), doNotPopulateThisValue));
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Verifies, that it occurs never.
+	/// </summary>
+	public TSelf Never()
+	{
+		quantifier.Exactly(0);
+		_expectationBuilder.AppendExpression(b => b.AppendMethod(nameof(Never)));
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Verifies, that it occurs exactly once.
+	/// </summary>
+	public TSelf Once()
+	{
+		quantifier.Exactly(1);
+		_expectationBuilder.AppendExpression(b => b.AppendMethod(nameof(Once)));
+		return (TSelf)this;
+	}
+}

--- a/Source/Testably.Expectations/Core/Results/StringCountExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/StringCountExpectationResult.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core.Helpers;
+
+namespace Testably.Expectations.Core.Results;
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying
+///     options
+///     on
+///     the <see cref="StringMatcher" />.
+/// </summary>
+public class StringCountExpectationResult<TResult, TValue>(
+	IExpectationBuilder expectationBuilder,
+	TValue returnValue,
+	Quantifier quantifier,
+	StringOptions options)
+	: StringCountExpectationResult<TResult, TValue,
+		StringCountExpectationResult<TResult, TValue>>(
+		expectationBuilder,
+		returnValue,
+		quantifier,
+		options);
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying
+///     options
+///     on
+///     the <see cref="StringMatcher" />.
+/// </summary>
+public class StringCountExpectationResult<TResult, TValue, TSelf>(
+	IExpectationBuilder expectationBuilder,
+	TValue returnValue,
+	Quantifier quantifier,
+	StringOptions options)
+	: CountExpectationResult<TResult, TValue, TSelf>(expectationBuilder, returnValue, quantifier)
+	where TSelf : StringCountExpectationResult<TResult, TValue, TSelf>
+{
+	private readonly IExpectationBuilder _expectationBuilder1 = expectationBuilder;
+
+	/// <summary>
+	///     Ignores casing when comparing the <see langword="string" />s.
+	/// </summary>
+	public StringCountExpectationResult<TResult, TValue, TSelf> IgnoringCase()
+	{
+		options.IgnoringCase();
+		_expectationBuilder1.AppendExpression(b => b.AppendMethod(nameof(IgnoringCase)));
+		return this;
+	}
+
+	/// <summary>
+	///     Uses the provided <paramref name="comparer" /> for comparing <see langword="string" />s.
+	/// </summary>
+	public StringCountExpectationResult<TResult, TValue, TSelf> Using(
+		IEqualityComparer<string> comparer,
+		[CallerArgumentExpression("comparer")] string doNotPopulateThisValue = "")
+	{
+		options.UsingComparer(comparer);
+		_expectationBuilder1.AppendExpression(b
+			=> b.AppendMethod(nameof(Using), doNotPopulateThisValue));
+		return this;
+	}
+}

--- a/Source/Testably.Expectations/Core/Results/StringExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/StringExpectationResult.cs
@@ -7,41 +7,40 @@ namespace Testably.Expectations.Core.Results;
 /// <summary>
 ///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
 ///     <para />
-///     In addition to the combinations from <see cref="CountExpectationResult{TResult,TValue}" />, allows specifying
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying
 ///     options on the <see cref="StringOptions" />.
 /// </summary>
-public class StringCountExpectationResult<TResult, TValue>(
+public class StringExpectationResult<TResult, TValue>(
 	IExpectationBuilder expectationBuilder,
 	TValue returnValue,
-	Quantifier quantifier,
 	StringOptions options)
-	: StringCountExpectationResult<TResult, TValue,
-		StringCountExpectationResult<TResult, TValue>>(
+	: StringExpectationResult<TResult, TValue,
+		StringExpectationResult<TResult, TValue>>(
 		expectationBuilder,
 		returnValue,
-		quantifier,
 		options);
 
 /// <summary>
 ///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
 ///     <para />
-///     In addition to the combinations from <see cref="CountExpectationResult{TResult,TValue}" />, allows specifying
-///     options on the <see cref="StringOptions" />.
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying
+///     options
+///     on
+///     the <see cref="StringMatcher" />.
 /// </summary>
-public class StringCountExpectationResult<TResult, TValue, TSelf>(
+public class StringExpectationResult<TResult, TValue, TSelf>(
 	IExpectationBuilder expectationBuilder,
 	TValue returnValue,
-	Quantifier quantifier,
 	StringOptions options)
-	: CountExpectationResult<TResult, TValue, TSelf>(expectationBuilder, returnValue, quantifier)
-	where TSelf : StringCountExpectationResult<TResult, TValue, TSelf>
+	: AndOrExpectationResult<TResult, TValue, TSelf>(expectationBuilder, returnValue)
+	where TSelf : StringExpectationResult<TResult, TValue, TSelf>
 {
 	private readonly IExpectationBuilder _expectationBuilder1 = expectationBuilder;
 
 	/// <summary>
 	///     Ignores casing when comparing the <see langword="string" />s.
 	/// </summary>
-	public StringCountExpectationResult<TResult, TValue, TSelf> IgnoringCase()
+	public StringExpectationResult<TResult, TValue, TSelf> IgnoringCase()
 	{
 		options.IgnoringCase();
 		_expectationBuilder1.AppendExpression(b => b.AppendMethod(nameof(IgnoringCase)));
@@ -51,7 +50,7 @@ public class StringCountExpectationResult<TResult, TValue, TSelf>(
 	/// <summary>
 	///     Uses the provided <paramref name="comparer" /> for comparing <see langword="string" />s.
 	/// </summary>
-	public StringCountExpectationResult<TResult, TValue, TSelf> Using(
+	public StringExpectationResult<TResult, TValue, TSelf> Using(
 		IEqualityComparer<string> comparer,
 		[CallerArgumentExpression("comparer")] string doNotPopulateThisValue = "")
 	{

--- a/Source/Testably.Expectations/Core/Results/StringMatcherExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/StringMatcherExpectationResult.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using Testably.Expectations.Core.Helpers;
 
 namespace Testably.Expectations.Core.Results;
@@ -6,14 +8,16 @@ namespace Testably.Expectations.Core.Results;
 /// <summary>
 ///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
 ///     <para />
-///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying options
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying
+///     options
 ///     on
 ///     the <see cref="StringMatcher" />.
 /// </summary>
 public class StringMatcherExpectationResult<TResult, TValue>(
 	IExpectationBuilder expectationBuilder,
 	TValue returnValue,
-	StringMatcher expected) : AndOrExpectationResult<TResult, TValue>(expectationBuilder, returnValue)
+	StringMatcher expected)
+	: AndOrExpectationResult<TResult, TValue>(expectationBuilder, returnValue)
 {
 	private readonly IExpectationBuilder _expectationBuilder = expectationBuilder;
 
@@ -45,6 +49,19 @@ public class StringMatcherExpectationResult<TResult, TValue>(
 	{
 		expected.IgnoringCase();
 		_expectationBuilder.AppendExpression(b => b.AppendMethod(nameof(IgnoringCase)));
+		return this;
+	}
+
+	/// <summary>
+	///     Uses the provided <paramref name="comparer" /> for comparing <see langword="string" />s.
+	/// </summary>
+	public StringMatcherExpectationResult<TResult, TValue> Using(
+		IEqualityComparer<string> comparer,
+		[CallerArgumentExpression("comparer")] string doNotPopulateThisValue = "")
+	{
+		expected.UsingComparer(comparer);
+		_expectationBuilder.AppendExpression(b
+			=> b.AppendMethod(nameof(Using), doNotPopulateThisValue));
 		return this;
 	}
 }

--- a/Source/Testably.Expectations/Core/StringOptions.cs
+++ b/Source/Testably.Expectations/Core/StringOptions.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using Testably.Expectations.Core.Formatting;
+
+namespace Testably.Expectations.Core;
+
+/// <summary>
+///     Quantifier an occurrence.
+/// </summary>
+public class StringOptions
+{
+	/// <summary>
+	///     The <see cref="IEqualityComparer{T}" /> to use for comparing <see langword="string" />s.
+	/// </summary>
+	public IEqualityComparer<string> Comparer
+		=> _comparer ?? UseDefaultComparer(IgnoreCase);
+
+	/// <summary>
+	///     Flag indicating, if casing is ignored when comparing the <see langword="string" />s.
+	/// </summary>
+	public bool IgnoreCase { get; private set; }
+
+	private IEqualityComparer<string>? _comparer;
+
+	/// <summary>
+	///     Ignores casing when comparing the <see langword="string" />s.
+	/// </summary>
+	public StringOptions IgnoringCase(bool ignoreCase = true)
+	{
+		IgnoreCase = ignoreCase;
+		return this;
+	}
+
+	/// <inheritdoc />
+	public override string ToString()
+	{
+		if (_comparer != null)
+		{
+			return $" using {Formatter.Format(_comparer.GetType())}";
+		}
+
+		if (IgnoreCase)
+		{
+			return " ignoring case";
+		}
+
+		return "";
+	}
+
+	/// <summary>
+	///     Specifies a specific <see cref="IEqualityComparer{T}" /> to use for comparing <see langword="string" />s.
+	/// </summary>
+	/// <remarks>
+	///     If set to <see langword="null" /> (default), uses the <see cref="StringComparer.Ordinal" /> or
+	///     <see cref="StringComparer.OrdinalIgnoreCase" /> depending on whether the casing is ignored.
+	/// </remarks>
+	public StringOptions UsingComparer(IEqualityComparer<string>? comparer)
+	{
+		_comparer = comparer;
+		return this;
+	}
+
+	private static StringComparer UseDefaultComparer(bool ignoreCase)
+		=> ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+}

--- a/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.HasParamNameConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.HasParamNameConstraint.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+using Testably.Expectations.Core.Sources;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatExceptionExtensions
+{
+	private readonly struct HasParamNameConstraint<T>(string expected) : IConstraint<T>,
+		IDelegateConstraint<DelegateSource.NoValue>
+		where T : ArgumentException
+	{
+		public ConstraintResult IsMetBy(SourceValue<DelegateSource.NoValue> value)
+		{
+			return IsMetBy(value.Exception as T);
+		}
+
+		public ConstraintResult IsMetBy(T? actual)
+		{
+			if (actual == null)
+			{
+				return new ConstraintResult.Failure(ToString(),
+					"found <null>");
+			}
+
+			if (actual.ParamName == expected)
+			{
+				return new ConstraintResult.Success<T?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(),
+				$"found ParamName {Formatter.Format(actual.ParamName)}");
+		}
+
+		public override string ToString()
+			=> $"has ParamName {Formatter.Format(expected)}";
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.cs
@@ -83,6 +83,19 @@ public static partial class ThatExceptionExtensions
 			source,
 			expected);
 
+	/// <summary>
+	///     Verifies that the actual exception has a message equal to <paramref name="expected" />
+	/// </summary>
+	public static AndOrExpectationResult<TException, That<TException?>> HasParamName<TException>(
+		this That<TException?> source,
+		string expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		where TException : ArgumentException
+		=> new(source.ExpectationBuilder.Add(
+				new HasParamNameConstraint<TException>(expected),
+				b => b.AppendMethod(nameof(HasMessage), doNotPopulateThisValue)),
+			source);
+
 	private class CastException<TBase, TTarget> : IConstraint<TBase?, TTarget?>
 		where TBase : Exception
 		where TTarget : Exception

--- a/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.ContainsConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.ContainsConstraint.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatStringExtensions
+{
+	private readonly struct ContainsConstraint(
+		string expected,
+		Quantifier quantifier,
+		StringOptions options)
+		: IConstraint<string?>
+	{
+		/// <inheritdoc />
+		public ConstraintResult IsMetBy(string? actual)
+		{
+			if (actual is null)
+			{
+				return new ConstraintResult.Failure<string?>(actual, ToString(),
+					"found <null>");
+			}
+
+			int actualCount = CountOccurrences(actual, expected, options.Comparer);
+			if (quantifier.Check(actualCount))
+			{
+				return new ConstraintResult.Success<string?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure<string?>(actual, ToString(),
+				$"found it {actualCount} times in {Formatter.Format(actual)}");
+		}
+
+		private static int CountOccurrences(string actual, string expected,
+			IEqualityComparer<string> comparer)
+		{
+			if (expected.Length > actual.Length)
+			{
+				return 0;
+			}
+
+			int count = 0;
+			int index = 0;
+			while (index < actual.Length)
+			{
+				if (comparer.Equals(actual.Substring(index, Math.Min(expected.Length, actual.Length - index)), expected))
+				{
+					count++;
+					index += expected.Length;
+				}
+				else
+				{
+					index++;
+				}
+			}
+
+			return count;
+		}
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> $"contains {Formatter.Format(expected)} {quantifier}{options}";
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.ContainsConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.ContainsConstraint.cs
@@ -46,7 +46,9 @@ public static partial class ThatStringExtensions
 			int index = 0;
 			while (index < actual.Length)
 			{
-				if (comparer.Equals(actual.Substring(index, Math.Min(expected.Length, actual.Length - index)), expected))
+				if (comparer.Equals(
+					actual.Substring(index, Math.Min(expected.Length, actual.Length - index)),
+					expected))
 				{
 					count++;
 					index += expected.Length;
@@ -62,6 +64,14 @@ public static partial class ThatStringExtensions
 
 		/// <inheritdoc />
 		public override string ToString()
-			=> $"contains {Formatter.Format(expected)} {quantifier}{options}";
+		{
+			string quantifierString = quantifier.ToString();
+			if (quantifierString == "never")
+			{
+				return $"does not contain {Formatter.Format(expected)}{options}";
+			}
+
+			return $"contains {Formatter.Format(expected)} {quantifier}{options}";
+		}
 	}
 }

--- a/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.cs
@@ -14,7 +14,8 @@ public static partial class ThatStringExtensions
 	/// <summary>
 	///     Verifies that the actual value is equal to <paramref name="expected" />.
 	/// </summary>
-	public static StringMatcherExpectationResult<string?, That<string?>> Is(this That<string?> source,
+	public static StringMatcherExpectationResult<string?, That<string?>> Is(
+		this That<string?> source,
 		StringMatcher expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		=> new(source.ExpectationBuilder.Add(
@@ -24,9 +25,28 @@ public static partial class ThatStringExtensions
 			expected);
 
 	/// <summary>
+	///     Verifies that the actual value contains the <paramref name="expected" /> <see langword="string" />.
+	/// </summary>
+	public static StringCountExpectationResult<string?, That<string?>> Contains(
+		this That<string?> source,
+		string expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		var quantifier = new Quantifier();
+		var options = new StringOptions();
+		return new StringCountExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
+				new ContainsConstraint(expected, quantifier, options),
+				b => b.AppendMethod(nameof(Is), doNotPopulateThisValue)),
+			source,
+			quantifier,
+			options);
+	}
+
+	/// <summary>
 	///     Verifies that the actual value is not <see langword="null" />.
 	/// </summary>
-	public static AndOrExpectationResult<string, That<string?>> IsNotNull(this That<string?> source)
+	public static AndOrExpectationResult<string, That<string?>> IsNotNull(
+		this That<string?> source)
 		=> new(source.ExpectationBuilder.Add(
 				new IsNotNullConstraint(),
 				b => b.AppendMethod(nameof(IsNotNull))),
@@ -35,7 +55,8 @@ public static partial class ThatStringExtensions
 	/// <summary>
 	///     Verifies that the actual value is <see langword="null" />.
 	/// </summary>
-	public static AndOrExpectationResult<string?, That<string?>> IsNull(this That<string?> source)
+	public static AndOrExpectationResult<string?, That<string?>> IsNull(
+		this That<string?> source)
 		=> new(source.ExpectationBuilder.Add(
 				new IsNullConstraint(),
 				b => b.AppendMethod(nameof(IsNull))),

--- a/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.cs
@@ -36,9 +36,27 @@ public static partial class ThatStringExtensions
 		var options = new StringOptions();
 		return new StringCountExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
 				new ContainsConstraint(expected, quantifier, options),
-				b => b.AppendMethod(nameof(Is), doNotPopulateThisValue)),
+				b => b.AppendMethod(nameof(Contains), doNotPopulateThisValue)),
 			source,
 			quantifier,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the actual value contains the <paramref name="unexpected" /> <see langword="string" />.
+	/// </summary>
+	public static StringExpectationResult<string?, That<string?>> DoesNotContain(
+		this That<string?> source,
+		string unexpected,
+		[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+	{
+		var quantifier = new Quantifier();
+		quantifier.Exactly(0);
+		var options = new StringOptions();
+		return new StringExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
+				new ContainsConstraint(unexpected, quantifier, options),
+				b => b.AppendMethod(nameof(DoesNotContain), doNotPopulateThisValue)),
+			source,
 			options);
 	}
 

--- a/Tests/Testably.Expectations.Tests/Core/BecauseTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/BecauseTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Testably.Expectations.Tests.TestHelpers;
 using Xunit;
@@ -91,8 +90,8 @@ public class BecauseTests
 		async Task Act()
 			=> await Expect.That(variable).IsFalse().Because(because);
 
-		await Expect.That(Act).ThrowsWithMessage("*because*");
-		//TODO.And.DoesNotContain("because because");
+		Exception exception = await Expect.That(Act).ThrowsWithMessage("*because*");
+		await Expect.That(exception.Message).DoesNotContain("because because");
 	}
 
 	[Fact]

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.ContainsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.ContainsTests.cs
@@ -1,0 +1,459 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Strings;
+
+public sealed partial class ThatString
+{
+	public class ContainsTests
+	{
+		[Fact]
+		public async Task AtLeast_WhenExpectedStringOccursEnoughTimes_ShouldSucceed()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).AtLeast(3);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task AtLeast_WhenExpectedStringOccursFewerTimes_ShouldFail()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).AtLeast(5);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "in" at least 5 times,
+				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).Is(expected).AtLeast(5)
+				                  """);
+		}
+
+		[Fact]
+		public async Task AtLeast_WhenExpectedStringOccursNever_ShouldFail()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "text that does not occur";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).AtLeast(1);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "text that does not occur" at least once,
+				                  but found it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).Is(expected).AtLeast(1)
+				                  """);
+		}
+
+		[Fact]
+		public async Task AtLeast_WhenMinimumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).AtLeast(-1);
+
+			await Expect.That(Act).ThrowsExactly<ArgumentOutOfRangeException>().Which
+				.HasMessage("*'minimum'*").AsWildcard().And
+				.HasParamName("minimum");
+		}
+
+		[Fact]
+		public async Task AtMost_WhenExpectedStringOccursMoreTimes_ShouldFail()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).AtMost(2);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "in" at most 2 times,
+				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).Is(expected).AtMost(2)
+				                  """);
+		}
+
+		[Fact]
+		public async Task AtMost_WhenExpectedStringOccursNever_ShouldSucceed()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "text that does not occur";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).AtMost(1);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task AtMost_WhenExpectedStringSufficientlyFewTimes_ShouldSucceed()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).AtMost(3);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task AtMost_WhenMaximumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).AtMost(-1);
+
+			await Expect.That(Act).ThrowsExactly<ArgumentOutOfRangeException>().Which
+				.HasMessage("*'maximum'*").AsWildcard().And
+				.HasParamName("maximum");
+		}
+
+		[Fact]
+		public async Task Between_WhenExpectedStringOccursFewerTimes_ShouldFail()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Between(4, 9);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "in" between 4 and 9 times,
+				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).Is(expected).Between(4, 9)
+				                  """);
+		}
+
+		[Fact]
+		public async Task Between_WhenExpectedStringOccursMoreTimes_ShouldFail()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Between(1, 2);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "in" between 1 and 2 times,
+				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).Is(expected).Between(1, 2)
+				                  """);
+		}
+
+		[Fact]
+		public async Task Between_WhenExpectedStringOccursSufficientTimes_ShouldSucceed()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Between(1, 4);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task Between_WhenMaximumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Between(1, -3);
+
+			await Expect.That(Act).ThrowsExactly<ArgumentOutOfRangeException>().Which
+				.HasMessage("*'maximum'*").AsWildcard().And
+				.HasParamName("maximum");
+		}
+
+		[Fact]
+		public async Task Between_WhenMinimumEqualsMaximum_ShouldBehaveLikeExactly()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Between(3, 3);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task Between_WhenMinimumIsGreaterThanMaximum_ShouldThrowArgumentException()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Between(4, 3);
+
+			await Expect.That(Act).ThrowsExactly<ArgumentException>().Which
+				.HasMessage("*'maximum'*greater*'minimum'*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task Between_WhenMinimumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Between(-1, 3);
+
+			await Expect.That(Act).ThrowsExactly<ArgumentOutOfRangeException>().Which
+				.HasMessage("*'minimum'*").AsWildcard().And
+				.HasParamName("minimum");
+		}
+
+		[Fact]
+		public async Task
+			Exactly_WhenExpectedIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Exactly(-1);
+
+			await Expect.That(Act).ThrowsExactly<ArgumentOutOfRangeException>().Which
+				.HasMessage("*'expected'*").AsWildcard().And
+				.HasParamName("expected");
+		}
+
+		[Fact]
+		public async Task Exactly_WhenExpectedStringOccursCorrectlyOften_ShouldSucceed()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Exactly(3);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task Exactly_WhenExpectedStringOccursFewerTimes_ShouldFail()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Exactly(4);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "in" exactly 4 times,
+				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).Is(expected).Exactly(4)
+				                  """);
+		}
+
+		[Fact]
+		public async Task Exactly_WhenExpectedStringOccursMoreTimes_ShouldFail()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Exactly(2);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "in" exactly 2 times,
+				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).Is(expected).Exactly(2)
+				                  """);
+		}
+
+		[Fact]
+		public async Task IgnoringCase_ShouldIncludeSettingInExpectationText()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).AtLeast(7).IgnoringCase();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "in" at least 7 times ignoring case,
+				                  but found it 5 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).Is(expected).AtLeast(7).IgnoringCase()
+				                  """);
+		}
+
+		[Fact]
+		public async Task
+			IgnoringCase_WhenExpectedStringOccursEnoughTimesCaseInsensitive_ShouldSucceed()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).AtLeast(5).IgnoringCase();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task Never_WhenExpectedStringDoesNotOccur_ShouldSucceed()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "detective";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Never();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task Never_WhenExpectedStringOccursMoreTimes_ShouldFail()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "investigator";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Never();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "investigator" never,
+				                  but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).Is(expected).Never()
+				                  """);
+		}
+
+		[Fact]
+		public async Task Once_WhenExpectedStringOccursExactly1Times_ShouldSucceed()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "investigator";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Once();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task Once_WhenExpectedStringOccursFewerTimes_ShouldFail()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "detective";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Once();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "detective" exactly once,
+				                  but found it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).Is(expected).Once()
+				                  """);
+		}
+
+		[Fact]
+		public async Task Once_WhenExpectedStringOccursMoreTimes_ShouldFail()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "word";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Once();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "word" exactly once,
+				                  but found it 2 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).Is(expected).Once()
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenExpectedStringIsContained_ShouldSucceed()
+		{
+			string actual = "some text";
+			string expected = "me";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenExpectedStringIsNotContained_ShouldFail()
+		{
+			string actual = "some text";
+			string expected = "not";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "not" at least once,
+				                  but found it 0 times in "some text"
+				                  at Expect.That(actual).Is(expected)
+				                  """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.ContainsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.ContainsTests.cs
@@ -37,7 +37,7 @@ public sealed partial class ThatString
 				                  Expected that actual
 				                  contains "in" at least 5 times,
 				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Is(expected).AtLeast(5)
+				                  at Expect.That(actual).Contains(expected).AtLeast(5)
 				                  """);
 		}
 
@@ -56,7 +56,7 @@ public sealed partial class ThatString
 				                  Expected that actual
 				                  contains "text that does not occur" at least once,
 				                  but found it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Is(expected).AtLeast(1)
+				                  at Expect.That(actual).Contains(expected).AtLeast(1)
 				                  """);
 		}
 
@@ -90,7 +90,7 @@ public sealed partial class ThatString
 				                  Expected that actual
 				                  contains "in" at most 2 times,
 				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Is(expected).AtMost(2)
+				                  at Expect.That(actual).Contains(expected).AtMost(2)
 				                  """);
 		}
 
@@ -150,7 +150,7 @@ public sealed partial class ThatString
 				                  Expected that actual
 				                  contains "in" between 4 and 9 times,
 				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Is(expected).Between(4, 9)
+				                  at Expect.That(actual).Contains(expected).Between(4, 9)
 				                  """);
 		}
 
@@ -169,7 +169,7 @@ public sealed partial class ThatString
 				                  Expected that actual
 				                  contains "in" between 1 and 2 times,
 				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Is(expected).Between(1, 2)
+				                  at Expect.That(actual).Contains(expected).Between(1, 2)
 				                  """);
 		}
 
@@ -287,7 +287,7 @@ public sealed partial class ThatString
 				                  Expected that actual
 				                  contains "in" exactly 4 times,
 				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Is(expected).Exactly(4)
+				                  at Expect.That(actual).Contains(expected).Exactly(4)
 				                  """);
 		}
 
@@ -306,7 +306,7 @@ public sealed partial class ThatString
 				                  Expected that actual
 				                  contains "in" exactly 2 times,
 				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Is(expected).Exactly(2)
+				                  at Expect.That(actual).Contains(expected).Exactly(2)
 				                  """);
 		}
 
@@ -325,7 +325,7 @@ public sealed partial class ThatString
 				                  Expected that actual
 				                  contains "in" at least 7 times ignoring case,
 				                  but found it 5 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Is(expected).AtLeast(7).IgnoringCase()
+				                  at Expect.That(actual).Contains(expected).AtLeast(7).IgnoringCase()
 				                  """);
 		}
 
@@ -369,9 +369,9 @@ public sealed partial class ThatString
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
 				                  Expected that actual
-				                  contains "investigator" never,
+				                  does not contain "investigator",
 				                  but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Is(expected).Never()
+				                  at Expect.That(actual).Contains(expected).Never()
 				                  """);
 		}
 
@@ -403,7 +403,7 @@ public sealed partial class ThatString
 				                  Expected that actual
 				                  contains "detective" exactly once,
 				                  but found it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Is(expected).Once()
+				                  at Expect.That(actual).Contains(expected).Once()
 				                  """);
 		}
 
@@ -422,7 +422,7 @@ public sealed partial class ThatString
 				                  Expected that actual
 				                  contains "word" exactly once,
 				                  but found it 2 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Is(expected).Once()
+				                  at Expect.That(actual).Contains(expected).Once()
 				                  """);
 		}
 
@@ -452,7 +452,7 @@ public sealed partial class ThatString
 				                  Expected that actual
 				                  contains "not" at least once,
 				                  but found it 0 times in "some text"
-				                  at Expect.That(actual).Is(expected)
+				                  at Expect.That(actual).Contains(expected)
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotContainTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotContainTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Strings;
+
+public sealed partial class ThatString
+{
+	public class DoesNotContainTests
+	{
+		[Fact]
+		public async Task WhenExpectedStringIsNotContained_ShouldSucceed()
+		{
+			string actual = "some text";
+			string expected = "not";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotContain(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenExpectedStringIsContained_ShouldFail()
+		{
+			string actual = "some text";
+			string expected = "me";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotContain(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  does not contain "me",
+				                  but found it 1 times in "some text"
+				                  at Expect.That(actual).DoesNotContain(expected)
+				                  """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotContainTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotContainTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 using Xunit.Sdk;
 
@@ -10,15 +9,22 @@ public sealed partial class ThatString
 	public class DoesNotContainTests
 	{
 		[Fact]
-		public async Task WhenExpectedStringIsNotContained_ShouldSucceed()
+		public async Task IgnoringCase_ShouldIncludeSettingInExpectationText()
 		{
-			string actual = "some text";
-			string expected = "not";
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "INVESTIGATOR";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotContain(expected);
+				=> await Expect.That(actual).DoesNotContain(expected).IgnoringCase();
 
-			await Expect.That(Act).DoesNotThrow();
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  does not contain "INVESTIGATOR" ignoring case,
+				                  but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).DoesNotContain(expected).IgnoringCase()
+				                  """);
 		}
 
 		[Fact]
@@ -37,6 +43,18 @@ public sealed partial class ThatString
 				                  but found it 1 times in "some text"
 				                  at Expect.That(actual).DoesNotContain(expected)
 				                  """);
+		}
+
+		[Fact]
+		public async Task WhenExpectedStringIsNotContained_ShouldSucceed()
+		{
+			string actual = "some text";
+			string expected = "not";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotContain(expected);
+
+			await Expect.That(Act).DoesNotThrow();
 		}
 	}
 }


### PR DESCRIPTION
Add `Contains(string)` expectations with the following options:
- `IgnoringCase()`
- `Using(IComparer<string>)`
- `AtLeast(int)`
- `AtMost(int)`
- `Exactly(int)`
- `Between(int, int)`
- `Never()`
- `Once()`

*Default options are `AtLeast(1)`*

Add `DoesNotContain(string)` expectations with the following options:
- `IgnoringCase()`
- `Using(IComparer<string>)`