### PR TITLE
feat: add equivalency assertions

### DIFF
--- a/Source/Testably.Expectations/Collections/QuantifiableCollection.AreEquivalentToConstraint.cs
+++ b/Source/Testably.Expectations/Collections/QuantifiableCollection.AreEquivalentToConstraint.cs
@@ -2,13 +2,17 @@
 using System.Linq;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Equivalency;
 using Testably.Expectations.Core.Formatting;
 
 namespace Testably.Expectations.Collections;
 
 public partial class QuantifiableCollection<TItem>
 {
-	private readonly struct AreEquivalentToConstraint(TItem expected, CollectionQuantifier quantifier)
+	private readonly struct AreEquivalentToConstraint(
+		TItem expected,
+		CollectionQuantifier quantifier,
+		EquivalencyOptions options)
 		: IConstraint<IEnumerable<TItem>>
 	{
 		public ConstraintResult IsMetBy(IEnumerable<TItem> actual)
@@ -17,8 +21,12 @@ public partial class QuantifiableCollection<TItem>
 			int count = 0;
 			foreach (TItem? item in list)
 			{
-				//TODO Change to IsEquivalentTo
-				if (item?.Equals(expected) != false)
+				IEnumerable<ComparisonFailure> failures = Compare.CheckEquivalent(item, expected,
+					new CompareOptions
+					{
+						MembersToIgnore = [.. options.MembersToIgnore],
+					});
+				if (!failures.Any())
 				{
 					count++;
 				}

--- a/Source/Testably.Expectations/Collections/QuantifiableCollection.AreEquivalentToConstraint.cs
+++ b/Source/Testably.Expectations/Collections/QuantifiableCollection.AreEquivalentToConstraint.cs
@@ -11,6 +11,7 @@ public partial class QuantifiableCollection<TItem>
 {
 	private readonly struct AreEquivalentToConstraint(
 		TItem expected,
+		string expectedExpression,
 		CollectionQuantifier quantifier,
 		EquivalencyOptions options)
 		: IConstraint<IEnumerable<TItem>>
@@ -37,10 +38,10 @@ public partial class QuantifiableCollection<TItem>
 				return new ConstraintResult.Success<IEnumerable<TItem>>(list, ToString());
 			}
 
-			return new ConstraintResult.Failure(ToString(), $"found {error} items");
+			return new ConstraintResult.Failure(ToString(), $"{error} items were equivalent");
 		}
 
 		public override string ToString()
-			=> $"has {quantifier} items equivalent to {Formatter.Format(expected)}";
+			=> $"has {quantifier} equivalent to {expectedExpression}";
 	}
 }

--- a/Source/Testably.Expectations/Collections/QuantifiableCollection.cs
+++ b/Source/Testably.Expectations/Collections/QuantifiableCollection.cs
@@ -33,8 +33,8 @@ public partial class QuantifiableCollection<TItem>(
 	{
 		var options = new EquivalencyOptions();
 		return new EquivalencyOptionsExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>>(
-			source.ExpectationBuilder.Add(new AreEquivalentToConstraint(expected, quantity, options),
-				b => b.AppendMethod(nameof(Are), doNotPopulateThisValue)),
+			source.ExpectationBuilder.Add(new AreEquivalentToConstraint(expected, doNotPopulateThisValue, quantity, options),
+				b => b.AppendMethod(nameof(AreEquivalentTo), doNotPopulateThisValue)),
 			source,
 			options);
 	}

--- a/Source/Testably.Expectations/Collections/QuantifiableCollection.cs
+++ b/Source/Testably.Expectations/Collections/QuantifiableCollection.cs
@@ -27,12 +27,17 @@ public partial class QuantifiableCollection<TItem>(
 	/// <summary>
 	///     ...are equivalent to <paramref name="expected" />.
 	/// </summary>
-	public AndOrExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>> AreEquivalentTo(
+	public EquivalencyOptionsExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>> AreEquivalentTo(
 		TItem expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder.Add(new AreEquivalentToConstraint(expected, quantity),
+	{
+		var options = new EquivalencyOptions();
+		return new EquivalencyOptionsExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>>(
+			source.ExpectationBuilder.Add(new AreEquivalentToConstraint(expected, quantity, options),
 				b => b.AppendMethod(nameof(Are), doNotPopulateThisValue)),
-			source);
+			source,
+			options);
+	}
 
 	/// <summary>
 	///     ...satisfy the <paramref name="predicate" />.

--- a/Source/Testably.Expectations/Core/Equivalency/Compare.cs
+++ b/Source/Testably.Expectations/Core/Equivalency/Compare.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2024 by Tom Longhurst
+// https://github.com/thomhurst/TUnit
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -112,7 +115,7 @@ internal static class Compare
             }
         }
         
-        foreach (var propertyInfo in actual.GetType().GetProperties().Concat(expected!.GetType().GetProperties())
+        foreach (var propertyInfo in actual.GetType().GetProperties().Concat(expected.GetType().GetProperties())
                      .Distinct()
                      .Where(p => p.GetIndexParameters().Length == 0))
         {

--- a/Source/Testably.Expectations/Core/Equivalency/Compare.cs
+++ b/Source/Testably.Expectations/Core/Equivalency/Compare.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Testably.Expectations.Core.Equivalency;
+
+internal static class Compare
+{
+    internal static IEnumerable<ComparisonFailure> CheckEquivalent<T>(T actual, T expected, CompareOptions options)
+    {
+        return CheckEquivalent(actual, expected, options, [], MemberType.Value);
+    }
+
+    internal static IEnumerable<ComparisonFailure> CheckEquivalent<T>(T actual, T expected, CompareOptions options, string[] memberNames, MemberType memberType)
+    {
+        if (actual is null && expected is null)
+        {
+            yield break;
+        }
+
+        if (actual is null || expected is null)
+        {
+            yield return new ComparisonFailure
+            {
+                Type = memberType,
+                Actual = actual,
+                Expected = expected,
+                NestedMemberNames = memberNames
+            };
+            
+            yield break;
+        }
+
+        if (actual is IEnumerable actualEnumerable && expected is IEnumerable expectedEnumerable)
+        {
+            var actualObjects = actualEnumerable.Cast<object>().ToArray();
+            var expectedObjects = expectedEnumerable.Cast<object>().ToArray();
+            
+            for (var i = 0; i < Math.Max(actualObjects.Length, expectedObjects.Length); i++)
+            {
+                string?[] readOnlySpan = [..memberNames, $"[{i}]"];
+                
+                if (options.MembersToIgnore.Contains(string.Join(".", readOnlySpan)))
+                {
+                    continue;
+                }
+                
+                var actualObject = actualObjects.ElementAtOrDefault(i);
+                var expectedObject = expectedObjects.ElementAtOrDefault(i);
+
+                foreach (var comparisonFailure in CheckEquivalent(actualObject, expectedObject, options, [..memberNames, $"[{i}]"], MemberType.EnumerableItem))
+                {
+                    yield return comparisonFailure;
+                }
+            }
+        }
+        
+        if (actual.GetType().IsPrimitive 
+            || actual.GetType().IsEnum 
+            || actual.GetType().IsValueType 
+            || actual is string)
+        {
+            if (!actual.Equals(expected))
+            {
+                yield return new ComparisonFailure
+                {
+                    Type = MemberType.Value,
+                    Actual = actual,
+                    Expected = expected,
+                    NestedMemberNames = memberNames
+                };
+            }
+            
+            yield break;
+        }
+
+        foreach (var fieldInfo in actual.GetType().GetFields().Concat(expected.GetType().GetFields()).Distinct())
+        {
+            string?[] readOnlySpan = [..memberNames, fieldInfo.Name];
+            
+            if (options.MembersToIgnore.Contains(string.Join(".", readOnlySpan)))
+            {
+                continue;
+            }
+            
+            var actualFieldValue = fieldInfo.GetValue(actual);
+            var expectedFieldValue = fieldInfo.GetValue(expected);
+
+            if (actualFieldValue?.Equals(actual) == true && expectedFieldValue?.Equals(expected) == true)
+            {
+                // To prevent cyclical references/stackoverflow
+               continue;
+            }
+            
+            if (actualFieldValue?.Equals(actual) == true || expectedFieldValue?.Equals(expected) == true)
+            {
+                yield return new ComparisonFailure
+                {
+                    Type = MemberType.Value,
+                    Actual = actual,
+                    Expected = expected,
+                    NestedMemberNames = memberNames
+                };
+                
+                yield break;
+            }
+
+            foreach (var comparisonFailure in CheckEquivalent(actualFieldValue, expectedFieldValue, options, [..memberNames, fieldInfo.Name], MemberType.Field))
+            {
+                yield return comparisonFailure;
+            }
+        }
+        
+        foreach (var propertyInfo in actual.GetType().GetProperties().Concat(expected!.GetType().GetProperties())
+                     .Distinct()
+                     .Where(p => p.GetIndexParameters().Length == 0))
+        {
+            string?[] readOnlySpan = [..memberNames, propertyInfo.Name];
+            
+            if (options.MembersToIgnore.Contains(string.Join(".", readOnlySpan)))
+            {
+                continue;
+            }
+
+            var actualPropertyValue = propertyInfo.GetValue(actual);
+            var expectedPropertyValue = propertyInfo.GetValue(expected);
+
+            if (actualPropertyValue?.Equals(actual) == true && expectedPropertyValue?.Equals(expected) == true)
+            {
+                // To prevent cyclical references/stackoverflow
+                continue;
+            }
+            
+            if (actualPropertyValue?.Equals(actual) == true || actualPropertyValue?.Equals(expected) == true)
+            {
+                yield return new ComparisonFailure
+                {
+                    Type = MemberType.Value,
+                    Actual = actual,
+                    Expected = expected,
+                    NestedMemberNames = memberNames
+                };
+                
+                yield break;
+            }
+            
+            foreach (var comparisonFailure in CheckEquivalent(actualPropertyValue, expectedPropertyValue, options, [..memberNames, propertyInfo.Name], MemberType.Property))
+            {
+                yield return comparisonFailure;
+            }
+        }
+    }
+}

--- a/Source/Testably.Expectations/Core/Equivalency/CompareOptions.cs
+++ b/Source/Testably.Expectations/Core/Equivalency/CompareOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace Testably.Expectations.Core.Equivalency;
+﻿// Copyright (c) 2024 by Tom Longhurst
+// https://github.com/thomhurst/TUnit
+
+namespace Testably.Expectations.Core.Equivalency;
 
 internal record CompareOptions
 {

--- a/Source/Testably.Expectations/Core/Equivalency/CompareOptions.cs
+++ b/Source/Testably.Expectations/Core/Equivalency/CompareOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace Testably.Expectations.Core.Equivalency;
+
+internal record CompareOptions
+{
+    public string[] MembersToIgnore { get; set; } = [];
+}

--- a/Source/Testably.Expectations/Core/Equivalency/ComparisonFailure.cs
+++ b/Source/Testably.Expectations/Core/Equivalency/ComparisonFailure.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2024 by Tom Longhurst
+// https://github.com/thomhurst/TUnit
+
+using System;
 
 namespace Testably.Expectations.Core.Equivalency;
 

--- a/Source/Testably.Expectations/Core/Equivalency/ComparisonFailure.cs
+++ b/Source/Testably.Expectations/Core/Equivalency/ComparisonFailure.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Testably.Expectations.Core.Equivalency;
+
+internal record ComparisonFailure
+{
+    public MemberType Type { get; set; }
+    public string[] NestedMemberNames { get; set; } = Array.Empty<string>();
+    public object? Actual { get; set; }
+    public object? Expected { get; set; }
+}

--- a/Source/Testably.Expectations/Core/Equivalency/MemberType.cs
+++ b/Source/Testably.Expectations/Core/Equivalency/MemberType.cs
@@ -1,0 +1,9 @@
+﻿namespace Testably.Expectations.Core.Equivalency;
+
+internal enum MemberType
+{
+    Property,
+    Field,
+    Value,
+    EnumerableItem
+}

--- a/Source/Testably.Expectations/Core/Equivalency/MemberType.cs
+++ b/Source/Testably.Expectations/Core/Equivalency/MemberType.cs
@@ -1,4 +1,7 @@
-﻿namespace Testably.Expectations.Core.Equivalency;
+﻿// Copyright (c) 2024 by Tom Longhurst
+// https://github.com/thomhurst/TUnit
+
+namespace Testably.Expectations.Core.Equivalency;
 
 internal enum MemberType
 {

--- a/Source/Testably.Expectations/Core/EquivalencyOptions.cs
+++ b/Source/Testably.Expectations/Core/EquivalencyOptions.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Testably.Expectations.Core.Formatting;
+
+namespace Testably.Expectations.Core;
+
+/// <summary>
+///     Options for equivalency.
+/// </summary>
+public class EquivalencyOptions
+{
+	internal IReadOnlyList<string> MembersToIgnore => _membersToIgnore;
+	private readonly List<string> _membersToIgnore = new();
+
+	/// <summary>
+	///     Ignores the <paramref name="memberToIgnore" /> when checking for equivalency.
+	/// </summary>
+	public EquivalencyOptions IgnoringMember(string memberToIgnore)
+	{
+		_membersToIgnore.Add(memberToIgnore);
+		return this;
+	}
+
+	/// <inheritdoc />
+	public override string ToString()
+	{
+		if (_membersToIgnore.Any())
+		{
+			return
+				$" ignoring [{string.Join(", ", _membersToIgnore.Select(m => Formatter.Format(m)))}]";
+		}
+
+		return "";
+	}
+}

--- a/Source/Testably.Expectations/Core/Results/EquivalencyOptionsExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/EquivalencyOptionsExpectationResult.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core.Helpers;
+
+namespace Testably.Expectations.Core.Results;
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying
+///     options on the <see cref="StringOptions" />.
+/// </summary>
+public class EquivalencyOptionsExpectationResult<TResult, TValue>(
+	IExpectationBuilder expectationBuilder,
+	TValue returnValue,
+	EquivalencyOptions options)
+	: EquivalencyOptionsExpectationResult<TResult, TValue,
+		EquivalencyOptionsExpectationResult<TResult, TValue>>(
+		expectationBuilder,
+		returnValue,
+		options);
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying
+///     options
+///     on
+///     the <see cref="StringMatcher" />.
+/// </summary>
+public class EquivalencyOptionsExpectationResult<TResult, TValue, TSelf>(
+	IExpectationBuilder expectationBuilder,
+	TValue returnValue,
+	EquivalencyOptions options)
+	: AndOrExpectationResult<TResult, TValue, TSelf>(expectationBuilder, returnValue)
+	where TSelf : EquivalencyOptionsExpectationResult<TResult, TValue, TSelf>
+{
+	private readonly IExpectationBuilder _expectationBuilder1 = expectationBuilder;
+
+	/// <summary>
+	///     Ignores the <paramref name="memberToIgnore" /> when checking for equivalency.
+	/// </summary>
+	public EquivalencyOptionsExpectationResult<TResult, TValue, TSelf> IgnoringMember(
+		string memberToIgnore,
+		[CallerArgumentExpression("memberToIgnore")] string doNotPopulateThisValue = "")
+	{
+		options.IgnoringMember(memberToIgnore);
+		_expectationBuilder1.AppendExpression(b => b.AppendMethod(nameof(IgnoringMember), doNotPopulateThisValue));
+		return this;
+	}
+}

--- a/Source/Testably.Expectations/Core/Results/StringMatcherExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/StringMatcherExpectationResult.cs
@@ -43,6 +43,16 @@ public class StringMatcherExpectationResult<TResult, TValue>(
 	}
 
 	/// <summary>
+	///     Interprets the expected <see langword="string" /> to be exactly equal.
+	/// </summary>
+	public StringMatcherExpectationResult<TResult, TValue> Exactly()
+	{
+		expected.Exactly();
+		_expectationBuilder.AppendExpression(b => b.AppendMethod(nameof(Exactly)));
+		return this;
+	}
+
+	/// <summary>
 	///     Ignores casing when comparing the <see langword="string" />s.
 	/// </summary>
 	public StringMatcherExpectationResult<TResult, TValue> IgnoringCase()

--- a/Source/Testably.Expectations/Core/StringMatcher.cs
+++ b/Source/Testably.Expectations/Core/StringMatcher.cs
@@ -41,6 +41,15 @@ public class StringMatcher(string? pattern)
 	}
 
 	/// <summary>
+	///     Interprets the expected <see langword="string" /> to be exactly equal.
+	/// </summary>
+	public StringMatcher Exactly()
+	{
+		_type = ExactMatch;
+		return this;
+	}
+
+	/// <summary>
 	///     Ignores casing when comparing the <see langword="string" />s.
 	/// </summary>
 	public StringMatcher IgnoringCase(bool ignoreCase = true)

--- a/Source/Testably.Expectations/Primitives/Objects/ThatObjectExtensions.IsEquivalentToConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Objects/ThatObjectExtensions.IsEquivalentToConstraint.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Testably.Expectations.Core;
@@ -23,10 +24,11 @@ public static partial class ThatObjectExtensions
 				return specialCaseResult;
 			}
 
-			var failures = Compare.CheckEquivalent(actual, expected, new CompareOptions
-			{
-				MembersToIgnore = [.. options.MembersToIgnore],
-			}).ToList();
+			List<ComparisonFailure> failures = Compare.CheckEquivalent(actual, expected,
+				new CompareOptions
+				{
+					MembersToIgnore = [.. options.MembersToIgnore],
+				}).ToList();
 
 			if (failures.FirstOrDefault() is { } firstFailure)
 			{
@@ -63,11 +65,13 @@ public static partial class ThatObjectExtensions
 			{
 				isEqual = enumerable.Cast<object>().SequenceEqual(enumerable2.Cast<object>());
 			}
+
 			if (isEqual == true)
 			{
 				constraintResult = new ConstraintResult.Success<object?>(actual, ToString());
 				return true;
 			}
+
 			if (isEqual == false)
 			{
 				constraintResult = new ConstraintResult.Failure(ToString(),

--- a/Source/Testably.Expectations/Primitives/Objects/ThatObjectExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Objects/ThatObjectExtensions.cs
@@ -27,13 +27,17 @@ public static partial class ThatObjectExtensions
 	/// <summary>
 	///     Expect the actual value to be equivalent to the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrExpectationResult<T, That<T>> IsEquivalentTo<T>(this That<T> source,
+	public static EquivalencyOptionsExpectationResult<T, That<T>> IsEquivalentTo<T>(this That<T> source,
 		object expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder.Add(
-				new IsEquivalentToConstraint(expected),
+	{
+		var options = new EquivalencyOptions();
+		return new(source.ExpectationBuilder.Add(
+				new IsEquivalentToConstraint(expected, doNotPopulateThisValue, options),
 				b => b.AppendMethod(nameof(IsEquivalentTo), doNotPopulateThisValue)),
-			source);
+			source,
+			options);
+	}
 
 	/// <summary>
 	///     Verifies that the value satisfies the <paramref name="expectations" /> on the properties selected by the

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AllAreEquivalentTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AllAreEquivalentTests.cs
@@ -1,0 +1,54 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Collections;
+
+public sealed partial class ThatCollection
+{
+	public sealed class AllAreEquivalentTests
+	{
+		[Fact]
+		public async Task WhenCollectionContainsOtherValues_ShouldFail()
+		{
+			MyClass[] collection =
+			[
+				new() { Value = "Foo" },
+				new() { Value = "Foo" },
+				new() { Value = "Foo" },
+				new() { Value = "Bar" }
+			];
+
+			MyClass expected = new() { Value = "Foo" };
+
+			async Task Act()
+				=> await Expect.That(collection).All().AreEquivalentTo(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that collection
+				                  has all items equivalent to expected,
+				                  but only 3 of 4 items were equivalent
+				                  at Expect.That(collection).All().AreEquivalentTo(expected)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenCollectionOnlyContainsEqualValues_ShouldSucceed()
+		{
+			MyClass[] collection =
+			[
+				new() { Value = "Foo" },
+				new() { Value = "Foo" },
+				new() { Value = "Foo" }
+			];
+
+			MyClass expected = new() { Value = "Foo" };
+
+			async Task Act()
+				=> await Expect.That(collection).All().AreEquivalentTo(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Testably.Expectations.Tests.Collections;
+public partial class ThatCollection
+{
+	public class MyClass
+	{
+		public string? Value { get; set; }
+		public InnerClass? Inner { get; set; }
+	}
+
+	public class InnerClass
+	{
+		public string? Value { get; set; }
+
+		public InnerClass? Inner { get; set; }
+
+		public IEnumerable<string>? Collection { get; set; }
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Objects/ThatObject.IsEquivalentToTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Objects/ThatObject.IsEquivalentToTests.cs
@@ -1,0 +1,238 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Testably.Expectations.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Expectations.Tests.Primitives.Objects;
+
+public sealed partial class ThatObject
+{
+	public sealed class IsEquivalentToTests
+	{
+		[Fact]
+		public async Task BasicObjects_ShouldBeEquivalent()
+		{
+			var object1 = new MyClass
+			{
+				Value = "Foo"
+			};
+			var object2 = new MyClass
+			{
+				Value = "Foo"
+			};
+
+			await Expect.That(object1).IsEquivalentTo(object2);
+		}
+
+		[Fact]
+		public async Task MismatchedObjects_ShouldNotBeEquivalent()
+		{
+			var object1 = new MyClass();
+			var object2 = new MyClass
+			{
+				Value = "Foo"
+			};
+
+			await Expect.That(async () => await Expect.That(object1).IsEquivalentTo(object2))
+				.ThrowsWithMessage("""
+				                   Expected that object1
+				                   is equivalent to object2,
+				                   but Property Value did not match:
+				                     Expected: "Foo"
+				                     Received: <null>
+				                   at Expect.That(object1).IsEquivalentTo(object2)
+				                   """);
+		}
+
+		[Fact]
+		public async Task ObjectsWithNestedMismatch_ShouldNotBeEquivalent()
+		{
+			var object1 = new MyClass
+			{
+				Value = "Foo",
+				Inner = new InnerClass
+				{
+					Value = "Bar",
+					Inner = new InnerClass()
+				}
+			};
+			var object2 = new MyClass
+			{
+				Value = "Foo",
+				Inner = new InnerClass
+				{
+					Value = "Bar",
+					Inner = new InnerClass
+					{
+						Value = "Baz"
+					}
+				}
+			};
+
+			await Expect.That(async () => await Expect.That(object1).IsEquivalentTo(object2))
+				.ThrowsWithMessage("""
+				                   Expected that object1
+				                   is equivalent to object2,
+				                   but Property Inner.Inner.Value did not match:
+				                     Expected: "Baz"
+				                     Received: <null>
+				                   at Expect.That(object1).IsEquivalentTo(object2)
+				                   """).Exactly();
+		}
+
+		[Fact]
+		public async Task ObjectsWithNestedMatches_ShouldBeEquivalent()
+		{
+			var object1 = new MyClass
+			{
+				Value = "Foo",
+				Inner = new InnerClass
+				{
+					Value = "Bar",
+					Inner = new InnerClass
+					{
+						Value = "Baz"
+					}
+				}
+			};
+			var object2 = new MyClass
+			{
+				Value = "Foo",
+				Inner = new InnerClass
+				{
+					Value = "Bar",
+					Inner = new InnerClass
+					{
+						Value = "Baz"
+					}
+				}
+			};
+
+			await Expect.That(object1).IsEquivalentTo(object2);
+		}
+
+		[Fact]
+		public void ObjectsWithNestedEnumerableMismatch_ShouldNotBeEquivalent()
+		{
+			var object1 = new MyClass
+			{
+				Value = "Foo",
+				Inner = new InnerClass
+				{
+					Value = "Bar",
+					Inner = new InnerClass
+					{
+						Value = "Baz",
+						Collection = ["1", "2", "3"]
+					}
+				}
+			};
+
+			var object2 = new MyClass
+			{
+				Value = "Foo",
+				Inner = new InnerClass
+				{
+					Value = "Bar",
+					Inner = new InnerClass
+					{
+						Value = "Baz",
+						Collection = ["1", "2", "3", "4"]
+					}
+				}
+			};
+
+			Expect.That(async () => await Expect.That(object1).IsEquivalentTo(object2))
+				.ThrowsWithMessage("""
+				                   Expected that object1
+				                   is equivalent to object2,
+				                   but EnumerableItem Inner.Inner.Collection.[3] did not match
+				                     Expected: "4"
+				                     Received: null
+				                   at Expect.That(object1).IsEquivalentTo(object2)
+				                   """);
+		}
+
+		[Fact]
+		public async Task ObjectsWithNestedEnumerableMismatch_WithIgnoreRule_ShouldBeEquivalent()
+		{
+			var object1 = new MyClass
+			{
+				Value = "Foo",
+				Inner = new InnerClass
+				{
+					Value = "Bar",
+					Inner = new InnerClass
+					{
+						Value = "Baz",
+						Collection = ["1", "2", "3"]
+					}
+				}
+			};
+
+			var object2 = new MyClass
+			{
+				Value = "Foo",
+				Inner = new InnerClass
+				{
+					Value = "Bar",
+					Inner = new InnerClass
+					{
+						Value = "Baz",
+						Collection = ["1", "2", "3", "4"]
+					}
+				}
+			};
+
+			await Expect.That(object1).IsEquivalentTo(object2).IgnoringMember("Inner.Inner.Collection.[3]");
+		}
+
+		[Fact]
+		public async Task ObjectsWithNestedEnumerableMatches_ShouldBeEquivalent()
+		{
+			var object1 = new MyClass
+			{
+				Value = "Foo",
+				Inner = new InnerClass
+				{
+					Value = "Bar",
+					Inner = new InnerClass
+					{
+						Value = "Baz",
+						Collection = ["1", "2", "3"]
+					}
+				}
+			};
+			var object2 = new MyClass
+			{
+				Value = "Foo",
+				Inner = new InnerClass
+				{
+					Value = "Bar",
+					Inner = new InnerClass
+					{
+						Value = "Baz",
+						Collection = ["1", "2", "3"]
+					}
+				}
+			};
+
+			await Expect.That(object1).IsEquivalentTo(object2);
+		}
+
+		public class MyClass
+		{
+			public string? Value { get; set; }
+			public InnerClass? Inner { get; set; }
+		}
+
+		public class InnerClass
+		{
+			public string? Value { get; set; }
+
+			public InnerClass? Inner { get; set; }
+
+			public IEnumerable<string>? Collection { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
Support equivalency assertions (using the same mechanism as [TUnit](https://github.com/thomhurst/TUnit/blob/main/TUnit.Assertions/Compare.cs)) to objects and collections:
```csharp
await Expect.That(sut).IsEquivalentTo(expected);
// or
await Expect.That(collection).All().AreEquivalentTo(expected);
await Expect.That(collection).AtLeast(1).AreEquivalentTo(expected);
```