### PR TITLE
feat: Add `OnlyIf` for thrown exceptions

### DIFF
--- a/Source/Testably.Expectations/Core/Helpers/ExceptionHelpers.cs
+++ b/Source/Testably.Expectations/Core/Helpers/ExceptionHelpers.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Testably.Expectations.Core.Helpers;
+
+internal static class ExceptionHelpers
+{
+	public static string FormatForMessage(this Exception exception)
+	{
+		string message = exception.GetType().Name.PrependAOrAn();
+		if (!string.IsNullOrEmpty(exception.Message))
+		{
+			message += ":" + Environment.NewLine + exception.Message.Indent();
+		}
+
+		return message;
+	}
+}

--- a/Source/Testably.Expectations/Core/Results/DelegateExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/DelegateExpectationResult.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core.Helpers;
 
 namespace Testably.Expectations.Core.Results;
 
@@ -22,10 +24,27 @@ public class
 			whichTextSeparator: ""));
 
 	private readonly IExpectationBuilder _expectationBuilder;
+	private readonly ThatDelegate.ThrowsOption _throwOptions;
 
-	internal DelegateExpectationResult(IExpectationBuilder expectationBuilder) : base(
-		expectationBuilder)
+	internal DelegateExpectationResult(IExpectationBuilder expectationBuilder,
+		ThatDelegate.ThrowsOption throwOptions)
+		: base(expectationBuilder)
 	{
 		_expectationBuilder = expectationBuilder;
+		_throwOptions = throwOptions;
+	}
+
+	/// <summary>
+	///     Verifies, that the exception was thrown only if the <paramref name="predicate" /> is <see langword="true" />,
+	///     otherwise it verifies, that no exception was thrown.
+	/// </summary>
+	public DelegateExpectationResult<TException> OnlyIf(bool predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		_throwOptions.CheckThrow(predicate);
+		_expectationBuilder.AppendExpression(b
+			=> b.AppendMethod(nameof(OnlyIf), doNotPopulateThisValue));
+		return this;
 	}
 }

--- a/Source/Testably.Expectations/Delegates/ThatDelegate.DoesNotThrowConstraint.cs
+++ b/Source/Testably.Expectations/Delegates/ThatDelegate.DoesNotThrowConstraint.cs
@@ -8,6 +8,19 @@ namespace Testably.Expectations;
 
 public abstract partial class ThatDelegate
 {
+	private static readonly string DoesNotThrowExpectation = "does not throw any exception";
+
+	private static ConstraintResult DoesNotThrowResult(Exception? exception)
+	{
+		if (exception is not null)
+		{
+			return new ConstraintResult.Failure<Exception?>(exception, DoesNotThrowExpectation,
+				$"it did throw {exception.FormatForMessage()}");
+		}
+
+		return new ConstraintResult.Success<Exception?>(null, DoesNotThrowExpectation);
+	}
+
 	private readonly struct DoesNotThrowConstraint<TValue> : IDelegateConstraint<TValue>
 	{
 		public ConstraintResult IsMetBy(SourceValue<TValue> value)
@@ -15,13 +28,13 @@ public abstract partial class ThatDelegate
 			if (value.Exception is not null)
 			{
 				return new ConstraintResult.Failure<TValue?>(value.Value, ToString(),
-					$"it did throw {value.Exception.GetType().Name.PrependAOrAn()}:{Environment.NewLine}{value.Exception.Message.Indent()}");
+					$"it did throw {value.Exception.FormatForMessage()}");
 			}
 
 			return new ConstraintResult.Success<TValue?>(value.Value, ToString());
 		}
 
 		public override string ToString()
-			=> "does not throw any exception";
+			=> DoesNotThrowExpectation;
 	}
 }

--- a/Source/Testably.Expectations/Delegates/ThatDelegate.ThrowsConstraint.cs
+++ b/Source/Testably.Expectations/Delegates/ThatDelegate.ThrowsConstraint.cs
@@ -9,7 +9,7 @@ namespace Testably.Expectations;
 
 public abstract partial class ThatDelegate
 {
-	private readonly struct ThrowsConstraint<TException> :
+	private readonly struct ThrowsConstraint<TException>(ThrowsOption throwOptions) :
 		IConstraint<DelegateSource.NoValue, TException>,
 		IDelegateConstraint<DelegateSource.NoValue>
 		where TException : Exception
@@ -17,6 +17,11 @@ public abstract partial class ThatDelegate
 		/// <inheritdoc />
 		public ConstraintResult IsMetBy(DelegateSource.NoValue actual, Exception? exception)
 		{
+			if (!throwOptions.DoCheckThrow)
+			{
+				return DoesNotThrowResult(exception);
+			}
+
 			if (exception is TException typedException)
 			{
 				return new ConstraintResult.Success<TException?>(typedException, ToString());
@@ -28,7 +33,7 @@ public abstract partial class ThatDelegate
 			}
 
 			return new ConstraintResult.Failure<TException?>(null, ToString(),
-				$"it did throw {exception.GetType().Name.PrependAOrAn()}:{Environment.NewLine}\t{exception.Message}");
+				$"it did throw {exception.FormatForMessage()}");
 		}
 
 		/// <inheritdoc />
@@ -36,6 +41,13 @@ public abstract partial class ThatDelegate
 			=> IsMetBy(value.Value, value.Exception);
 
 		public override string ToString()
-			=> $"throws {typeof(TException).Name.PrependAOrAn()}";
+		{
+			if (!throwOptions.DoCheckThrow)
+			{
+				return DoesNotThrowExpectation;
+			}
+
+			return $"throws {typeof(TException).Name.PrependAOrAn()}";
+		}
 	}
 }

--- a/Source/Testably.Expectations/Delegates/ThatDelegate.ThrowsExactlyConstraint.cs
+++ b/Source/Testably.Expectations/Delegates/ThatDelegate.ThrowsExactlyConstraint.cs
@@ -9,7 +9,7 @@ namespace Testably.Expectations;
 
 public abstract partial class ThatDelegate
 {
-	private readonly struct ThrowsExactlyConstraint<TException> :
+	private readonly struct ThrowsExactlyConstraint<TException>(ThrowsOption throwOptions) :
 		IConstraint<DelegateSource.NoValue, TException>,
 		IDelegateConstraint<DelegateSource.NoValue>
 		where TException : Exception
@@ -17,6 +17,11 @@ public abstract partial class ThatDelegate
 		/// <inheritdoc />
 		public ConstraintResult IsMetBy(DelegateSource.NoValue actual, Exception? exception)
 		{
+			if (!throwOptions.DoCheckThrow)
+			{
+				return DoesNotThrowResult(exception);
+			}
+
 			if (exception is TException typedException && exception.GetType() == typeof(TException))
 			{
 				return new ConstraintResult.Success<TException?>(typedException, ToString());
@@ -28,7 +33,7 @@ public abstract partial class ThatDelegate
 			}
 
 			return new ConstraintResult.Failure<TException?>(null, ToString(),
-				$"it did throw {exception.GetType().Name.PrependAOrAn()}:{Environment.NewLine}\t{exception.Message}");
+				$"it did throw {exception.FormatForMessage()}");
 		}
 
 		/// <inheritdoc />
@@ -37,6 +42,13 @@ public abstract partial class ThatDelegate
 
 		/// <inheritdoc />
 		public override string ToString()
-			=> $"throws exactly {typeof(TException).Name.PrependAOrAn()}";
+		{
+			if (!throwOptions.DoCheckThrow)
+			{
+				return DoesNotThrowExpectation;
+			}
+
+			return $"throws exactly {typeof(TException).Name.PrependAOrAn()}";
+		}
 	}
 }

--- a/Source/Testably.Expectations/Delegates/ThatDelegate.cs
+++ b/Source/Testably.Expectations/Delegates/ThatDelegate.cs
@@ -23,26 +23,49 @@ public abstract partial class ThatDelegate
 	/// </summary>
 	public DelegateExpectationResult<TException> Throws<TException>()
 		where TException : Exception
-		=> new(_expectationBuilder.AddCast(
-			new ThrowsConstraint<TException>(),
-			b => b.Append('.').Append(nameof(Throws)).Append('<').Append(typeof(TException).Name)
-				.Append(">()")));
+	{
+		ThrowsOption throwOptions = new();
+		return new DelegateExpectationResult<TException>(_expectationBuilder.AddCast(
+				new ThrowsConstraint<TException>(throwOptions),
+				b => b.Append('.').Append(nameof(Throws)).Append('<')
+					.Append(typeof(TException).Name)
+					.Append(">()")),
+			throwOptions);
+	}
 
 	/// <summary>
 	///     Verifies that the delegate throws exactly an exception of type <typeparamref name="TException" />.
 	/// </summary>
 	public DelegateExpectationResult<TException> ThrowsExactly<TException>()
 		where TException : Exception
-		=> new(_expectationBuilder.AddCast(
-			new ThrowsExactlyConstraint<TException>(),
+	{
+		ThrowsOption throwOptions = new();
+		return new(_expectationBuilder.AddCast(
+			new ThrowsExactlyConstraint<TException>(throwOptions),
 			b => b.Append('.').Append(nameof(ThrowsExactly)).Append('<')
-				.Append(typeof(TException).Name).Append(">()")));
+				.Append(typeof(TException).Name).Append(">()")),
+			throwOptions);
+	}
 
 	/// <summary>
 	///     Verifies that the delegate throws an exception.
 	/// </summary>
 	public DelegateExpectationResult<Exception> ThrowsException()
-		=> new(_expectationBuilder.AddCast(
-			new ThrowsConstraint<Exception>(),
-			b => b.AppendMethod(nameof(ThrowsException))));
+	{
+		ThrowsOption throwOptions = new();
+		return new(_expectationBuilder.AddCast(
+			new ThrowsConstraint<Exception>(throwOptions),
+			b => b.AppendMethod(nameof(ThrowsException))),
+			throwOptions);
+	}
+
+	internal class ThrowsOption
+	{
+		public bool DoCheckThrow { get; private set; } = true;
+
+		public void CheckThrow(bool doCheckThrow)
+		{
+			DoCheckThrow = doCheckThrow;
+		}
+	}
 }

--- a/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.HasInnerExceptionConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.HasInnerExceptionConstraint.cs
@@ -27,7 +27,7 @@ public static partial class ThatExceptionExtensions
 			if (innerException is not null)
 			{
 				return new ConstraintResult.Failure<Exception?>(innerException, ToString(),
-					$"found {innerException.GetType().Name.PrependAOrAn()}:{Environment.NewLine}{innerException.Message.Indent()}");
+					$"found {innerException.FormatForMessage()}");
 			}
 
 			return new ConstraintResult.Failure(ToString(),

--- a/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.cs
@@ -113,7 +113,7 @@ public static partial class ThatExceptionExtensions
 			return new ConstraintResult.Failure<Exception?>(actual, "",
 				actual == null
 					? "found <null>"
-					: $"found {actual.GetType().Name.PrependAOrAn()}:{Environment.NewLine}{actual.Message.Indent()}");
+					: $"found {actual.FormatForMessage()}");
 		}
 
 		#endregion

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.OnlyIfTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.OnlyIfTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Testably.Expectations.Tests.Delegates;
+
+public sealed partial class ThatDelegate
+{
+	public sealed class OnlyIfTests
+	{
+		[Fact]
+		public async Task WhenTrue_ShouldSucceedWhenAnExceptionWasThrow()
+		{
+			Exception exception = new("");
+			Action action = () => throw exception;
+
+			async Task Act()
+				=> await Expect.That(action).ThrowsException().OnlyIf(true);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenFalse_ShouldSucceedWhenNoExceptionWasThrown()
+		{
+			Action action = () => { };
+
+			async Task Act()
+				=> await Expect.That(action).ThrowsException().OnlyIf(false);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+		[Fact]
+		public async Task WhenTrue_ShouldFailWhenNoExceptionWasThrow()
+		{
+			Action action = () => { };
+
+			async Task Act()
+				=> await Expect.That(action).ThrowsException().OnlyIf(true);
+
+			await Expect.That(Act).ThrowsException()
+				.Which.HasMessage("""
+				                  Expected that action
+				                  throws an Exception,
+				                  but it did not
+				                  at Expect.That(action).ThrowsException().OnlyIf(true)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenFalse_ShouldFailWhenAnExceptionWasThrown()
+		{
+			Exception exception = new("");
+			Action action = () => throw exception;
+
+			async Task Act()
+				=> await Expect.That(action).ThrowsException().OnlyIf(false);
+
+			await Expect.That(Act).ThrowsException()
+				.Which.HasMessage("""
+				                  Expected that action
+				                  does not throw any exception,
+				                  but it did throw an Exception
+				                  at Expect.That(action).ThrowsException().OnlyIf(false)
+				                  """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsExactlyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsExactlyTests.cs
@@ -15,7 +15,7 @@ public sealed partial class ThatDelegate
 			                          Expected that action
 			                          throws exactly a CustomException,
 			                          but it did throw an OtherException:
-			                          	{nameof(Fails_For_Code_With_Other_Exceptions)}
+			                            {nameof(Fails_For_Code_With_Other_Exceptions)}
 			                          at Expect.That(action).ThrowsExactly<CustomException>()
 			                          """;
 			Exception exception = CreateOtherException();
@@ -35,7 +35,7 @@ public sealed partial class ThatDelegate
 			                          Expected that action
 			                          throws exactly a CustomException,
 			                          but it did throw a SubCustomException:
-			                          	{nameof(Fails_For_Code_With_Subtype_Exceptions)}
+			                            {nameof(Fails_For_Code_With_Subtype_Exceptions)}
 			                          at Expect.That(action).ThrowsExactly<CustomException>()
 			                          """;
 			Exception exception = CreateSubCustomException();

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsTests.cs
@@ -15,7 +15,7 @@ public sealed partial class ThatDelegate
 			                          Expected that action
 			                          throws a CustomException,
 			                          but it did throw an OtherException:
-			                          	{nameof(Fails_For_Code_With_Other_Exceptions)}
+			                            {nameof(Fails_For_Code_With_Other_Exceptions)}
 			                          at Expect.That(action).Throws<CustomException>()
 			                          """;
 			Exception exception = CreateOtherException();
@@ -35,7 +35,7 @@ public sealed partial class ThatDelegate
 			                          Expected that action
 			                          throws a SubCustomException,
 			                          but it did throw a CustomException:
-			                          	{nameof(Fails_For_Code_With_Supertype_Exceptions)}
+			                            {nameof(Fails_For_Code_With_Supertype_Exceptions)}
 			                          at Expect.That(action).Throws<SubCustomException>()
 			                          """;
 			Exception exception = CreateCustomException();

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsTests.cs
@@ -22,14 +22,7 @@ public sealed partial class ThatString
 			async Task Act()
 				=> await Expect.That(actual).Is(pattern).AsWildcard();
 
-			if (expectMatch)
-			{
-				await Expect.That(Act).DoesNotThrow();
-			}
-			else
-			{
-				await Expect.That(Act).ThrowsException();
-			}
+			await Expect.That(Act).ThrowsException().OnlyIf(!expectMatch);
 		}
 
 		[Theory]


### PR DESCRIPTION
I often have the issue that I want to assert in a test, that an exception was only thrown when a certain condition applies.
Currently I have to introduce an if/else clause, e.g.
```csharp
if (expectMatch)
{
    await Expect.That(sut).ThrowsNothing();
}
else
{
    await Expect.That(sut).ThrowsException().Which.HasMessage(expectedExpression);
}
```

This PR adds an `OnlyIf` method to the `DelegateExpectationResult` class, so that this can be simplified to
```csharp
await Expect.That(sut).ThrowsException().OnlyIf(!expectMatch).Which.HasMessage(expectedExpression);
```

The `OnlyIf` will check the predicate, and if it is `true` it will ensure, that the exception was thrown as specified. If it is `false`, it will instead ensure, that no exception was thrown.

*Note: This is similar to https://github.com/thomhurst/TUnit/pull/882.*