### PR TITLE
feat: add support for async constraints

### DIFF
--- a/Source/Testably.Expectations/Core/Constraints/IAsyncConstraint.cs
+++ b/Source/Testably.Expectations/Core/Constraints/IAsyncConstraint.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+
+namespace Testably.Expectations.Core.Constraints;
+
+/// <summary>
+///     A simple expectation on type <typeparamref name="TValue" />.
+/// </summary>
+public interface IAsyncConstraint<in TValue> : IConstraint
+{
+	/// <summary>
+	///     Checks if the <paramref name="actual" /> value meets the expectation.
+	/// </summary>
+	public Task<ConstraintResult> IsMetBy(TValue actual);
+}

--- a/Source/Testably.Expectations/Expect.Specialized.cs
+++ b/Source/Testably.Expectations/Expect.Specialized.cs
@@ -1,0 +1,15 @@
+﻿using System.Net.Http;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+
+namespace Testably.Expectations;
+
+public static partial class Expect
+{
+	/// <summary>
+	///     Start expectations for the current <see cref="HttpResponseMessage" /> <paramref name="subject" />.
+	/// </summary>
+	public static That<HttpResponseMessage?> That(HttpResponseMessage? subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<HttpResponseMessage?>(subject, doNotPopulateThisValue));
+}

--- a/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.HasContentConstraint.cs
+++ b/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.HasContentConstraint.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading.Tasks;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 
@@ -8,11 +9,17 @@ namespace Testably.Expectations;
 public static partial class ThatHttpResponseMessageExtensions
 {
 	private readonly struct HasContentConstraint(StringMatcher expected)
-		: IConstraint<HttpResponseMessage>
+		: IAsyncConstraint<HttpResponseMessage>
 	{
-		public ConstraintResult IsMetBy(HttpResponseMessage? actual)
+		public async Task<ConstraintResult> IsMetBy(HttpResponseMessage? actual)
 		{
-			string? message = actual?.Content.ReadAsStringAsync().Result;
+			if (actual == null)
+			{
+				return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+					"found <null>");
+			}
+
+			string message = await actual.Content.ReadAsStringAsync();
 			if (expected.Matches(message))
 			{
 				return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());

--- a/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.HasContentConstraint.cs
+++ b/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.HasContentConstraint.cs
@@ -1,0 +1,28 @@
+﻿using System.Net.Http;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Constraints;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatHttpResponseMessageExtensions
+{
+	private readonly struct HasContentConstraint(StringMatcher expected)
+		: IConstraint<HttpResponseMessage>
+	{
+		public ConstraintResult IsMetBy(HttpResponseMessage? actual)
+		{
+			string? message = actual?.Content.ReadAsStringAsync().Result;
+			if (expected.Matches(message))
+			{
+				return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+				expected.GetExtendedFailure(message));
+		}
+
+		public override string ToString()
+			=> $"has a string content {expected.GetExpectation(GrammaticVoice.PassiveVoice)}";
+	}
+}

--- a/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.cs
+++ b/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System.Net.Http;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Core.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on <see cref="HttpResponseMessage" /> values.
+/// </summary>
+public static partial class ThatHttpResponseMessageExtensions
+{
+	/// <summary>
+	///     Verifies that the string content is equal to <paramref name="expected" />
+	/// </summary>
+	public static StringMatcherExpectationResult<HttpResponseMessage, That<HttpResponseMessage?>>
+		HasContent(
+			this That<HttpResponseMessage?> source,
+			StringMatcher expected,
+			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new HasContentConstraint(expected),
+				b => b.AppendMethod(nameof(HasContent), doNotPopulateThisValue)),
+			source,
+			expected);
+}

--- a/Source/Testably.Expectations/Testably.Expectations.csproj
+++ b/Source/Testably.Expectations/Testably.Expectations.csproj
@@ -10,8 +10,11 @@
 
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<Nullable>annotations</Nullable>
-		<Nullable>annotations</Nullable>
 	</PropertyGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<None Include="$(SolutionDir)README.md" Pack="true" PackagePath="/Docs/" Link="Docs\README.md" />

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasContentTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasContentTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Specialized.Http;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed class HasContentTests
+	{
+		[Fact]
+		public async Task WhenContentDiffersFromExpected_ShouldFail()
+		{
+			string expected = "other content";
+			HttpResponseMessage sut = Create("some content");
+
+			async Task Act()
+				=> await Expect.That(sut).HasContent(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that sut
+				                  has a string content equal to "other content",
+				                  but found "some content" which differs at index 0:
+				                     ↓ (actual)
+				                    "some content"
+				                    "other content"
+				                     ↑ (expected)
+				                  at Expect.That(sut).HasContent(expected)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenContentEqualsExpected_ShouldSucceed()
+		{
+			string expected = "some content";
+			HttpResponseMessage sut = Create(expected);
+
+			async Task Act()
+				=> await Expect.That(sut).HasContent(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.cs
@@ -1,0 +1,15 @@
+﻿using System.Net;
+using System.Net.Http;
+
+namespace Testably.Expectations.Tests.Specialized.Http;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	private static HttpResponseMessage Create(string content,
+		HttpStatusCode statusCode = HttpStatusCode.OK)
+	{
+		HttpResponseMessage httpResponseMessage = new HttpResponseMessage(statusCode);
+		httpResponseMessage.Content = new StringContent(content);
+		return httpResponseMessage;
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Testably.Expectations.Tests.csproj
+++ b/Tests/Testably.Expectations.Tests/Testably.Expectations.Tests.csproj
@@ -4,6 +4,10 @@
 		<TargetFrameworks>net8.0</TargetFrameworks>
 	</PropertyGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\..\Source\Testably.Expectations\Testably.Expectations.csproj" />
 	</ItemGroup>


### PR DESCRIPTION
Add the interface `IAsyncConstraint<TValue>` which allows evaluating the constraint asynchronously.
Add as an example for the `HttpResponseMessage.HasContent` method.