### PR TITLE
feat: add check for HTTP status codes

### DIFF
--- a/Source/Testably.Expectations/Core/Formatting/Formatter.cs
+++ b/Source/Testably.Expectations/Core/Formatting/Formatter.cs
@@ -19,6 +19,7 @@ public class Formatter
 		new BooleanFormatter(),
 		new StringFormatter(),
 		new TypeFormatter(),
+		new HttpStatusCodeFormatter(),
 		new CollectionFormatter(),
 		new NumberFormatter<int>(),
 		new NumberFormatter<uint>(),

--- a/Source/Testably.Expectations/Core/Formatting/Formatters/HttpStatusCodeFormatter.cs
+++ b/Source/Testably.Expectations/Core/Formatting/Formatters/HttpStatusCodeFormatter.cs
@@ -1,0 +1,14 @@
+﻿using System.Net;
+using System.Text;
+
+namespace Testably.Expectations.Core.Formatting.Formatters;
+
+internal class HttpStatusCodeFormatter : FormatterBase<HttpStatusCode>
+{
+	/// <inheritdoc />
+	public override void Format(HttpStatusCode value, StringBuilder stringBuilder,
+		FormattingOptions options)
+	{
+		stringBuilder.Append($"{(int)value} {value}");
+	}
+}

--- a/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.HasStatusCodeConstraint.cs
+++ b/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.HasStatusCodeConstraint.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatHttpResponseMessageExtensions
+{
+	private readonly struct HasStatusCodeConstraint(HttpStatusCode expected)
+		: IAsyncConstraint<HttpResponseMessage>
+	{
+		public async Task<ConstraintResult> IsMetBy(HttpResponseMessage? actual)
+		{
+			if (actual == null)
+			{
+				return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+					"found <null>");
+			}
+
+			if (actual.StatusCode == expected)
+			{
+				return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());
+			}
+
+			string formattedResponse = await HttpResponseMessageFormatter.Format(actual, "  ");
+			return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+				$"found {Formatter.Format(actual.StatusCode)}:{Environment.NewLine}{formattedResponse}");
+		}
+
+		public override string ToString()
+			=> $"has StatusCode {Formatter.Format(expected)}";
+	}
+}

--- a/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.HasStatusCodeRangeConstraint.cs
+++ b/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.HasStatusCodeRangeConstraint.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatHttpResponseMessageExtensions
+{
+	private readonly struct HasStatusCodeRangeConstraint(Func<int, bool> predicate, string expectation)
+		: IAsyncConstraint<HttpResponseMessage>
+	{
+		public async Task<ConstraintResult> IsMetBy(HttpResponseMessage? actual)
+		{
+			if (actual == null)
+			{
+				return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+					"found <null>");
+			}
+
+			if (predicate((int)actual.StatusCode))
+			{
+				return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());
+			}
+
+			string formattedResponse = await HttpResponseMessageFormatter.Format(actual, "  ");
+			return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+				$"found {Formatter.Format(actual.StatusCode)}:{Environment.NewLine}{formattedResponse}");
+		}
+
+		public override string ToString()
+			=> expectation;
+	}
+}

--- a/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.HttpResponseMessageFormatter.cs
+++ b/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.HttpResponseMessageFormatter.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Testably.Expectations.Core.Helpers;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatHttpResponseMessageExtensions
+{
+	private static class HttpResponseMessageFormatter
+	{
+		public static async Task<string> Format(HttpResponseMessage response, string indentation)
+		{
+			StringBuilder messageBuilder = new StringBuilder();
+
+			messageBuilder.Append(indentation)
+				.Append("HTTP/").Append(response.Version)
+				.Append(" ").Append((int)response.StatusCode).Append(" ").Append(response.StatusCode)
+				.AppendLine();
+
+			AppendHeaders(messageBuilder, response.Headers, indentation);
+			await AppendContent(messageBuilder, response.Content, indentation);
+
+			HttpRequestMessage? request = response.RequestMessage;
+			if (request == null)
+			{
+				messageBuilder.Append(indentation).AppendLine("The originating request was <null>");
+			}
+			else
+			{
+				messageBuilder.Append(indentation).AppendLine("The originating request was:");
+				messageBuilder.Append(indentation).Append(indentation).Append(request.Method.ToString().ToUpper()).Append(" ")
+					.Append(request.RequestUri).Append(" HTTP ").Append(request.Version).AppendLine();
+
+				AppendHeaders(messageBuilder, request.Headers, indentation);
+				if (request.Content != null)
+				{
+					await AppendContent(messageBuilder, request.Content, indentation + indentation);
+				}
+			}
+
+			return messageBuilder.ToString().TrimEnd();
+		}
+
+		private static async Task AppendContent(StringBuilder messageBuilder,
+			HttpContent content,
+			string indentation)
+		{
+			if (content is StringContent)
+			{
+				var stringContent = await content.ReadAsStringAsync();
+				messageBuilder.AppendLine(stringContent.Indent(indentation));
+			}
+			else if (content is FormUrlEncodedContent)
+			{
+				var stringContent = await content.ReadAsStringAsync();
+				messageBuilder.AppendLine(stringContent.Indent(indentation));
+			}
+			else
+			{
+				messageBuilder.Append(indentation).AppendLine("Content is binary");
+			}
+		}
+
+		private static void AppendHeaders(
+			StringBuilder messageBuilder,
+			HttpHeaders headers,
+			string indentation)
+		{
+			foreach (KeyValuePair<string, IEnumerable<string>> header in headers
+				.OrderBy(x => x.Key == "Content-Length"))
+			{
+				foreach (string headerValue in header.Value)
+				{
+					messageBuilder.Append(indentation).Append(indentation)
+						.Append(header.Key).Append(": ").AppendLine(headerValue);
+				}
+			}
+		}
+	}
+}

--- a/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.cs
+++ b/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.cs
@@ -14,6 +14,19 @@ namespace Testably.Expectations;
 public static partial class ThatHttpResponseMessageExtensions
 {
 	/// <summary>
+	///     Verifies that the response has a client error status code (4xx)
+	/// </summary>
+	public static AndOrExpectationResult<HttpResponseMessage, That<HttpResponseMessage?>>
+		HasClientError(
+			this That<HttpResponseMessage?> source)
+		=> new(source.ExpectationBuilder.Add(
+				new HasStatusCodeRangeConstraint(
+					statusCode => statusCode >= 400 && statusCode < 500,
+					"has client error (status code 4xx)"),
+				b => b.AppendMethod(nameof(HasClientError))),
+			source);
+
+	/// <summary>
 	///     Verifies that the string content is equal to <paramref name="expected" />
 	/// </summary>
 	public static StringMatcherExpectationResult<HttpResponseMessage, That<HttpResponseMessage?>>
@@ -28,6 +41,19 @@ public static partial class ThatHttpResponseMessageExtensions
 			expected);
 
 	/// <summary>
+	///     Verifies that the response has a server error status code (5xx)
+	/// </summary>
+	public static AndOrExpectationResult<HttpResponseMessage, That<HttpResponseMessage?>>
+		HasServerError(
+			this That<HttpResponseMessage?> source)
+		=> new(source.ExpectationBuilder.Add(
+				new HasStatusCodeRangeConstraint(
+					statusCode => statusCode >= 500 && statusCode < 600,
+					"has server error (status code 5xx)"),
+				b => b.AppendMethod(nameof(HasServerError))),
+			source);
+
+	/// <summary>
 	///     Verifies that the response has a status code equal to <paramref name="expected" />
 	/// </summary>
 	public static AndOrExpectationResult<HttpResponseMessage, That<HttpResponseMessage?>>
@@ -38,5 +64,31 @@ public static partial class ThatHttpResponseMessageExtensions
 		=> new(source.ExpectationBuilder.Add(
 				new HasStatusCodeConstraint(expected),
 				b => b.AppendMethod(nameof(HasContent), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the response has a redirection status code (3xx)
+	/// </summary>
+	public static AndOrExpectationResult<HttpResponseMessage, That<HttpResponseMessage?>>
+		IsRedirection(
+			this That<HttpResponseMessage?> source)
+		=> new(source.ExpectationBuilder.Add(
+				new HasStatusCodeRangeConstraint(
+					statusCode => statusCode >= 300 && statusCode < 400,
+					"is redirection (status code 3xx)"),
+				b => b.AppendMethod(nameof(IsRedirection))),
+			source);
+
+	/// <summary>
+	///     Verifies that the response has a success status code (2xx)
+	/// </summary>
+	public static AndOrExpectationResult<HttpResponseMessage, That<HttpResponseMessage?>>
+		IsSuccessful(
+			this That<HttpResponseMessage?> source)
+		=> new(source.ExpectationBuilder.Add(
+				new HasStatusCodeRangeConstraint(
+					statusCode => statusCode >= 200 && statusCode < 300,
+					"is successful (status code 2xx)"),
+				b => b.AppendMethod(nameof(IsSuccessful))),
 			source);
 }

--- a/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.cs
+++ b/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
+using Testably.Expectations.Core.Formatting;
 using Testably.Expectations.Core.Helpers;
 using Testably.Expectations.Core.Results;
 
@@ -13,6 +14,21 @@ namespace Testably.Expectations;
 /// </summary>
 public static partial class ThatHttpResponseMessageExtensions
 {
+	/// <summary>
+	///     Verifies that the response has a status code different to <paramref name="unexpected" />
+	/// </summary>
+	public static AndOrExpectationResult<HttpResponseMessage, That<HttpResponseMessage?>>
+		DoesNotHaveStatusCode(
+			this That<HttpResponseMessage?> source,
+			HttpStatusCode unexpected,
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new HasStatusCodeRangeConstraint(statusCode => statusCode != (int)unexpected,
+					$"has StatusCode different to {Formatter.Format(unexpected)}"),
+				b => b.AppendMethod(nameof(DoesNotHaveStatusCode), doNotPopulateThisValue)),
+			source);
+
 	/// <summary>
 	///     Verifies that the response has a client error status code (4xx)
 	/// </summary>
@@ -39,6 +55,19 @@ public static partial class ThatHttpResponseMessageExtensions
 				b => b.AppendMethod(nameof(HasContent), doNotPopulateThisValue)),
 			source,
 			expected);
+
+	/// <summary>
+	///     Verifies that the response has a client or server error status code (4xx or 5xx)
+	/// </summary>
+	public static AndOrExpectationResult<HttpResponseMessage, That<HttpResponseMessage?>>
+		HasError(
+			this That<HttpResponseMessage?> source)
+		=> new(source.ExpectationBuilder.Add(
+				new HasStatusCodeRangeConstraint(
+					statusCode => statusCode >= 400 && statusCode < 600,
+					"has an error (status code 4xx or 5xx)"),
+				b => b.AppendMethod(nameof(HasError))),
+			source);
 
 	/// <summary>
 	///     Verifies that the response has a server error status code (5xx)

--- a/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.cs
+++ b/Source/Testably.Expectations/Specialized/Http/ThatHttpResponseMessageExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Net;
+using System.Net.Http;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Helpers;
@@ -25,4 +26,17 @@ public static partial class ThatHttpResponseMessageExtensions
 				b => b.AppendMethod(nameof(HasContent), doNotPopulateThisValue)),
 			source,
 			expected);
+
+	/// <summary>
+	///     Verifies that the response has a status code equal to <paramref name="expected" />
+	/// </summary>
+	public static AndOrExpectationResult<HttpResponseMessage, That<HttpResponseMessage?>>
+		HasStatusCode(
+			this That<HttpResponseMessage?> source,
+			HttpStatusCode expected,
+			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new HasStatusCodeConstraint(expected),
+				b => b.AppendMethod(nameof(HasContent), doNotPopulateThisValue)),
+			source);
 }

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.DoesNotHaveStatusCodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.DoesNotHaveStatusCodeTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Specialized.Http;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed class DoesNotHaveStatusCodeTests
+	{
+		[Theory]
+		[MemberData(nameof(SuccessStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(RedirectStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(ClientErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
+		{
+			HttpStatusCode unexpected = statusCode;
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(statusCode);
+
+			async Task Act()
+				=> await Expect.That(sut).DoesNotHaveStatusCode(unexpected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage(
+					"*StatusCode different to*Expect.That(sut).DoesNotHaveStatusCode(unexpected)")
+				.AsWildcard();
+		}
+
+		[Fact]
+		public async Task WhenStatusCodeDiffersFromExpected_ShouldSucceed()
+		{
+			HttpStatusCode unexpected = HttpStatusCode.OK;
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(HttpStatusCode.BadRequest);
+
+			async Task Act()
+				=> await Expect.That(sut).DoesNotHaveStatusCode(unexpected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasClientErrorTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasClientErrorTests.cs
@@ -1,0 +1,83 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Specialized.Http;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed class HasClientErrorTests
+	{
+		[Theory]
+		//4xx
+		[InlineData(HttpStatusCode.BadRequest)]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.PaymentRequired)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		[InlineData(HttpStatusCode.NotFound)]
+		[InlineData(HttpStatusCode.MethodNotAllowed)]
+		[InlineData(HttpStatusCode.NotAcceptable)]
+		[InlineData(HttpStatusCode.ProxyAuthenticationRequired)]
+		[InlineData(HttpStatusCode.RequestTimeout)]
+		[InlineData(HttpStatusCode.Conflict)]
+		[InlineData(HttpStatusCode.Gone)]
+		[InlineData(HttpStatusCode.LengthRequired)]
+		[InlineData(HttpStatusCode.PreconditionFailed)]
+		[InlineData(HttpStatusCode.RequestEntityTooLarge)]
+		[InlineData(HttpStatusCode.RequestUriTooLong)]
+		[InlineData(HttpStatusCode.UnsupportedMediaType)]
+		[InlineData(HttpStatusCode.RequestedRangeNotSatisfiable)]
+		[InlineData(HttpStatusCode.ExpectationFailed)]
+		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(statusCode);
+
+			async Task Act()
+				=> await Expect.That(sut).HasClientError();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		//2xx
+		[InlineData(HttpStatusCode.OK)]
+		[InlineData(HttpStatusCode.Created)]
+		[InlineData(HttpStatusCode.Accepted)]
+		[InlineData(HttpStatusCode.NonAuthoritativeInformation)]
+		[InlineData(HttpStatusCode.NoContent)]
+		[InlineData(HttpStatusCode.ResetContent)]
+		[InlineData(HttpStatusCode.PartialContent)]
+		//3xx
+		[InlineData(HttpStatusCode.MultipleChoices)]
+		[InlineData(HttpStatusCode.MovedPermanently)]
+		[InlineData(HttpStatusCode.Redirect)]
+		[InlineData(HttpStatusCode.SeeOther)]
+		[InlineData(HttpStatusCode.NotModified)]
+		[InlineData(HttpStatusCode.UseProxy)]
+		[InlineData(HttpStatusCode.Unused)]
+		[InlineData(HttpStatusCode.TemporaryRedirect)]
+		//5xx
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		[InlineData(HttpStatusCode.BadGateway)]
+		[InlineData(HttpStatusCode.ServiceUnavailable)]
+		[InlineData(HttpStatusCode.GatewayTimeout)]
+		[InlineData(HttpStatusCode.HttpVersionNotSupported)]
+		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(statusCode);
+
+			async Task Act()
+				=> await Expect.That(sut).HasClientError();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage(
+					"*client error (status code 4xx)*Expect.That(sut).HasClientError()")
+				.AsWildcard();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasClientErrorTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasClientErrorTests.cs
@@ -11,25 +11,7 @@ public sealed partial class ThatHttpResponseMessage
 	public sealed class HasClientErrorTests
 	{
 		[Theory]
-		//4xx
-		[InlineData(HttpStatusCode.BadRequest)]
-		[InlineData(HttpStatusCode.Unauthorized)]
-		[InlineData(HttpStatusCode.PaymentRequired)]
-		[InlineData(HttpStatusCode.Forbidden)]
-		[InlineData(HttpStatusCode.NotFound)]
-		[InlineData(HttpStatusCode.MethodNotAllowed)]
-		[InlineData(HttpStatusCode.NotAcceptable)]
-		[InlineData(HttpStatusCode.ProxyAuthenticationRequired)]
-		[InlineData(HttpStatusCode.RequestTimeout)]
-		[InlineData(HttpStatusCode.Conflict)]
-		[InlineData(HttpStatusCode.Gone)]
-		[InlineData(HttpStatusCode.LengthRequired)]
-		[InlineData(HttpStatusCode.PreconditionFailed)]
-		[InlineData(HttpStatusCode.RequestEntityTooLarge)]
-		[InlineData(HttpStatusCode.RequestUriTooLong)]
-		[InlineData(HttpStatusCode.UnsupportedMediaType)]
-		[InlineData(HttpStatusCode.RequestedRangeNotSatisfiable)]
-		[InlineData(HttpStatusCode.ExpectationFailed)]
+		[MemberData(nameof(ClientErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
 		{
 			HttpResponseMessage sut = ResponseBuilder
@@ -42,30 +24,9 @@ public sealed partial class ThatHttpResponseMessage
 		}
 
 		[Theory]
-		//2xx
-		[InlineData(HttpStatusCode.OK)]
-		[InlineData(HttpStatusCode.Created)]
-		[InlineData(HttpStatusCode.Accepted)]
-		[InlineData(HttpStatusCode.NonAuthoritativeInformation)]
-		[InlineData(HttpStatusCode.NoContent)]
-		[InlineData(HttpStatusCode.ResetContent)]
-		[InlineData(HttpStatusCode.PartialContent)]
-		//3xx
-		[InlineData(HttpStatusCode.MultipleChoices)]
-		[InlineData(HttpStatusCode.MovedPermanently)]
-		[InlineData(HttpStatusCode.Redirect)]
-		[InlineData(HttpStatusCode.SeeOther)]
-		[InlineData(HttpStatusCode.NotModified)]
-		[InlineData(HttpStatusCode.UseProxy)]
-		[InlineData(HttpStatusCode.Unused)]
-		[InlineData(HttpStatusCode.TemporaryRedirect)]
-		//5xx
-		[InlineData(HttpStatusCode.InternalServerError)]
-		[InlineData(HttpStatusCode.NotImplemented)]
-		[InlineData(HttpStatusCode.BadGateway)]
-		[InlineData(HttpStatusCode.ServiceUnavailable)]
-		[InlineData(HttpStatusCode.GatewayTimeout)]
-		[InlineData(HttpStatusCode.HttpVersionNotSupported)]
+		[MemberData(nameof(SuccessStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(RedirectStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
 		{
 			HttpResponseMessage sut = ResponseBuilder

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasContentTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasContentTests.cs
@@ -13,7 +13,8 @@ public sealed partial class ThatHttpResponseMessage
 		public async Task WhenContentDiffersFromExpected_ShouldFail()
 		{
 			string expected = "other content";
-			HttpResponseMessage sut = Create("some content");
+			HttpResponseMessage sut = ResponseBuilder
+				.WithContent("some content");
 
 			async Task Act()
 				=> await Expect.That(sut).HasContent(expected);
@@ -35,7 +36,8 @@ public sealed partial class ThatHttpResponseMessage
 		public async Task WhenContentEqualsExpected_ShouldSucceed()
 		{
 			string expected = "some content";
-			HttpResponseMessage sut = Create(expected);
+			HttpResponseMessage sut = ResponseBuilder
+				.WithContent(expected);
 
 			async Task Act()
 				=> await Expect.That(sut).HasContent(expected);

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasErrorTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasErrorTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Specialized.Http;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed class HasErrorTests
+	{
+		[Theory]
+		[MemberData(nameof(ClientErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(statusCode);
+
+			async Task Act()
+				=> await Expect.That(sut).HasError();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		[MemberData(nameof(SuccessStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(RedirectStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(statusCode);
+
+			async Task Act()
+				=> await Expect.That(sut).HasError();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage(
+					"*an error (status code 4xx or 5xx)*Expect.That(sut).HasError()")
+				.AsWildcard();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasServerErrorTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasServerErrorTests.cs
@@ -1,0 +1,83 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Specialized.Http;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed class HasServerErrorTests
+	{
+		[Theory]
+		//5xx
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		[InlineData(HttpStatusCode.BadGateway)]
+		[InlineData(HttpStatusCode.ServiceUnavailable)]
+		[InlineData(HttpStatusCode.GatewayTimeout)]
+		[InlineData(HttpStatusCode.HttpVersionNotSupported)]
+		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(statusCode);
+
+			async Task Act()
+				=> await Expect.That(sut).HasServerError();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		//2xx
+		[InlineData(HttpStatusCode.OK)]
+		[InlineData(HttpStatusCode.Created)]
+		[InlineData(HttpStatusCode.Accepted)]
+		[InlineData(HttpStatusCode.NonAuthoritativeInformation)]
+		[InlineData(HttpStatusCode.NoContent)]
+		[InlineData(HttpStatusCode.ResetContent)]
+		[InlineData(HttpStatusCode.PartialContent)]
+		//3xx
+		[InlineData(HttpStatusCode.MultipleChoices)]
+		[InlineData(HttpStatusCode.MovedPermanently)]
+		[InlineData(HttpStatusCode.Redirect)]
+		[InlineData(HttpStatusCode.SeeOther)]
+		[InlineData(HttpStatusCode.NotModified)]
+		[InlineData(HttpStatusCode.UseProxy)]
+		[InlineData(HttpStatusCode.Unused)]
+		[InlineData(HttpStatusCode.TemporaryRedirect)]
+		//4xx
+		[InlineData(HttpStatusCode.BadRequest)]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.PaymentRequired)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		[InlineData(HttpStatusCode.NotFound)]
+		[InlineData(HttpStatusCode.MethodNotAllowed)]
+		[InlineData(HttpStatusCode.NotAcceptable)]
+		[InlineData(HttpStatusCode.ProxyAuthenticationRequired)]
+		[InlineData(HttpStatusCode.RequestTimeout)]
+		[InlineData(HttpStatusCode.Conflict)]
+		[InlineData(HttpStatusCode.Gone)]
+		[InlineData(HttpStatusCode.LengthRequired)]
+		[InlineData(HttpStatusCode.PreconditionFailed)]
+		[InlineData(HttpStatusCode.RequestEntityTooLarge)]
+		[InlineData(HttpStatusCode.RequestUriTooLong)]
+		[InlineData(HttpStatusCode.UnsupportedMediaType)]
+		[InlineData(HttpStatusCode.RequestedRangeNotSatisfiable)]
+		[InlineData(HttpStatusCode.ExpectationFailed)]
+		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(statusCode);
+
+			async Task Act()
+				=> await Expect.That(sut).HasServerError();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage(
+					"*server error (status code 5xx)*Expect.That(sut).HasServerError()")
+				.AsWildcard();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasServerErrorTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasServerErrorTests.cs
@@ -11,13 +11,7 @@ public sealed partial class ThatHttpResponseMessage
 	public sealed class HasServerErrorTests
 	{
 		[Theory]
-		//5xx
-		[InlineData(HttpStatusCode.InternalServerError)]
-		[InlineData(HttpStatusCode.NotImplemented)]
-		[InlineData(HttpStatusCode.BadGateway)]
-		[InlineData(HttpStatusCode.ServiceUnavailable)]
-		[InlineData(HttpStatusCode.GatewayTimeout)]
-		[InlineData(HttpStatusCode.HttpVersionNotSupported)]
+		[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
 		{
 			HttpResponseMessage sut = ResponseBuilder
@@ -30,42 +24,9 @@ public sealed partial class ThatHttpResponseMessage
 		}
 
 		[Theory]
-		//2xx
-		[InlineData(HttpStatusCode.OK)]
-		[InlineData(HttpStatusCode.Created)]
-		[InlineData(HttpStatusCode.Accepted)]
-		[InlineData(HttpStatusCode.NonAuthoritativeInformation)]
-		[InlineData(HttpStatusCode.NoContent)]
-		[InlineData(HttpStatusCode.ResetContent)]
-		[InlineData(HttpStatusCode.PartialContent)]
-		//3xx
-		[InlineData(HttpStatusCode.MultipleChoices)]
-		[InlineData(HttpStatusCode.MovedPermanently)]
-		[InlineData(HttpStatusCode.Redirect)]
-		[InlineData(HttpStatusCode.SeeOther)]
-		[InlineData(HttpStatusCode.NotModified)]
-		[InlineData(HttpStatusCode.UseProxy)]
-		[InlineData(HttpStatusCode.Unused)]
-		[InlineData(HttpStatusCode.TemporaryRedirect)]
-		//4xx
-		[InlineData(HttpStatusCode.BadRequest)]
-		[InlineData(HttpStatusCode.Unauthorized)]
-		[InlineData(HttpStatusCode.PaymentRequired)]
-		[InlineData(HttpStatusCode.Forbidden)]
-		[InlineData(HttpStatusCode.NotFound)]
-		[InlineData(HttpStatusCode.MethodNotAllowed)]
-		[InlineData(HttpStatusCode.NotAcceptable)]
-		[InlineData(HttpStatusCode.ProxyAuthenticationRequired)]
-		[InlineData(HttpStatusCode.RequestTimeout)]
-		[InlineData(HttpStatusCode.Conflict)]
-		[InlineData(HttpStatusCode.Gone)]
-		[InlineData(HttpStatusCode.LengthRequired)]
-		[InlineData(HttpStatusCode.PreconditionFailed)]
-		[InlineData(HttpStatusCode.RequestEntityTooLarge)]
-		[InlineData(HttpStatusCode.RequestUriTooLong)]
-		[InlineData(HttpStatusCode.UnsupportedMediaType)]
-		[InlineData(HttpStatusCode.RequestedRangeNotSatisfiable)]
-		[InlineData(HttpStatusCode.ExpectationFailed)]
+		[MemberData(nameof(SuccessStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(RedirectStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(ClientErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
 		{
 			HttpResponseMessage sut = ResponseBuilder

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasStatusCodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasStatusCodeTests.cs
@@ -1,0 +1,90 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Specialized.Http;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed class HasStatusCodeTests
+	{
+		[Fact]
+		public async Task WhenFailing_ShouldIncludeRequestInMessage()
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(HttpStatusCode.BadRequest)
+				.WithContent("some content")
+				.WithRequest(HttpMethod.Get, "https://example.com")
+				.WithRequestContent("request content");
+
+			async Task Act()
+				=> await Expect.That(sut).HasStatusCode(HttpStatusCode.OK);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that sut
+				                  has StatusCode 200 OK,
+				                  but found 400 BadRequest:
+				                    HTTP/1.1 400 BadRequest
+				                    some content
+				                    The originating request was:
+				                      GET https://example.com/ HTTP 1.1
+				                      request content
+				                  at Expect.That(sut).HasContent(HttpStatusCode.OK)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenFailing_ShouldIncludeResponseContentAndStatusCodeInMessage()
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(HttpStatusCode.BadRequest)
+				.WithContent("some content");
+
+			async Task Act()
+				=> await Expect.That(sut).HasStatusCode(HttpStatusCode.OK);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that sut
+				                  has StatusCode 200 OK,
+				                  but found 400 BadRequest:
+				                    HTTP/1.1 400 BadRequest
+				                    some content
+				                    The originating request was <null>
+				                  at Expect.That(sut).HasContent(HttpStatusCode.OK)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenStatusCodeDiffersFromExpected_ShouldFail()
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(HttpStatusCode.BadRequest);
+
+			async Task Act()
+				=> await Expect.That(sut).HasStatusCode(HttpStatusCode.OK);
+
+			await Expect.That(Act).Throws<XunitException>();
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.OK)]
+		[InlineData(HttpStatusCode.BadRequest)]
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.Redirect)]
+		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
+		{
+			HttpStatusCode expected = statusCode;
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(statusCode);
+
+			async Task Act()
+				=> await Expect.That(sut).HasStatusCode(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasStatusCodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasStatusCodeTests.cs
@@ -71,10 +71,10 @@ public sealed partial class ThatHttpResponseMessage
 		}
 
 		[Theory]
-		[InlineData(HttpStatusCode.OK)]
-		[InlineData(HttpStatusCode.BadRequest)]
-		[InlineData(HttpStatusCode.InternalServerError)]
-		[InlineData(HttpStatusCode.Redirect)]
+		[MemberData(nameof(SuccessStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(RedirectStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(ClientErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
 		{
 			HttpStatusCode expected = statusCode;

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsRedirectionTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsRedirectionTests.cs
@@ -11,15 +11,7 @@ public sealed partial class ThatHttpResponseMessage
 	public sealed class IsRedirectionTests
 	{
 		[Theory]
-		//3xx
-		[InlineData(HttpStatusCode.MultipleChoices)]
-		[InlineData(HttpStatusCode.MovedPermanently)]
-		[InlineData(HttpStatusCode.Redirect)]
-		[InlineData(HttpStatusCode.SeeOther)]
-		[InlineData(HttpStatusCode.NotModified)]
-		[InlineData(HttpStatusCode.UseProxy)]
-		[InlineData(HttpStatusCode.Unused)]
-		[InlineData(HttpStatusCode.TemporaryRedirect)]
+		[MemberData(nameof(RedirectStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
 		{
 			HttpResponseMessage sut = ResponseBuilder
@@ -32,40 +24,9 @@ public sealed partial class ThatHttpResponseMessage
 		}
 
 		[Theory]
-		//2xx
-		[InlineData(HttpStatusCode.OK)]
-		[InlineData(HttpStatusCode.Created)]
-		[InlineData(HttpStatusCode.Accepted)]
-		[InlineData(HttpStatusCode.NonAuthoritativeInformation)]
-		[InlineData(HttpStatusCode.NoContent)]
-		[InlineData(HttpStatusCode.ResetContent)]
-		[InlineData(HttpStatusCode.PartialContent)]
-		//4xx
-		[InlineData(HttpStatusCode.BadRequest)]
-		[InlineData(HttpStatusCode.Unauthorized)]
-		[InlineData(HttpStatusCode.PaymentRequired)]
-		[InlineData(HttpStatusCode.Forbidden)]
-		[InlineData(HttpStatusCode.NotFound)]
-		[InlineData(HttpStatusCode.MethodNotAllowed)]
-		[InlineData(HttpStatusCode.NotAcceptable)]
-		[InlineData(HttpStatusCode.ProxyAuthenticationRequired)]
-		[InlineData(HttpStatusCode.RequestTimeout)]
-		[InlineData(HttpStatusCode.Conflict)]
-		[InlineData(HttpStatusCode.Gone)]
-		[InlineData(HttpStatusCode.LengthRequired)]
-		[InlineData(HttpStatusCode.PreconditionFailed)]
-		[InlineData(HttpStatusCode.RequestEntityTooLarge)]
-		[InlineData(HttpStatusCode.RequestUriTooLong)]
-		[InlineData(HttpStatusCode.UnsupportedMediaType)]
-		[InlineData(HttpStatusCode.RequestedRangeNotSatisfiable)]
-		[InlineData(HttpStatusCode.ExpectationFailed)]
-		//5xx
-		[InlineData(HttpStatusCode.InternalServerError)]
-		[InlineData(HttpStatusCode.NotImplemented)]
-		[InlineData(HttpStatusCode.BadGateway)]
-		[InlineData(HttpStatusCode.ServiceUnavailable)]
-		[InlineData(HttpStatusCode.GatewayTimeout)]
-		[InlineData(HttpStatusCode.HttpVersionNotSupported)]
+		[MemberData(nameof(SuccessStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(ClientErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
 		{
 			HttpResponseMessage sut = ResponseBuilder

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsRedirectionTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsRedirectionTests.cs
@@ -1,0 +1,83 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Specialized.Http;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed class IsRedirectionTests
+	{
+		[Theory]
+		//3xx
+		[InlineData(HttpStatusCode.MultipleChoices)]
+		[InlineData(HttpStatusCode.MovedPermanently)]
+		[InlineData(HttpStatusCode.Redirect)]
+		[InlineData(HttpStatusCode.SeeOther)]
+		[InlineData(HttpStatusCode.NotModified)]
+		[InlineData(HttpStatusCode.UseProxy)]
+		[InlineData(HttpStatusCode.Unused)]
+		[InlineData(HttpStatusCode.TemporaryRedirect)]
+		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(statusCode);
+
+			async Task Act()
+				=> await Expect.That(sut).IsRedirection();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		//2xx
+		[InlineData(HttpStatusCode.OK)]
+		[InlineData(HttpStatusCode.Created)]
+		[InlineData(HttpStatusCode.Accepted)]
+		[InlineData(HttpStatusCode.NonAuthoritativeInformation)]
+		[InlineData(HttpStatusCode.NoContent)]
+		[InlineData(HttpStatusCode.ResetContent)]
+		[InlineData(HttpStatusCode.PartialContent)]
+		//4xx
+		[InlineData(HttpStatusCode.BadRequest)]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.PaymentRequired)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		[InlineData(HttpStatusCode.NotFound)]
+		[InlineData(HttpStatusCode.MethodNotAllowed)]
+		[InlineData(HttpStatusCode.NotAcceptable)]
+		[InlineData(HttpStatusCode.ProxyAuthenticationRequired)]
+		[InlineData(HttpStatusCode.RequestTimeout)]
+		[InlineData(HttpStatusCode.Conflict)]
+		[InlineData(HttpStatusCode.Gone)]
+		[InlineData(HttpStatusCode.LengthRequired)]
+		[InlineData(HttpStatusCode.PreconditionFailed)]
+		[InlineData(HttpStatusCode.RequestEntityTooLarge)]
+		[InlineData(HttpStatusCode.RequestUriTooLong)]
+		[InlineData(HttpStatusCode.UnsupportedMediaType)]
+		[InlineData(HttpStatusCode.RequestedRangeNotSatisfiable)]
+		[InlineData(HttpStatusCode.ExpectationFailed)]
+		//5xx
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		[InlineData(HttpStatusCode.BadGateway)]
+		[InlineData(HttpStatusCode.ServiceUnavailable)]
+		[InlineData(HttpStatusCode.GatewayTimeout)]
+		[InlineData(HttpStatusCode.HttpVersionNotSupported)]
+		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(statusCode);
+
+			async Task Act()
+				=> await Expect.That(sut).IsRedirection();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage(
+					"*is redirection (status code 3xx)*Expect.That(sut).IsRedirection()")
+				.AsWildcard();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsSuccessfulTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsSuccessfulTests.cs
@@ -11,14 +11,7 @@ public sealed partial class ThatHttpResponseMessage
 	public sealed class IsSuccessfulTests
 	{
 		[Theory]
-		//2xx
-		[InlineData(HttpStatusCode.OK)]
-		[InlineData(HttpStatusCode.Created)]
-		[InlineData(HttpStatusCode.Accepted)]
-		[InlineData(HttpStatusCode.NonAuthoritativeInformation)]
-		[InlineData(HttpStatusCode.NoContent)]
-		[InlineData(HttpStatusCode.ResetContent)]
-		[InlineData(HttpStatusCode.PartialContent)]
+		[MemberData(nameof(SuccessStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
 		{
 			HttpResponseMessage sut = ResponseBuilder
@@ -31,41 +24,9 @@ public sealed partial class ThatHttpResponseMessage
 		}
 
 		[Theory]
-		//3xx
-		[InlineData(HttpStatusCode.MultipleChoices)]
-		[InlineData(HttpStatusCode.MovedPermanently)]
-		[InlineData(HttpStatusCode.Redirect)]
-		[InlineData(HttpStatusCode.SeeOther)]
-		[InlineData(HttpStatusCode.NotModified)]
-		[InlineData(HttpStatusCode.UseProxy)]
-		[InlineData(HttpStatusCode.Unused)]
-		[InlineData(HttpStatusCode.TemporaryRedirect)]
-		//4xx
-		[InlineData(HttpStatusCode.BadRequest)]
-		[InlineData(HttpStatusCode.Unauthorized)]
-		[InlineData(HttpStatusCode.PaymentRequired)]
-		[InlineData(HttpStatusCode.Forbidden)]
-		[InlineData(HttpStatusCode.NotFound)]
-		[InlineData(HttpStatusCode.MethodNotAllowed)]
-		[InlineData(HttpStatusCode.NotAcceptable)]
-		[InlineData(HttpStatusCode.ProxyAuthenticationRequired)]
-		[InlineData(HttpStatusCode.RequestTimeout)]
-		[InlineData(HttpStatusCode.Conflict)]
-		[InlineData(HttpStatusCode.Gone)]
-		[InlineData(HttpStatusCode.LengthRequired)]
-		[InlineData(HttpStatusCode.PreconditionFailed)]
-		[InlineData(HttpStatusCode.RequestEntityTooLarge)]
-		[InlineData(HttpStatusCode.RequestUriTooLong)]
-		[InlineData(HttpStatusCode.UnsupportedMediaType)]
-		[InlineData(HttpStatusCode.RequestedRangeNotSatisfiable)]
-		[InlineData(HttpStatusCode.ExpectationFailed)]
-		//5xx
-		[InlineData(HttpStatusCode.InternalServerError)]
-		[InlineData(HttpStatusCode.NotImplemented)]
-		[InlineData(HttpStatusCode.BadGateway)]
-		[InlineData(HttpStatusCode.ServiceUnavailable)]
-		[InlineData(HttpStatusCode.GatewayTimeout)]
-		[InlineData(HttpStatusCode.HttpVersionNotSupported)]
+		[MemberData(nameof(RedirectStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(ClientErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+		[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
 		{
 			HttpResponseMessage sut = ResponseBuilder

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsSuccessfulTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsSuccessfulTests.cs
@@ -1,0 +1,83 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Specialized.Http;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed class IsSuccessfulTests
+	{
+		[Theory]
+		//2xx
+		[InlineData(HttpStatusCode.OK)]
+		[InlineData(HttpStatusCode.Created)]
+		[InlineData(HttpStatusCode.Accepted)]
+		[InlineData(HttpStatusCode.NonAuthoritativeInformation)]
+		[InlineData(HttpStatusCode.NoContent)]
+		[InlineData(HttpStatusCode.ResetContent)]
+		[InlineData(HttpStatusCode.PartialContent)]
+		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(statusCode);
+
+			async Task Act()
+				=> await Expect.That(sut).IsSuccessful();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		//3xx
+		[InlineData(HttpStatusCode.MultipleChoices)]
+		[InlineData(HttpStatusCode.MovedPermanently)]
+		[InlineData(HttpStatusCode.Redirect)]
+		[InlineData(HttpStatusCode.SeeOther)]
+		[InlineData(HttpStatusCode.NotModified)]
+		[InlineData(HttpStatusCode.UseProxy)]
+		[InlineData(HttpStatusCode.Unused)]
+		[InlineData(HttpStatusCode.TemporaryRedirect)]
+		//4xx
+		[InlineData(HttpStatusCode.BadRequest)]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.PaymentRequired)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		[InlineData(HttpStatusCode.NotFound)]
+		[InlineData(HttpStatusCode.MethodNotAllowed)]
+		[InlineData(HttpStatusCode.NotAcceptable)]
+		[InlineData(HttpStatusCode.ProxyAuthenticationRequired)]
+		[InlineData(HttpStatusCode.RequestTimeout)]
+		[InlineData(HttpStatusCode.Conflict)]
+		[InlineData(HttpStatusCode.Gone)]
+		[InlineData(HttpStatusCode.LengthRequired)]
+		[InlineData(HttpStatusCode.PreconditionFailed)]
+		[InlineData(HttpStatusCode.RequestEntityTooLarge)]
+		[InlineData(HttpStatusCode.RequestUriTooLong)]
+		[InlineData(HttpStatusCode.UnsupportedMediaType)]
+		[InlineData(HttpStatusCode.RequestedRangeNotSatisfiable)]
+		[InlineData(HttpStatusCode.ExpectationFailed)]
+		//5xx
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		[InlineData(HttpStatusCode.BadGateway)]
+		[InlineData(HttpStatusCode.ServiceUnavailable)]
+		[InlineData(HttpStatusCode.GatewayTimeout)]
+		[InlineData(HttpStatusCode.HttpVersionNotSupported)]
+		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
+		{
+			HttpResponseMessage sut = ResponseBuilder
+				.WithStatusCode(statusCode);
+
+			async Task Act()
+				=> await Expect.That(sut).IsSuccessful();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage(
+					"*is successful (status code 2xx)*Expect.That(sut).IsSuccessful()")
+				.AsWildcard();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.cs
@@ -1,12 +1,84 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using Xunit;
 
 namespace Testably.Expectations.Tests.Specialized.Http;
 
 public sealed partial class ThatHttpResponseMessage
 {
 	private static HttpResponseBuilder ResponseBuilder => new();
+
+	/// <summary>
+	///     Status codes indicating a client error (4xx)
+	/// </summary>
+	public static TheoryData<HttpStatusCode> ClientErrorStatusCodes()
+		=>
+		[
+			HttpStatusCode.BadRequest,
+			HttpStatusCode.Unauthorized,
+			HttpStatusCode.PaymentRequired,
+			HttpStatusCode.Forbidden,
+			HttpStatusCode.NotFound,
+			HttpStatusCode.MethodNotAllowed,
+			HttpStatusCode.NotAcceptable,
+			HttpStatusCode.ProxyAuthenticationRequired,
+			HttpStatusCode.RequestTimeout,
+			HttpStatusCode.Conflict,
+			HttpStatusCode.Gone,
+			HttpStatusCode.LengthRequired,
+			HttpStatusCode.PreconditionFailed,
+			HttpStatusCode.RequestEntityTooLarge,
+			HttpStatusCode.RequestUriTooLong,
+			HttpStatusCode.UnsupportedMediaType,
+			HttpStatusCode.RequestedRangeNotSatisfiable,
+			HttpStatusCode.ExpectationFailed
+		];
+
+	/// <summary>
+	///     Status codes indicating a redirect (3xx)
+	/// </summary>
+	public static TheoryData<HttpStatusCode> RedirectStatusCodes()
+		=>
+		[
+			HttpStatusCode.MultipleChoices,
+			HttpStatusCode.MovedPermanently,
+			HttpStatusCode.Redirect,
+			HttpStatusCode.SeeOther,
+			HttpStatusCode.NotModified,
+			HttpStatusCode.UseProxy,
+			HttpStatusCode.Unused,
+			HttpStatusCode.TemporaryRedirect
+		];
+
+	/// <summary>
+	///     Status codes indicating a server error (5xx)
+	/// </summary>
+	public static TheoryData<HttpStatusCode> ServerErrorStatusCodes()
+		=>
+		[
+			HttpStatusCode.InternalServerError,
+			HttpStatusCode.NotImplemented,
+			HttpStatusCode.BadGateway,
+			HttpStatusCode.ServiceUnavailable,
+			HttpStatusCode.GatewayTimeout,
+			HttpStatusCode.HttpVersionNotSupported
+		];
+
+	/// <summary>
+	///     Status codes indicating success (2xx)
+	/// </summary>
+	public static TheoryData<HttpStatusCode> SuccessStatusCodes()
+		=>
+		[
+			HttpStatusCode.OK,
+			HttpStatusCode.Created,
+			HttpStatusCode.Accepted,
+			HttpStatusCode.NonAuthoritativeInformation,
+			HttpStatusCode.NoContent,
+			HttpStatusCode.ResetContent,
+			HttpStatusCode.PartialContent
+		];
 
 	private class HttpResponseBuilder
 	{

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.cs
@@ -20,6 +20,12 @@ public sealed partial class ThatHttpResponseMessage
 		public static implicit operator HttpResponseMessage(HttpResponseBuilder builder)
 			=> builder.Build();
 
+		public HttpResponseBuilder WithContent(string content)
+		{
+			_content = new StringContent(content);
+			return this;
+		}
+
 		public HttpRequestBuilder WithRequest(HttpMethod method, string uri)
 		{
 			_requestBuilder = new HttpRequestBuilder(this, method, uri);
@@ -29,12 +35,6 @@ public sealed partial class ThatHttpResponseMessage
 		public HttpResponseBuilder WithStatusCode(HttpStatusCode statusCode)
 		{
 			_statusCode = statusCode;
-			return this;
-		}
-
-		public HttpResponseBuilder WithContent(string content)
-		{
-			_content = new StringContent(content);
 			return this;
 		}
 

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.cs
@@ -1,15 +1,97 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Http;
 
 namespace Testably.Expectations.Tests.Specialized.Http;
 
 public sealed partial class ThatHttpResponseMessage
 {
-	private static HttpResponseMessage Create(string content,
-		HttpStatusCode statusCode = HttpStatusCode.OK)
+	private static HttpResponseBuilder ResponseBuilder => new();
+
+	private class HttpResponseBuilder
 	{
-		HttpResponseMessage httpResponseMessage = new HttpResponseMessage(statusCode);
-		httpResponseMessage.Content = new StringContent(content);
-		return httpResponseMessage;
+		private HttpContent? _content;
+		private HttpRequestBuilder? _requestBuilder;
+		private HttpStatusCode _statusCode = HttpStatusCode.OK;
+
+		/// <summary>
+		///     Implicitly converts the <paramref name="builder" /> to a <see cref="HttpResponseMessage" />.
+		/// </summary>
+		public static implicit operator HttpResponseMessage(HttpResponseBuilder builder)
+			=> builder.Build();
+
+		public HttpRequestBuilder WithRequest(HttpMethod method, string uri)
+		{
+			_requestBuilder = new HttpRequestBuilder(this, method, uri);
+			return _requestBuilder;
+		}
+
+		public HttpResponseBuilder WithStatusCode(HttpStatusCode statusCode)
+		{
+			_statusCode = statusCode;
+			return this;
+		}
+
+		public HttpResponseBuilder WithContent(string content)
+		{
+			_content = new StringContent(content);
+			return this;
+		}
+
+		private HttpResponseMessage Build()
+		{
+			HttpResponseMessage httpResponseMessage = new();
+			httpResponseMessage.StatusCode = _statusCode;
+			httpResponseMessage.Content = _content ?? new StringContent("");
+			if (_requestBuilder != null)
+			{
+				httpResponseMessage.RequestMessage = _requestBuilder;
+			}
+
+			return httpResponseMessage;
+		}
+
+		public class HttpRequestBuilder
+		{
+			private HttpContent? _content;
+			private readonly HttpMethod _method;
+			private readonly HttpResponseBuilder _responseBuilder;
+			private readonly string _uri;
+
+			public HttpRequestBuilder(HttpResponseBuilder responseBuilder, HttpMethod method,
+				string uri)
+			{
+				_responseBuilder = responseBuilder;
+				_method = method;
+				_uri = uri;
+			}
+
+			/// <summary>
+			///     Implicitly converts the <paramref name="builder" /> to a <see cref="HttpResponseMessage" />.
+			/// </summary>
+			public static implicit operator HttpRequestMessage(HttpRequestBuilder builder)
+				=> builder.Build();
+
+			/// <summary>
+			///     Implicitly converts the <paramref name="builder" /> to a <see cref="HttpResponseMessage" />.
+			/// </summary>
+			public static implicit operator HttpResponseMessage(HttpRequestBuilder builder)
+				=> builder._responseBuilder.Build();
+
+			public HttpRequestBuilder WithRequestContent(string content)
+			{
+				_content = new StringContent(content);
+				return this;
+			}
+
+			private HttpRequestMessage Build()
+			{
+				HttpRequestMessage httpResponseMessage = new();
+				httpResponseMessage.Method = _method;
+				httpResponseMessage.RequestUri = new Uri(_uri);
+				httpResponseMessage.Content = _content;
+				return httpResponseMessage;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Add the following assertions for `HttpResponseMessage`:
- `IsSuccessful()`
  Checks for 2xx status codes
- `IsRedirection()`
  Checks for 3xx status codes
- `HasClientError()`
  Checks for 4xx status codes
- `HasServerError()`
  Checks for 5xx status codes
- `HasError()`
  Checks for 4xx or 5xx status codes
- `HasStatusCode(HttpStatusCode)`
- `DoesNotHaveStatusCode(HttpStatusCode)`

Also include the HTTP request information when checking for status codes.