### PR TITLE
feat: add chronology assertions

### DIFF
--- a/Source/Testably.Expectations/Core/Formatting/Formatter.cs
+++ b/Source/Testably.Expectations/Core/Formatting/Formatter.cs
@@ -19,8 +19,15 @@ public class Formatter
 		new BooleanFormatter(),
 		new StringFormatter(),
 		new TypeFormatter(),
-		new HttpStatusCodeFormatter(),
 		new CollectionFormatter(),
+		new HttpStatusCodeFormatter(),
+		new DateTimeFormatter(),
+		new DateTimeOffsetFormatter(),
+		new TimeSpanFormatter(),
+#if !NETSTANDARD2_0
+		new DateOnlyFormatter(),
+		new TimeOnlyFormatter(),
+#endif
 		new NumberFormatter<int>(),
 		new NumberFormatter<uint>(),
 		new NumberFormatter<byte>(),

--- a/Source/Testably.Expectations/Core/Formatting/Formatters/DateOnlyFormatter.cs
+++ b/Source/Testably.Expectations/Core/Formatting/Formatters/DateOnlyFormatter.cs
@@ -1,0 +1,16 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using System.Text;
+
+namespace Testably.Expectations.Core.Formatting.Formatters;
+
+internal class DateOnlyFormatter : FormatterBase<DateOnly>
+{
+	/// <inheritdoc />
+	public override void Format(DateOnly value, StringBuilder stringBuilder,
+		FormattingOptions options)
+	{
+		stringBuilder.Append(value.ToString("o"));
+	}
+}
+#endif

--- a/Source/Testably.Expectations/Core/Formatting/Formatters/DateTimeFormatter.cs
+++ b/Source/Testably.Expectations/Core/Formatting/Formatters/DateTimeFormatter.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Text;
+
+namespace Testably.Expectations.Core.Formatting.Formatters;
+
+internal class DateTimeFormatter : FormatterBase<DateTime>
+{
+	/// <inheritdoc />
+	public override void Format(DateTime value, StringBuilder stringBuilder,
+		FormattingOptions options)
+	{
+		stringBuilder.Append(value.ToString("o"));
+	}
+}

--- a/Source/Testably.Expectations/Core/Formatting/Formatters/DateTimeOffsetFormatter.cs
+++ b/Source/Testably.Expectations/Core/Formatting/Formatters/DateTimeOffsetFormatter.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Text;
+
+namespace Testably.Expectations.Core.Formatting.Formatters;
+
+internal class DateTimeOffsetFormatter : FormatterBase<DateTimeOffset>
+{
+	/// <inheritdoc />
+	public override void Format(DateTimeOffset value, StringBuilder stringBuilder,
+		FormattingOptions options)
+	{
+		stringBuilder.Append(value.ToString("o"));
+	}
+}

--- a/Source/Testably.Expectations/Core/Formatting/Formatters/TimeOnlyFormatter.cs
+++ b/Source/Testably.Expectations/Core/Formatting/Formatters/TimeOnlyFormatter.cs
@@ -1,0 +1,16 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using System.Text;
+
+namespace Testably.Expectations.Core.Formatting.Formatters;
+
+internal class TimeOnlyFormatter : FormatterBase<TimeOnly>
+{
+	/// <inheritdoc />
+	public override void Format(TimeOnly value, StringBuilder stringBuilder,
+		FormattingOptions options)
+	{
+		stringBuilder.Append(value.ToString("o"));
+	}
+}
+#endif

--- a/Source/Testably.Expectations/Core/Formatting/Formatters/TimeSpanFormatter.cs
+++ b/Source/Testably.Expectations/Core/Formatting/Formatters/TimeSpanFormatter.cs
@@ -9,6 +9,25 @@ internal class TimeSpanFormatter : FormatterBase<TimeSpan>
 	public override void Format(TimeSpan value, StringBuilder stringBuilder,
 		FormattingOptions options)
 	{
-		stringBuilder.Append(value.ToString("g"));
+		string formatString;
+		if (value.Days > 0)
+		{
+			formatString = @"d\.hh\:mm\:ss";
+		}
+		else if (value.Hours > 0)
+		{
+			formatString = @"h\:mm\:ss";
+		}
+		else
+		{
+			formatString = @"m\:ss";
+		}
+
+		if (value.Milliseconds > 0)
+		{
+			formatString += @"\.fff";
+		}
+
+		stringBuilder.Append(value.ToString(formatString));
 	}
 }

--- a/Source/Testably.Expectations/Core/Formatting/Formatters/TimeSpanFormatter.cs
+++ b/Source/Testably.Expectations/Core/Formatting/Formatters/TimeSpanFormatter.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Text;
+
+namespace Testably.Expectations.Core.Formatting.Formatters;
+
+internal class TimeSpanFormatter : FormatterBase<TimeSpan>
+{
+	/// <inheritdoc />
+	public override void Format(TimeSpan value, StringBuilder stringBuilder,
+		FormattingOptions options)
+	{
+		stringBuilder.Append(value.ToString("g"));
+	}
+}

--- a/Source/Testably.Expectations/Core/Results/StringMatcherExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/StringMatcherExpectationResult.cs
@@ -9,9 +9,7 @@ namespace Testably.Expectations.Core.Results;
 ///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
 ///     <para />
 ///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying
-///     options
-///     on
-///     the <see cref="StringMatcher" />.
+///     options on the <see cref="StringMatcher" />.
 /// </summary>
 public class StringMatcherExpectationResult<TResult, TValue>(
 	IExpectationBuilder expectationBuilder,

--- a/Source/Testably.Expectations/Core/Results/TimeToleranceExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/TimeToleranceExpectationResult.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core.Helpers;
+
+namespace Testably.Expectations.Core.Results;
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying a tolerance.
+/// </summary>
+public class TimeToleranceExpectationResult<TResult, TValue>(
+	IExpectationBuilder expectationBuilder,
+	TValue returnValue,
+	TimeTolerance options)
+	: TimeToleranceExpectationResult<TResult, TValue,
+		TimeToleranceExpectationResult<TResult, TValue>>(
+		expectationBuilder,
+		returnValue,
+		options);
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrExpectationResult{TResult,TValue}" />, allows specifying a tolerance.
+/// </summary>
+public class TimeToleranceExpectationResult<TResult, TValue, TSelf>(
+	IExpectationBuilder expectationBuilder,
+	TValue returnValue,
+	TimeTolerance options)
+	: AndOrExpectationResult<TResult, TValue, TSelf>(expectationBuilder, returnValue)
+	where TSelf : TimeToleranceExpectationResult<TResult, TValue, TSelf>
+{
+	private readonly IExpectationBuilder _expectationBuilder1 = expectationBuilder;
+
+	/// <summary>
+	///     Specifies a tolerance to apply on the time comparison.
+	/// </summary>
+	public TimeToleranceExpectationResult<TResult, TValue, TSelf> Within(TimeSpan tolerance,
+		[CallerArgumentExpression("tolerance")] string doNotPopulateThisValue = "")
+	{
+		options.SetTolerance(tolerance);
+		_expectationBuilder1.AppendExpression(b => b.AppendMethod(nameof(Within), doNotPopulateThisValue));
+		return this;
+	}
+}

--- a/Source/Testably.Expectations/Core/TimeTolerance.cs
+++ b/Source/Testably.Expectations/Core/TimeTolerance.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Testably.Expectations.Core.Formatting;
+
+namespace Testably.Expectations.Core;
+
+/// <summary>
+///     Tolerance for time comparisons.
+/// </summary>
+public class TimeTolerance
+{
+	/// <summary>
+	///     The tolerance to apply on the time comparisons.
+	/// </summary>
+	public TimeSpan? Tolerance { get; private set; }
+
+	/// <summary>
+	///     Sets the tolerance to apply on the time comparisons.
+	/// </summary>
+	public TimeTolerance SetTolerance(TimeSpan tolerance)
+	{
+		Tolerance = tolerance;
+		return this;
+	}
+
+	/// <inheritdoc />
+	public override string ToString()
+	{
+		if (Tolerance == null)
+		{
+			return "";
+		}
+
+		const char plusMinus = '\u00b1';
+		return $" {plusMinus} {Formatter.Format(Tolerance.Value)}";
+	}
+
+	internal bool IsWithinTolerance(TimeSpan difference)
+	{
+		if (Tolerance == null)
+		{
+			return difference == TimeSpan.Zero;
+		}
+
+		return difference <= Tolerance.Value && difference >= Tolerance.Value.Negate();
+	}
+}

--- a/Source/Testably.Expectations/Expect.cs
+++ b/Source/Testably.Expectations/Expect.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 
@@ -24,6 +23,52 @@ public static partial class Expect
 		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
 		=> new(new ExpectationBuilder<bool?>(subject, doNotPopulateThisValue));
 
+#if !NETSTANDARD2_0
+	/// <summary>
+	///     Start expectations for current <see cref="DateOnly" /> <paramref name="subject" />.
+	/// </summary>
+	public static That<DateOnly> That(DateOnly subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<DateOnly>(subject, doNotPopulateThisValue));
+#endif
+
+#if !NETSTANDARD2_0
+	/// <summary>
+	///     Start expectations for the current <see cref="DateOnly" />? <paramref name="subject" />.
+	/// </summary>
+	public static That<DateOnly?> That(DateOnly? subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<DateOnly?>(subject, doNotPopulateThisValue));
+#endif
+
+	/// <summary>
+	///     Start expectations for current <see cref="DateTime" /> <paramref name="subject" />.
+	/// </summary>
+	public static That<DateTime> That(DateTime subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<DateTime>(subject, doNotPopulateThisValue));
+
+	/// <summary>
+	///     Start expectations for the current <see cref="DateTime" />? <paramref name="subject" />.
+	/// </summary>
+	public static That<DateTime?> That(DateTime? subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<DateTime?>(subject, doNotPopulateThisValue));
+
+	/// <summary>
+	///     Start expectations for current <see cref="DateTimeOffset" /> <paramref name="subject" />.
+	/// </summary>
+	public static That<DateTimeOffset> That(DateTimeOffset subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<DateTimeOffset>(subject, doNotPopulateThisValue));
+
+	/// <summary>
+	///     Start expectations for the current <see cref="DateTimeOffset" />? <paramref name="subject" />.
+	/// </summary>
+	public static That<DateTimeOffset?> That(DateTimeOffset? subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<DateTimeOffset?>(subject, doNotPopulateThisValue));
+
 	/// <summary>
 	///     Start expectations for the current <typeparamref name="TException" /> <paramref name="subject" />.
 	/// </summary>
@@ -45,4 +90,36 @@ public static partial class Expect
 	public static That<string?> That(string? subject,
 		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
 		=> new(new ExpectationBuilder<string?>(subject, doNotPopulateThisValue));
+
+#if !NETSTANDARD2_0
+	/// <summary>
+	///     Start expectations for current <see cref="TimeOnly" /> <paramref name="subject" />.
+	/// </summary>
+	public static That<TimeOnly> That(TimeOnly subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<TimeOnly>(subject, doNotPopulateThisValue));
+#endif
+
+#if !NETSTANDARD2_0
+	/// <summary>
+	///     Start expectations for the current <see cref="TimeOnly" />? <paramref name="subject" />.
+	/// </summary>
+	public static That<TimeOnly?> That(TimeOnly? subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<TimeOnly?>(subject, doNotPopulateThisValue));
+#endif
+
+	/// <summary>
+	///     Start expectations for current <see cref="TimeSpan" /> <paramref name="subject" />.
+	/// </summary>
+	public static That<TimeSpan> That(TimeSpan subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<TimeSpan>(subject, doNotPopulateThisValue));
+
+	/// <summary>
+	///     Start expectations for the current <see cref="TimeSpan" />? <paramref name="subject" />.
+	/// </summary>
+	public static That<TimeSpan?> That(TimeSpan? subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<TimeSpan?>(subject, doNotPopulateThisValue));
 }

--- a/Source/Testably.Expectations/Primitives/Booleans/ThatBoolExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Booleans/ThatBoolExtensions.cs
@@ -12,7 +12,7 @@ namespace Testably.Expectations;
 public static partial class ThatBoolExtensions
 {
 	/// <summary>
-	///     Verifies that the actual value implies the specified <paramref name="consequent" /> value.
+	///     Verifies that the subject implies the <paramref name="consequent" /> value.
 	/// </summary>
 	public static AndOrExpectationResult<bool, That<bool>> Implies(this That<bool> source,
 		bool consequent,
@@ -23,7 +23,7 @@ public static partial class ThatBoolExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is equal to the specified <paramref name="expected" /> value.
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
 	public static AndOrExpectationResult<bool, That<bool>> Is(this That<bool> source,
 		bool expected,
@@ -33,7 +33,7 @@ public static partial class ThatBoolExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is <see langword="false" />.
+	///     Verifies that the subject is <see langword="false" />.
 	/// </summary>
 	public static AndOrExpectationResult<bool, That<bool>> IsFalse(this That<bool> source)
 		=> new(source.ExpectationBuilder.Add(new IsConstraint(false),
@@ -41,7 +41,7 @@ public static partial class ThatBoolExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is not equal to the specified <paramref name="unexpected" /> value.
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static AndOrExpectationResult<bool, That<bool>> IsNot(this That<bool> source,
 		bool unexpected,
@@ -52,7 +52,7 @@ public static partial class ThatBoolExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is <see langword="true" />.
+	///     Verifies that the subject is <see langword="true" />.
 	/// </summary>
 	public static AndOrExpectationResult<bool, That<bool>> IsTrue(this That<bool> source)
 		=> new(source.ExpectationBuilder.Add(new IsConstraint(true),

--- a/Source/Testably.Expectations/Primitives/Booleans/ThatNullableBoolExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Booleans/ThatNullableBoolExtensions.cs
@@ -12,7 +12,7 @@ namespace Testably.Expectations;
 public static partial class ThatNullableBoolExtensions
 {
 	/// <summary>
-	///     Verifies that the actual value is equal to the specified <paramref name="expected" /> value.
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
 	public static AndOrExpectationResult<bool?, That<bool?>> Is(this That<bool?> source,
 		bool? expected,
@@ -23,7 +23,7 @@ public static partial class ThatNullableBoolExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is <see langword="false" />.
+	///     Verifies that the subject is <see langword="false" />.
 	/// </summary>
 	public static AndOrExpectationResult<bool?, That<bool?>> IsFalse(this That<bool?> source)
 		=> new(source.ExpectationBuilder.Add(
@@ -32,7 +32,7 @@ public static partial class ThatNullableBoolExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is not equal to the specified <paramref name="unexpected" /> value.
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static AndOrExpectationResult<bool?, That<bool?>> IsNot(this That<bool?> source,
 		bool? unexpected,
@@ -44,7 +44,7 @@ public static partial class ThatNullableBoolExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is not <see langword="false" />.
+	///     Verifies that the subject is not <see langword="false" />.
 	/// </summary>
 	public static AndOrExpectationResult<bool?, That<bool?>> IsNotFalse(this That<bool?> source)
 		=> new(source.ExpectationBuilder.Add(
@@ -53,7 +53,7 @@ public static partial class ThatNullableBoolExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is not <see langword="null" />.
+	///     Verifies that the subject is not <see langword="null" />.
 	/// </summary>
 	public static AndOrExpectationResult<bool?, That<bool?>> IsNotNull(this That<bool?> source)
 		=> new(source.ExpectationBuilder.Add(
@@ -62,7 +62,7 @@ public static partial class ThatNullableBoolExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is not <see langword="true" />.
+	///     Verifies that the subject is not <see langword="true" />.
 	/// </summary>
 	public static AndOrExpectationResult<bool?, That<bool?>> IsNotTrue(this That<bool?> source)
 		=> new(source.ExpectationBuilder.Add(
@@ -71,7 +71,7 @@ public static partial class ThatNullableBoolExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is <see langword="null" />.
+	///     Verifies that the subject is <see langword="null" />.
 	/// </summary>
 	public static AndOrExpectationResult<bool?, That<bool?>> IsNull(this That<bool?> source)
 		=> new(source.ExpectationBuilder.Add(
@@ -80,7 +80,7 @@ public static partial class ThatNullableBoolExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is <see langword="true" />.
+	///     Verifies that the subject is <see langword="true" />.
 	/// </summary>
 	public static AndOrExpectationResult<bool?, That<bool?>> IsTrue(this That<bool?> source)
 		=> new(source.ExpectationBuilder.Add(

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateOnlyExtensions.IsConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateOnlyExtensions.IsConstraint.cs
@@ -1,0 +1,27 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatDateOnlyExtensions
+{
+	private readonly struct IsConstraint(DateOnly expected) : IConstraint<DateOnly>
+	{
+		public ConstraintResult IsMetBy(DateOnly actual)
+		{
+			if (expected.Equals(actual))
+			{
+				return new ConstraintResult.Success<DateOnly>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> $"is {Formatter.Format(expected)}";
+	}
+}
+#endif

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateOnlyExtensions.IsNotConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateOnlyExtensions.IsNotConstraint.cs
@@ -1,0 +1,27 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatDateOnlyExtensions
+{
+	private readonly struct IsNotConstraint(DateOnly unexpected) : IConstraint<DateOnly>
+	{
+		public ConstraintResult IsMetBy(DateOnly actual)
+		{
+			if (!unexpected.Equals(actual))
+			{
+				return new ConstraintResult.Success<DateOnly>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> $"is not {Formatter.Format(unexpected)}";
+	}
+}
+#endif

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateOnlyExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateOnlyExtensions.cs
@@ -1,0 +1,37 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Core.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on <see cref="DateOnly" /> values.
+/// </summary>
+public static partial class ThatDateOnlyExtensions
+{
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateOnly, That<DateOnly>> Is(this That<DateOnly> source,
+		DateOnly expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new IsConstraint(expected),
+				b => b.AppendMethod(nameof(Is), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateOnly, That<DateOnly>> IsNot(this That<DateOnly> source,
+		DateOnly unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new IsNotConstraint(unexpected),
+				b => b.AppendMethod(nameof(IsNot), doNotPopulateThisValue)),
+			source);
+}
+#endif

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.ConditionConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.ConditionConstraint.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatDateTimeExtensions
+{
+	private readonly struct ConditionConstraint(DateTime expected, Func<DateTime, DateTime, bool> condition, string expectation) : IConstraint<DateTime>
+	{
+		public ConstraintResult IsMetBy(DateTime actual)
+		{
+			if (condition(actual, expected))
+			{
+				return new ConstraintResult.Success<DateTime>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> expectation;
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.ConditionConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.ConditionConstraint.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.Formatting;
 
@@ -7,11 +8,16 @@ namespace Testably.Expectations;
 
 public static partial class ThatDateTimeExtensions
 {
-	private readonly struct ConditionConstraint(DateTime expected, Func<DateTime, DateTime, bool> condition, string expectation) : IConstraint<DateTime>
+	private readonly struct ConditionConstraint(
+		DateTime expected,
+		Func<DateTime, DateTime, TimeSpan, bool> condition,
+		string expectation,
+		TimeTolerance tolerance) : IConstraint<DateTime>
 	{
 		public ConstraintResult IsMetBy(DateTime actual)
 		{
-			if (condition(actual, expected))
+			_ = tolerance;
+			if (condition(actual, expected, tolerance.Tolerance ?? TimeSpan.Zero))
 			{
 				return new ConstraintResult.Success<DateTime>(actual, ToString());
 			}
@@ -20,6 +26,6 @@ public static partial class ThatDateTimeExtensions
 		}
 
 		public override string ToString()
-			=> expectation;
+			=> expectation + tolerance;
 	}
 }

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.IsConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.IsConstraint.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatDateTimeExtensions
+{
+	private readonly struct IsConstraint(DateTime expected) : IConstraint<DateTime>
+	{
+		public ConstraintResult IsMetBy(DateTime actual)
+		{
+			if (expected.Equals(actual))
+			{
+				return new ConstraintResult.Success<DateTime>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> $"is {Formatter.Format(expected)}";
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.IsConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.IsConstraint.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.Formatting;
 
@@ -7,11 +8,11 @@ namespace Testably.Expectations;
 
 public static partial class ThatDateTimeExtensions
 {
-	private readonly struct IsConstraint(DateTime expected) : IConstraint<DateTime>
+	private readonly struct IsConstraint(DateTime expected, TimeTolerance tolerance) : IConstraint<DateTime>
 	{
 		public ConstraintResult IsMetBy(DateTime actual)
 		{
-			if (expected.Equals(actual))
+			if (tolerance.IsWithinTolerance(actual - expected))
 			{
 				return new ConstraintResult.Success<DateTime>(actual, ToString());
 			}
@@ -20,6 +21,6 @@ public static partial class ThatDateTimeExtensions
 		}
 
 		public override string ToString()
-			=> $"is {Formatter.Format(expected)}";
+			=> $"is {Formatter.Format(expected)}{tolerance}";
 	}
 }

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.IsNotConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.IsNotConstraint.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatDateTimeExtensions
+{
+	private readonly struct IsNotConstraint(DateTime unexpected) : IConstraint<DateTime>
+	{
+		public ConstraintResult IsMetBy(DateTime actual)
+		{
+			if (!unexpected.Equals(actual))
+			{
+				return new ConstraintResult.Success<DateTime>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> $"is not {Formatter.Format(unexpected)}";
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.IsNotConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.IsNotConstraint.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.Formatting;
 
@@ -7,11 +8,11 @@ namespace Testably.Expectations;
 
 public static partial class ThatDateTimeExtensions
 {
-	private readonly struct IsNotConstraint(DateTime unexpected) : IConstraint<DateTime>
+	private readonly struct IsNotConstraint(DateTime unexpected, TimeTolerance tolerance) : IConstraint<DateTime>
 	{
 		public ConstraintResult IsMetBy(DateTime actual)
 		{
-			if (!unexpected.Equals(actual))
+			if (!tolerance.IsWithinTolerance(actual - unexpected))
 			{
 				return new ConstraintResult.Success<DateTime>(actual, ToString());
 			}
@@ -20,6 +21,6 @@ public static partial class ThatDateTimeExtensions
 		}
 
 		public override string ToString()
-			=> $"is not {Formatter.Format(unexpected)}";
+			=> $"is not {Formatter.Format(unexpected)}{tolerance}";
 	}
 }

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.cs
@@ -16,133 +16,195 @@ public static partial class ThatDateTimeExtensions
 	/// <summary>
 	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrExpectationResult<DateTime, That<DateTime>> Is(this That<DateTime> source,
+	public static TimeToleranceExpectationResult<DateTime, That<DateTime>> Is(
+		this That<DateTime> source,
 		DateTime expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder.Add(new IsConstraint(expected),
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceExpectationResult<DateTime, That<DateTime>>(
+			source.ExpectationBuilder.Add(new IsConstraint(expected, tolerance),
 				b => b.AppendMethod(nameof(Is), doNotPopulateThisValue)),
-			source);
+			source,
+			tolerance);
+	}
 
 	/// <summary>
 	///     Verifies that the subject is after the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrExpectationResult<DateTime, That<DateTime>> IsAfter(this That<DateTime> source,
+	public static TimeToleranceExpectationResult<DateTime, That<DateTime>> IsAfter(
+		this That<DateTime> source,
 		DateTime expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder.Add(
+	{
+		TimeTolerance tolerance = new();
+		return new(source.ExpectationBuilder.Add(
 				new ConditionConstraint(
 					expected,
-					(a, e) => a > e,
-					$"is after {Formatter.Format(expected)}"),
+					(a, e, t) =>
+					{
+						return a + t > e;
+					},
+					$"is after {Formatter.Format(expected)}",
+					tolerance),
 				b => b.AppendMethod(nameof(IsAfter), doNotPopulateThisValue)),
-			source);
-
-	/// <summary>
-	///     Verifies that the subject is on or after the <paramref name="expected" /> value.
-	/// </summary>
-	public static AndOrExpectationResult<DateTime, That<DateTime>> IsOnOrAfter(this That<DateTime> source,
-		DateTime expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder.Add(
-				new ConditionConstraint(
-					expected,
-					(a, e) => a >= e,
-					$"is on or after {Formatter.Format(expected)}"),
-				b => b.AppendMethod(nameof(IsOnOrAfter), doNotPopulateThisValue)),
-			source);
+			source,
+			tolerance);
+	}
 
 	/// <summary>
 	///     Verifies that the subject is before the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrExpectationResult<DateTime, That<DateTime>> IsBefore(this That<DateTime> source,
+	public static TimeToleranceExpectationResult<DateTime, That<DateTime>> IsBefore(
+		this That<DateTime> source,
 		DateTime expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder.Add(
+	{
+		TimeTolerance tolerance = new();
+		return new(source.ExpectationBuilder.Add(
 				new ConditionConstraint(
 					expected,
-					(a, e) => a < e,
-					$"is before {Formatter.Format(expected)}"),
+					(a, e, t) => a - t < e,
+					$"is before {Formatter.Format(expected)}",
+					tolerance),
 				b => b.AppendMethod(nameof(IsBefore), doNotPopulateThisValue)),
-			source);
-
-	/// <summary>
-	///     Verifies that the subject is on or before the <paramref name="expected" /> value.
-	/// </summary>
-	public static AndOrExpectationResult<DateTime, That<DateTime>> IsOnOrBefore(this That<DateTime> source,
-		DateTime expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder.Add(
-				new ConditionConstraint(
-					expected,
-					(a, e) => a <= e,
-					$"is on or before {Formatter.Format(expected)}"),
-				b => b.AppendMethod(nameof(IsOnOrBefore), doNotPopulateThisValue)),
-			source);
-
-	/// <summary>
-	///     Verifies that the subject is not after the <paramref name="expected" /> value.
-	/// </summary>
-	public static AndOrExpectationResult<DateTime, That<DateTime>> IsNotAfter(this That<DateTime> source,
-		DateTime expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder.Add(
-				new ConditionConstraint(
-					expected,
-					(a, e) => a <= e,
-					$"is not after {Formatter.Format(expected)}"),
-				b => b.AppendMethod(nameof(IsNotAfter), doNotPopulateThisValue)),
-			source);
-
-	/// <summary>
-	///     Verifies that the subject is not on or after the <paramref name="expected" /> value.
-	/// </summary>
-	public static AndOrExpectationResult<DateTime, That<DateTime>> IsNotOnOrAfter(this That<DateTime> source,
-		DateTime expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder.Add(
-				new ConditionConstraint(
-					expected,
-					(a, e) => a < e,
-					$"is not on or after {Formatter.Format(expected)}"),
-				b => b.AppendMethod(nameof(IsNotOnOrAfter), doNotPopulateThisValue)),
-			source);
-
-	/// <summary>
-	///     Verifies that the subject is not before the <paramref name="expected" /> value.
-	/// </summary>
-	public static AndOrExpectationResult<DateTime, That<DateTime>> IsNotBefore(this That<DateTime> source,
-		DateTime expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder.Add(
-				new ConditionConstraint(
-					expected,
-					(a, e) => a >= e,
-					$"is not before {Formatter.Format(expected)}"),
-				b => b.AppendMethod(nameof(IsNotBefore), doNotPopulateThisValue)),
-			source);
-
-	/// <summary>
-	///     Verifies that the subject is not on or before the <paramref name="expected" /> value.
-	/// </summary>
-	public static AndOrExpectationResult<DateTime, That<DateTime>> IsNotOnOrBefore(this That<DateTime> source,
-		DateTime expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder.Add(
-				new ConditionConstraint(
-					expected,
-					(a, e) => a > e,
-					$"is not on or before {Formatter.Format(expected)}"),
-				b => b.AppendMethod(nameof(IsNotOnOrBefore), doNotPopulateThisValue)),
-			source);
+			source,
+			tolerance);
+	}
 
 	/// <summary>
 	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
 	/// </summary>
-	public static AndOrExpectationResult<DateTime, That<DateTime>> IsNot(this That<DateTime> source,
+	public static TimeToleranceExpectationResult<DateTime, That<DateTime>> IsNot(
+		this That<DateTime> source,
 		DateTime unexpected,
 		[CallerArgumentExpression("unexpected")]
 		string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder.Add(new IsNotConstraint(unexpected),
+	{
+		TimeTolerance tolerance = new();
+		return new(source.ExpectationBuilder.Add(new IsNotConstraint(unexpected, tolerance),
 				b => b.AppendMethod(nameof(IsNot), doNotPopulateThisValue)),
-			source);
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceExpectationResult<DateTime, That<DateTime>> IsNotAfter(
+		this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		TimeTolerance tolerance = new();
+		return new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e, t) => a - t <= e,
+					$"is not after {Formatter.Format(expected)}",
+					tolerance),
+				b => b.AppendMethod(nameof(IsNotAfter), doNotPopulateThisValue)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceExpectationResult<DateTime, That<DateTime>> IsNotBefore(
+		this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		TimeTolerance tolerance = new();
+		return new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e, t) => a + t >= e,
+					$"is not before {Formatter.Format(expected)}",
+					tolerance),
+				b => b.AppendMethod(nameof(IsNotBefore), doNotPopulateThisValue)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceExpectationResult<DateTime, That<DateTime>> IsNotOnOrAfter(
+		this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		TimeTolerance tolerance = new();
+		return new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e, t) => a - t < e,
+					$"is not on or after {Formatter.Format(expected)}",
+					tolerance),
+				b => b.AppendMethod(nameof(IsNotOnOrAfter), doNotPopulateThisValue)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceExpectationResult<DateTime, That<DateTime>> IsNotOnOrBefore(
+		this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		TimeTolerance tolerance = new();
+		return new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e, t) => a + t > e,
+					$"is not on or before {Formatter.Format(expected)}",
+					tolerance),
+				b => b.AppendMethod(nameof(IsNotOnOrBefore), doNotPopulateThisValue)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is on or after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceExpectationResult<DateTime, That<DateTime>> IsOnOrAfter(
+		this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		TimeTolerance tolerance = new();
+		return new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e, t) => a + t >= e,
+					$"is on or after {Formatter.Format(expected)}",
+					tolerance),
+				b => b.AppendMethod(nameof(IsOnOrAfter), doNotPopulateThisValue)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is on or before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceExpectationResult<DateTime, That<DateTime>> IsOnOrBefore(
+		this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		TimeTolerance tolerance = new();
+		return new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e, t) => a - t <= e,
+					$"is on or before {Formatter.Format(expected)}",
+					tolerance),
+				b => b.AppendMethod(nameof(IsOnOrBefore), doNotPopulateThisValue)),
+			source,
+			tolerance);
+	}
 }

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
+using Testably.Expectations.Core.Formatting;
 using Testably.Expectations.Core.Helpers;
 using Testably.Expectations.Core.Results;
 
@@ -20,6 +21,118 @@ public static partial class ThatDateTimeExtensions
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		=> new(source.ExpectationBuilder.Add(new IsConstraint(expected),
 				b => b.AppendMethod(nameof(Is), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is after the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateTime, That<DateTime>> IsAfter(this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e) => a > e,
+					$"is after {Formatter.Format(expected)}"),
+				b => b.AppendMethod(nameof(IsAfter), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is on or after the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateTime, That<DateTime>> IsOnOrAfter(this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e) => a >= e,
+					$"is on or after {Formatter.Format(expected)}"),
+				b => b.AppendMethod(nameof(IsOnOrAfter), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is before the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateTime, That<DateTime>> IsBefore(this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e) => a < e,
+					$"is before {Formatter.Format(expected)}"),
+				b => b.AppendMethod(nameof(IsBefore), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is on or before the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateTime, That<DateTime>> IsOnOrBefore(this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e) => a <= e,
+					$"is on or before {Formatter.Format(expected)}"),
+				b => b.AppendMethod(nameof(IsOnOrBefore), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not after the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateTime, That<DateTime>> IsNotAfter(this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e) => a <= e,
+					$"is not after {Formatter.Format(expected)}"),
+				b => b.AppendMethod(nameof(IsNotAfter), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not on or after the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateTime, That<DateTime>> IsNotOnOrAfter(this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e) => a < e,
+					$"is not on or after {Formatter.Format(expected)}"),
+				b => b.AppendMethod(nameof(IsNotOnOrAfter), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not before the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateTime, That<DateTime>> IsNotBefore(this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e) => a >= e,
+					$"is not before {Formatter.Format(expected)}"),
+				b => b.AppendMethod(nameof(IsNotBefore), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not on or before the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateTime, That<DateTime>> IsNotOnOrBefore(this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new ConditionConstraint(
+					expected,
+					(a, e) => a > e,
+					$"is not on or before {Formatter.Format(expected)}"),
+				b => b.AppendMethod(nameof(IsNotOnOrBefore), doNotPopulateThisValue)),
 			source);
 
 	/// <summary>

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Core.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on <see cref="DateTime" /> values.
+/// </summary>
+public static partial class ThatDateTimeExtensions
+{
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateTime, That<DateTime>> Is(this That<DateTime> source,
+		DateTime expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new IsConstraint(expected),
+				b => b.AppendMethod(nameof(Is), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateTime, That<DateTime>> IsNot(this That<DateTime> source,
+		DateTime unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new IsNotConstraint(unexpected),
+				b => b.AppendMethod(nameof(IsNot), doNotPopulateThisValue)),
+			source);
+}

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeOffsetExtensions.IsConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeOffsetExtensions.IsConstraint.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatDateTimeOffsetExtensions
+{
+	private readonly struct IsConstraint(DateTimeOffset expected) : IConstraint<DateTimeOffset>
+	{
+		public ConstraintResult IsMetBy(DateTimeOffset actual)
+		{
+			if (expected.Equals(actual))
+			{
+				return new ConstraintResult.Success<DateTimeOffset>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> $"is {Formatter.Format(expected)}";
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeOffsetExtensions.IsNotConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeOffsetExtensions.IsNotConstraint.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatDateTimeOffsetExtensions
+{
+	private readonly struct IsNotConstraint(DateTimeOffset unexpected) : IConstraint<DateTimeOffset>
+	{
+		public ConstraintResult IsMetBy(DateTimeOffset actual)
+		{
+			if (!unexpected.Equals(actual))
+			{
+				return new ConstraintResult.Success<DateTimeOffset>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> $"is not {Formatter.Format(unexpected)}";
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeOffsetExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatDateTimeOffsetExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Core.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on <see cref="DateTimeOffset" /> values.
+/// </summary>
+public static partial class ThatDateTimeOffsetExtensions
+{
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateTimeOffset, That<DateTimeOffset>> Is(this That<DateTimeOffset> source,
+		DateTimeOffset expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new IsConstraint(expected),
+				b => b.AppendMethod(nameof(Is), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<DateTimeOffset, That<DateTimeOffset>> IsNot(this That<DateTimeOffset> source,
+		DateTimeOffset unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new IsNotConstraint(unexpected),
+				b => b.AppendMethod(nameof(IsNot), doNotPopulateThisValue)),
+			source);
+}

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatTimeOnlyExtensions.IsConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatTimeOnlyExtensions.IsConstraint.cs
@@ -1,0 +1,27 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatTimeOnlyExtensions
+{
+	private readonly struct IsConstraint(TimeOnly expected) : IConstraint<TimeOnly>
+	{
+		public ConstraintResult IsMetBy(TimeOnly actual)
+		{
+			if (expected.Equals(actual))
+			{
+				return new ConstraintResult.Success<TimeOnly>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> $"is {Formatter.Format(expected)}";
+	}
+}
+#endif

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatTimeOnlyExtensions.IsNotConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatTimeOnlyExtensions.IsNotConstraint.cs
@@ -1,0 +1,27 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatTimeOnlyExtensions
+{
+	private readonly struct IsNotConstraint(TimeOnly unexpected) : IConstraint<TimeOnly>
+	{
+		public ConstraintResult IsMetBy(TimeOnly actual)
+		{
+			if (!unexpected.Equals(actual))
+			{
+				return new ConstraintResult.Success<TimeOnly>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> $"is not {Formatter.Format(unexpected)}";
+	}
+}
+#endif

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatTimeOnlyExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatTimeOnlyExtensions.cs
@@ -1,0 +1,37 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Core.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on <see cref="TimeOnly" /> values.
+/// </summary>
+public static partial class ThatTimeOnlyExtensions
+{
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<TimeOnly, That<TimeOnly>> Is(this That<TimeOnly> source,
+		TimeOnly expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new IsConstraint(expected),
+				b => b.AppendMethod(nameof(Is), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<TimeOnly, That<TimeOnly>> IsNot(this That<TimeOnly> source,
+		TimeOnly unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new IsNotConstraint(unexpected),
+				b => b.AppendMethod(nameof(IsNot), doNotPopulateThisValue)),
+			source);
+}
+#endif

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatTimeSpanExtensions.IsConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatTimeSpanExtensions.IsConstraint.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatTimeSpanExtensions
+{
+	private readonly struct IsConstraint(TimeSpan expected) : IConstraint<TimeSpan>
+	{
+		public ConstraintResult IsMetBy(TimeSpan actual)
+		{
+			if (expected.Equals(actual))
+			{
+				return new ConstraintResult.Success<TimeSpan>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> $"is {Formatter.Format(expected)}";
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatTimeSpanExtensions.IsNotConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatTimeSpanExtensions.IsNotConstraint.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatTimeSpanExtensions
+{
+	private readonly struct IsNotConstraint(TimeSpan unexpected) : IConstraint<TimeSpan>
+	{
+		public ConstraintResult IsMetBy(TimeSpan actual)
+		{
+			if (!unexpected.Equals(actual))
+			{
+				return new ConstraintResult.Success<TimeSpan>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> $"is not {Formatter.Format(unexpected)}";
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Chronology/ThatTimeSpanExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Chronology/ThatTimeSpanExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Core.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on <see cref="TimeSpan" /> values.
+/// </summary>
+public static partial class ThatTimeSpanExtensions
+{
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<TimeSpan, That<TimeSpan>> Is(this That<TimeSpan> source,
+		TimeSpan expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new IsConstraint(expected),
+				b => b.AppendMethod(nameof(Is), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<TimeSpan, That<TimeSpan>> IsNot(this That<TimeSpan> source,
+		TimeSpan unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new IsNotConstraint(unexpected),
+				b => b.AppendMethod(nameof(IsNot), doNotPopulateThisValue)),
+			source);
+}

--- a/Source/Testably.Expectations/Primitives/Numbers/ThatNumberExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Numbers/ThatNumberExtensions.cs
@@ -13,7 +13,7 @@ namespace Testably.Expectations;
 public static partial class ThatNumberExtensions
 {
 	/// <summary>
-	///     Verifies that the actual value is equal to the specified <paramref name="expected" /> value.
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
 	public static AndOrExpectationResult<TNumber, That<TNumber>> Is<TNumber>(
 		this That<TNumber> source,
@@ -25,7 +25,7 @@ public static partial class ThatNumberExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is equal to the specified <paramref name="expected" /> value.
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
 	public static AndOrExpectationResult<TNumber?, That<TNumber?>> Is<TNumber>(
 		this That<TNumber?> source,
@@ -37,7 +37,7 @@ public static partial class ThatNumberExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is seen as not a number (<see cref="float.NaN" />).
+	///     Verifies that the subject is seen as not a number (<see cref="float.NaN" />).
 	/// </summary>
 	public static AndOrExpectationResult<float, That<float>> IsNaN(this That<float> source)
 		=> new(source.ExpectationBuilder.Add(new IsNaNConstraint<float>(float.IsNaN),
@@ -45,7 +45,7 @@ public static partial class ThatNumberExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is seen as not a number (<see cref="double.NaN" />).
+	///     Verifies that the subject is seen as not a number (<see cref="double.NaN" />).
 	/// </summary>
 	public static AndOrExpectationResult<double, That<double>> IsNaN(this That<double> source)
 		=> new(source.ExpectationBuilder.Add(new IsNaNConstraint<double>(double.IsNaN),
@@ -53,7 +53,7 @@ public static partial class ThatNumberExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is not equal to the specified <paramref name="expected" /> value.
+	///     Verifies that the subject is not equal to the <paramref name="expected" /> value.
 	/// </summary>
 	public static AndOrExpectationResult<TNumber, That<TNumber>> IsNot<TNumber>(
 		this That<TNumber> source,

--- a/Source/Testably.Expectations/Primitives/Objects/ThatObjectExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Objects/ThatObjectExtensions.cs
@@ -14,7 +14,7 @@ namespace Testably.Expectations;
 public static partial class ThatObjectExtensions
 {
 	/// <summary>
-	///     Expect the actual value to be of type <typeparamref name="TType" />.
+	///     Verifies that the subject is of type <typeparamref name="TType" />.
 	/// </summary>
 	public static AndOrWhichExpectationResult<TType, That<object?>> Is<TType>(
 		this That<object?> source)
@@ -25,7 +25,7 @@ public static partial class ThatObjectExtensions
 			source);
 
 	/// <summary>
-	///     Expect the actual value to be equivalent to the <paramref name="expected" /> value.
+	///     Verifies that the subject is equivalent to the <paramref name="expected" /> value.
 	/// </summary>
 	public static EquivalencyOptionsExpectationResult<T, That<T>> IsEquivalentTo<T>(this That<T> source,
 		object expected,

--- a/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.cs
@@ -12,7 +12,7 @@ namespace Testably.Expectations;
 public static partial class ThatStringExtensions
 {
 	/// <summary>
-	///     Verifies that the actual value is equal to <paramref name="expected" />.
+	///     Verifies that the subject is equal to <paramref name="expected" />.
 	/// </summary>
 	public static StringMatcherExpectationResult<string?, That<string?>> Is(
 		this That<string?> source,
@@ -25,7 +25,7 @@ public static partial class ThatStringExtensions
 			expected);
 
 	/// <summary>
-	///     Verifies that the actual value contains the <paramref name="expected" /> <see langword="string" />.
+	///     Verifies that the subject contains the <paramref name="expected" /> <see langword="string" />.
 	/// </summary>
 	public static StringCountExpectationResult<string?, That<string?>> Contains(
 		this That<string?> source,
@@ -43,7 +43,7 @@ public static partial class ThatStringExtensions
 	}
 
 	/// <summary>
-	///     Verifies that the actual value contains the <paramref name="unexpected" /> <see langword="string" />.
+	///     Verifies that the subject contains the <paramref name="unexpected" /> <see langword="string" />.
 	/// </summary>
 	public static StringExpectationResult<string?, That<string?>> DoesNotContain(
 		this That<string?> source,
@@ -61,7 +61,7 @@ public static partial class ThatStringExtensions
 	}
 
 	/// <summary>
-	///     Verifies that the actual value is not <see langword="null" />.
+	///     Verifies that the subject is not <see langword="null" />.
 	/// </summary>
 	public static AndOrExpectationResult<string, That<string?>> IsNotNull(
 		this That<string?> source)
@@ -71,7 +71,7 @@ public static partial class ThatStringExtensions
 			source);
 
 	/// <summary>
-	///     Verifies that the actual value is <see langword="null" />.
+	///     Verifies that the subject is <see langword="null" />.
 	/// </summary>
 	public static AndOrExpectationResult<string?, That<string?>> IsNull(
 		this That<string?> source)

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsNotTests.cs
@@ -1,0 +1,44 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateOnly
+{
+	public sealed class IsNotTests
+	{
+		[Fact]
+		public async Task Fails_For_Same_Value()
+		{
+			DateOnly value = CurrentTime();
+			DateOnly unexpected = value;
+
+			async Task Act()
+				=> await Expect.That(value).IsNot(unexpected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not {unexpected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsNot(unexpected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task Succeeds_For_Different_Value()
+		{
+			DateOnly value = CurrentTime();
+			DateOnly unexpected = LaterTime();
+			
+			async Task Act()
+				=> await Expect.That(value).IsNot(unexpected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsNotTests.cs
@@ -11,7 +11,7 @@ public sealed partial class ThatDateOnly
 	public sealed class IsNotTests
 	{
 		[Fact]
-		public async Task Fails_For_Same_Value()
+		public async Task WhenValuesAreTheSame_ShouldFail()
 		{
 			DateOnly value = CurrentTime();
 			DateOnly unexpected = value;
@@ -29,7 +29,7 @@ public sealed partial class ThatDateOnly
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Different_Value()
+		public async Task WhenValuesAreDifferent_ShouldSucceed()
 		{
 			DateOnly value = CurrentTime();
 			DateOnly unexpected = LaterTime();

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsTests.cs
@@ -11,7 +11,7 @@ public sealed partial class ThatDateOnly
 	public sealed class IsTests
 	{
 		[Fact]
-		public async Task Fails_For_Different_Value()
+		public async Task WhenValuesAreDifferent_ShouldFail()
 		{
 			DateOnly value = CurrentTime();
 			DateOnly expected = LaterTime();
@@ -29,7 +29,7 @@ public sealed partial class ThatDateOnly
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Same_Value()
+		public async Task WhenValuesAreTheSame_ShouldSucceed()
 		{
 			DateOnly value = CurrentTime();
 			DateOnly expected = value;

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsTests.cs
@@ -1,0 +1,44 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateOnly
+{
+	public sealed class IsTests
+	{
+		[Fact]
+		public async Task Fails_For_Different_Value()
+		{
+			DateOnly value = CurrentTime();
+			DateOnly expected = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).Is(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).Is(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task Succeeds_For_Same_Value()
+		{
+			DateOnly value = CurrentTime();
+			DateOnly expected = value;
+
+			async Task Act()
+				=> await Expect.That(value).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.cs
@@ -1,0 +1,26 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateOnly
+{
+	/// <summary>
+	/// Use a fixed random time in each test run to ensure, that the tests don't rely on special times.
+	/// </summary>
+	private static readonly Lazy<DateOnly> CurrentTimeLazy = new(
+		() => DateOnly.MinValue.AddDays(new Random().Next(10000)));
+
+	private static DateOnly EarlierTime(int days = 1)
+		=> CurrentTime().AddDays((-1)*days);
+
+	private static DateOnly CurrentTime()
+		=> CurrentTimeLazy.Value;
+
+	private static DateOnly LaterTime(int days = 1)
+		=> CurrentTime().AddDays(days);
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsAfterTests.cs
@@ -56,5 +56,35 @@ public sealed partial class ThatDateTime
 
 			await Expect.That(Act).DoesNotThrow();
 		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime(3);
+
+			async Task Act()
+				=> await Expect.That(value).IsAfter(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is after {expected:O} ± 0:03,
+				                   but found {value:O}
+				                   at Expect.That(value).IsAfter(expected).Within(TimeSpan.FromSeconds(3))
+				                   """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime(2);
+
+			async Task Act()
+				=> await Expect.That(value).IsAfter(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).DoesNotThrow();
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsAfterTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTime
+{
+	public sealed class IsAfterTests
+	{
+		[Fact]
+		public async Task WhenValueIsEarlier_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsAfter(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is after {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsAfter(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValueIsSame_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = expected;
+
+			async Task Act()
+				=> await Expect.That(value).IsAfter(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is after {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsAfter(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValuesIsLater_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsAfter(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsBeforeTests.cs
@@ -56,5 +56,35 @@ public sealed partial class ThatDateTime
 
 			await Expect.That(Act).DoesNotThrow();
 		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime(3);
+
+			async Task Act()
+				=> await Expect.That(value).IsBefore(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is before {expected:O} ± 0:03,
+				                   but found {value:O}
+				                   at Expect.That(value).IsBefore(expected).Within(TimeSpan.FromSeconds(3))
+				                   """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime(2);
+
+			async Task Act()
+				=> await Expect.That(value).IsBefore(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).DoesNotThrow();
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsBeforeTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTime
+{
+	public sealed class IsBeforeTests
+	{
+		[Fact]
+		public async Task WhenValueIsLater_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsBefore(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is before {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsBefore(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValueIsSame_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = expected;
+
+			async Task Act()
+				=> await Expect.That(value).IsBefore(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is before {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsBefore(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValuesIsEarlier_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsBefore(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotAfterTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTime
+{
+	public sealed class IsNotAfterTests
+	{
+		[Fact]
+		public async Task WhenValueIsLater_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsNotAfter(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not after {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsNotAfter(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValueIsSame_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = expected;
+
+			async Task Act()
+				=> await Expect.That(value).IsNotAfter(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenValuesIsEarlier_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsNotAfter(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotAfterTests.cs
@@ -50,5 +50,35 @@ public sealed partial class ThatDateTime
 
 			await Expect.That(Act).DoesNotThrow();
 		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime(4);
+
+			async Task Act()
+				=> await Expect.That(value).IsNotAfter(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not after {expected:O} ± 0:03,
+				                   but found {value:O}
+				                   at Expect.That(value).IsNotAfter(expected).Within(TimeSpan.FromSeconds(3))
+				                   """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime(3);
+
+			async Task Act()
+				=> await Expect.That(value).IsNotAfter(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).DoesNotThrow();
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotBeforeTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTime
+{
+	public sealed class IsNotBeforeTests
+	{
+		[Fact]
+		public async Task WhenValueIsEarlier_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsNotBefore(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not before {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsNotBefore(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValueIsSame_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = expected;
+
+			async Task Act()
+				=> await Expect.That(value).IsNotBefore(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenValuesIsLater_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsNotBefore(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotBeforeTests.cs
@@ -50,5 +50,35 @@ public sealed partial class ThatDateTime
 
 			await Expect.That(Act).DoesNotThrow();
 		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime(4);
+
+			async Task Act()
+				=> await Expect.That(value).IsNotBefore(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not before {expected:O} ± 0:03,
+				                   but found {value:O}
+				                   at Expect.That(value).IsNotBefore(expected).Within(TimeSpan.FromSeconds(3))
+				                   """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime(3);
+
+			async Task Act()
+				=> await Expect.That(value).IsNotBefore(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).DoesNotThrow();
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrAfterTests.cs
@@ -56,5 +56,37 @@ public sealed partial class ThatDateTime
 
 			await Expect.That(Act).DoesNotThrow();
 		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime(3);
+
+			async Task Act()
+				=> await Expect.That(value).IsNotOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not on or after {expected:O} ± 0:03,
+				                   but found {value:O}
+				                   at Expect.That(value).IsNotOnOrAfter(expected).Within(TimeSpan.FromSeconds(3))
+				                   """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime(2);
+
+			async Task Act()
+				=> await Expect.That(value).IsNotOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).DoesNotThrow();
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrAfterTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTime
+{
+	public sealed class IsNotOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenValueIsLater_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsNotOnOrAfter(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not on or after {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsNotOnOrAfter(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValueIsSame_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = expected;
+
+			async Task Act()
+				=> await Expect.That(value).IsNotOnOrAfter(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not on or after {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsNotOnOrAfter(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValuesIsEarlier_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsNotOnOrAfter(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrBeforeTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTime
+{
+	public sealed class IsNotOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenValueIsEarlier_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsNotOnOrBefore(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not on or before {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsNotOnOrBefore(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValueIsSame_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = expected;
+
+			async Task Act()
+				=> await Expect.That(value).IsNotOnOrBefore(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not on or before {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsNotOnOrBefore(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValuesIsLater_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsNotOnOrBefore(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrBeforeTests.cs
@@ -56,5 +56,37 @@ public sealed partial class ThatDateTime
 
 			await Expect.That(Act).DoesNotThrow();
 		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime(3);
+
+			async Task Act()
+				=> await Expect.That(value).IsNotOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not on or before {expected:O} ± 0:03,
+				                   but found {value:O}
+				                   at Expect.That(value).IsNotOnOrBefore(expected).Within(TimeSpan.FromSeconds(3))
+				                   """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime(2);
+
+			async Task Act()
+				=> await Expect.That(value).IsNotOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).DoesNotThrow();
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotTests.cs
@@ -10,7 +10,7 @@ public sealed partial class ThatDateTime
 	public sealed class IsNotTests
 	{
 		[Fact]
-		public async Task Fails_For_Same_Value()
+		public async Task WhenValuesAreTheSame_ShouldFail()
 		{
 			DateTime value = CurrentTime();
 			DateTime unexpected = value;
@@ -28,7 +28,7 @@ public sealed partial class ThatDateTime
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Different_Value()
+		public async Task WhenValuesAreDifferent_ShouldSucceed()
 		{
 			DateTime value = CurrentTime();
 			DateTime unexpected = LaterTime();

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTime
+{
+	public sealed class IsNotTests
+	{
+		[Fact]
+		public async Task Fails_For_Same_Value()
+		{
+			DateTime value = CurrentTime();
+			DateTime unexpected = value;
+
+			async Task Act()
+				=> await Expect.That(value).IsNot(unexpected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not {unexpected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsNot(unexpected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task Succeeds_For_Different_Value()
+		{
+			DateTime value = CurrentTime();
+			DateTime unexpected = LaterTime();
+			
+			async Task Act()
+				=> await Expect.That(value).IsNot(unexpected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotTests.cs
@@ -10,6 +10,18 @@ public sealed partial class ThatDateTime
 	public sealed class IsNotTests
 	{
 		[Fact]
+		public async Task WhenValuesAreDifferent_ShouldSucceed()
+		{
+			DateTime value = CurrentTime();
+			DateTime unexpected = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsNot(unexpected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
 		public async Task WhenValuesAreTheSame_ShouldFail()
 		{
 			DateTime value = CurrentTime();
@@ -28,15 +40,33 @@ public sealed partial class ThatDateTime
 		}
 
 		[Fact]
-		public async Task WhenValuesAreDifferent_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
 		{
 			DateTime value = CurrentTime();
-			DateTime unexpected = LaterTime();
-			
+			DateTime expected = LaterTime(4);
+
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(value).IsNot(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			DateTime value = CurrentTime();
+			DateTime expected = LaterTime(3);
+
+			async Task Act()
+				=> await Expect.That(value).IsNot(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not {expected:O} ± 0:03,
+				                   but found {value:O}
+				                   at Expect.That(value).IsNot(expected).Within(TimeSpan.FromSeconds(3))
+				                   """);
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrAfterTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTime
+{
+	public sealed class IsOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenValueIsEarlier_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsOnOrAfter(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is on or after {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsOnOrAfter(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValueIsSame_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = expected;
+
+			async Task Act()
+				=> await Expect.That(value).IsOnOrAfter(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenValuesIsLater_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsOnOrAfter(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrAfterTests.cs
@@ -50,5 +50,35 @@ public sealed partial class ThatDateTime
 
 			await Expect.That(Act).DoesNotThrow();
 		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime(4);
+
+			async Task Act()
+				=> await Expect.That(value).IsOnOrAfter(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is on or after {expected:O} ± 0:03,
+				                   but found {value:O}
+				                   at Expect.That(value).IsOnOrAfter(expected).Within(TimeSpan.FromSeconds(3))
+				                   """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime(3);
+
+			async Task Act()
+				=> await Expect.That(value).IsOnOrAfter(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).DoesNotThrow();
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrBeforeTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTime
+{
+	public sealed class IsOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenValueIsLater_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsOnOrBefore(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is on or before {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsOnOrBefore(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValueIsSame_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = expected;
+
+			async Task Act()
+				=> await Expect.That(value).IsOnOrBefore(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenValuesIsEarlier_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = EarlierTime();
+
+			async Task Act()
+				=> await Expect.That(value).IsOnOrBefore(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrBeforeTests.cs
@@ -50,5 +50,35 @@ public sealed partial class ThatDateTime
 
 			await Expect.That(Act).DoesNotThrow();
 		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime(4);
+
+			async Task Act()
+				=> await Expect.That(value).IsOnOrBefore(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is on or before {expected:O} ± 0:03,
+				                   but found {value:O}
+				                   at Expect.That(value).IsOnOrBefore(expected).Within(TimeSpan.FromSeconds(3))
+				                   """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTime expected = CurrentTime();
+			DateTime value = LaterTime(3);
+
+			async Task Act()
+				=> await Expect.That(value).IsOnOrBefore(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).DoesNotThrow();
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsTests.cs
@@ -10,7 +10,7 @@ public sealed partial class ThatDateTime
 	public sealed class IsTests
 	{
 		[Fact]
-		public async Task Fails_For_Different_Value()
+		public async Task WhenValuesAreDifferent_ShouldFail()
 		{
 			DateTime value = CurrentTime();
 			DateTime expected = LaterTime();
@@ -28,7 +28,7 @@ public sealed partial class ThatDateTime
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Same_Value()
+		public async Task WhenValuesAreTheSame_ShouldSucceed()
 		{
 			DateTime value = CurrentTime();
 			DateTime expected = value;

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTime
+{
+	public sealed class IsTests
+	{
+		[Fact]
+		public async Task Fails_For_Different_Value()
+		{
+			DateTime value = CurrentTime();
+			DateTime expected = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).Is(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).Is(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task Succeeds_For_Same_Value()
+		{
+			DateTime value = CurrentTime();
+			DateTime expected = value;
+
+			async Task Act()
+				=> await Expect.That(value).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsTests.cs
@@ -38,5 +38,35 @@ public sealed partial class ThatDateTime
 
 			await Expect.That(Act).DoesNotThrow();
 		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTime value = CurrentTime();
+			DateTime expected = LaterTime(4);
+
+			async Task Act()
+				=> await Expect.That(value).Is(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is {expected:O} ± 0:03,
+				                   but found {value:O}
+				                   at Expect.That(value).Is(expected).Within(TimeSpan.FromSeconds(3))
+				                   """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTime value = CurrentTime();
+			DateTime expected = LaterTime(3);
+
+			async Task Act()
+				=> await Expect.That(value).Is(expected).Within(TimeSpan.FromSeconds(3));
+
+			await Expect.That(Act).DoesNotThrow();
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTime
+{
+	/// <summary>
+	///     Use a fixed random time in each test run to ensure, that the tests don't rely on special times.
+	/// </summary>
+	private static readonly Lazy<DateTime> CurrentTimeLazy = new(
+		() => DateTime.MinValue.AddSeconds(new Random().Next()));
+
+	private static DateTime CurrentTime()
+		=> CurrentTimeLazy.Value;
+
+	private static DateTime EarlierTime(int seconds = 1)
+		=> CurrentTime().AddSeconds(-1 * seconds);
+
+	private static DateTime LaterTime(int seconds = 1)
+		=> CurrentTime().AddSeconds(seconds);
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsNotTests.cs
@@ -10,7 +10,7 @@ public sealed partial class ThatDateTimeOffset
 	public sealed class IsNotTests
 	{
 		[Fact]
-		public async Task Fails_For_Same_Value()
+		public async Task WhenValuesAreTheSame_ShouldFail()
 		{
 			DateTimeOffset value = CurrentTime();
 			DateTimeOffset unexpected = value;
@@ -28,7 +28,7 @@ public sealed partial class ThatDateTimeOffset
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Different_Value()
+		public async Task WhenValuesAreDifferent_ShouldSucceed()
 		{
 			DateTimeOffset value = CurrentTime();
 			DateTimeOffset unexpected = LaterTime();

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsNotTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTimeOffset
+{
+	public sealed class IsNotTests
+	{
+		[Fact]
+		public async Task Fails_For_Same_Value()
+		{
+			DateTimeOffset value = CurrentTime();
+			DateTimeOffset unexpected = value;
+
+			async Task Act()
+				=> await Expect.That(value).IsNot(unexpected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not {unexpected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsNot(unexpected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task Succeeds_For_Different_Value()
+		{
+			DateTimeOffset value = CurrentTime();
+			DateTimeOffset unexpected = LaterTime();
+			
+			async Task Act()
+				=> await Expect.That(value).IsNot(unexpected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsTests.cs
@@ -10,7 +10,7 @@ public sealed partial class ThatDateTimeOffset
 	public sealed class IsTests
 	{
 		[Fact]
-		public async Task Fails_For_Different_Value()
+		public async Task WhenValuesAreDifferent_ShouldFail()
 		{
 			DateTimeOffset value = CurrentTime();
 			DateTimeOffset expected = LaterTime();
@@ -28,7 +28,7 @@ public sealed partial class ThatDateTimeOffset
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Same_Value()
+		public async Task WhenValuesAreTheSame_ShouldSucceed()
 		{
 			DateTimeOffset value = CurrentTime();
 			DateTimeOffset expected = value;

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTimeOffset
+{
+	public sealed class IsTests
+	{
+		[Fact]
+		public async Task Fails_For_Different_Value()
+		{
+			DateTimeOffset value = CurrentTime();
+			DateTimeOffset expected = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).Is(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).Is(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task Succeeds_For_Same_Value()
+		{
+			DateTimeOffset value = CurrentTime();
+			DateTimeOffset expected = value;
+
+			async Task Act()
+				=> await Expect.That(value).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatDateTimeOffset
+{
+	/// <summary>
+	///     Use a fixed random time in each test run to ensure, that the tests don't rely on special times.
+	/// </summary>
+	private static readonly Lazy<DateTimeOffset> CurrentTimeLazy = new(
+		() => DateTimeOffset.MinValue.AddSeconds(new Random().Next()));
+
+	private static DateTimeOffset CurrentTime()
+		=> CurrentTimeLazy.Value;
+
+	private static DateTimeOffset EarlierTime(int seconds = 1)
+		=> CurrentTime().AddSeconds(-1 * seconds);
+
+	private static DateTimeOffset LaterTime(int seconds = 1)
+		=> CurrentTime().AddSeconds(seconds);
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsNotTests.cs
@@ -11,7 +11,7 @@ public sealed partial class ThatTimeOnly
 	public sealed class IsNotTests
 	{
 		[Fact]
-		public async Task Fails_For_Same_Value()
+		public async Task WhenValuesAreTheSame_ShouldFail()
 		{
 			TimeOnly value = CurrentTime();
 			TimeOnly unexpected = value;
@@ -29,7 +29,7 @@ public sealed partial class ThatTimeOnly
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Different_Value()
+		public async Task WhenValuesAreDifferent_ShouldSucceed()
 		{
 			TimeOnly value = CurrentTime();
 			TimeOnly unexpected = LaterTime();

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsNotTests.cs
@@ -1,0 +1,44 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatTimeOnly
+{
+	public sealed class IsNotTests
+	{
+		[Fact]
+		public async Task Fails_For_Same_Value()
+		{
+			TimeOnly value = CurrentTime();
+			TimeOnly unexpected = value;
+
+			async Task Act()
+				=> await Expect.That(value).IsNot(unexpected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not {unexpected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).IsNot(unexpected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task Succeeds_For_Different_Value()
+		{
+			TimeOnly value = CurrentTime();
+			TimeOnly unexpected = LaterTime();
+			
+			async Task Act()
+				=> await Expect.That(value).IsNot(unexpected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsTests.cs
@@ -1,0 +1,44 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatTimeOnly
+{
+	public sealed class IsTests
+	{
+		[Fact]
+		public async Task Fails_For_Different_Value()
+		{
+			TimeOnly value = CurrentTime();
+			TimeOnly expected = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).Is(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is {expected:O},
+				                   but found {value:O}
+				                   at Expect.That(value).Is(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task Succeeds_For_Same_Value()
+		{
+			TimeOnly value = CurrentTime();
+			TimeOnly expected = value;
+
+			async Task Act()
+				=> await Expect.That(value).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsTests.cs
@@ -11,7 +11,7 @@ public sealed partial class ThatTimeOnly
 	public sealed class IsTests
 	{
 		[Fact]
-		public async Task Fails_For_Different_Value()
+		public async Task WhenValuesAreDifferent_ShouldFail()
 		{
 			TimeOnly value = CurrentTime();
 			TimeOnly expected = LaterTime();
@@ -29,7 +29,7 @@ public sealed partial class ThatTimeOnly
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Same_Value()
+		public async Task WhenValuesAreTheSame_ShouldSucceed()
 		{
 			TimeOnly value = CurrentTime();
 			TimeOnly expected = value;

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.cs
@@ -1,0 +1,26 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatTimeOnly
+{
+	/// <summary>
+	/// Use a fixed random time in each test run to ensure, that the tests don't rely on special times.
+	/// </summary>
+	private static readonly Lazy<TimeOnly> CurrentTimeLazy = new(
+		() => TimeOnly.MinValue.Add(TimeSpan.FromSeconds(new Random().Next(86400))));
+
+	private static TimeOnly EarlierTime(int seconds = 1)
+		=> CurrentTime().Add(TimeSpan.FromSeconds(-1*seconds));
+
+	private static TimeOnly CurrentTime()
+		=> CurrentTimeLazy.Value;
+
+	private static TimeOnly LaterTime(int seconds = 1)
+		=> CurrentTime().Add(TimeSpan.FromSeconds(seconds));
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsNotTests.cs
@@ -10,7 +10,7 @@ public sealed partial class ThatTimeSpan
 	public sealed class IsNotTests
 	{
 		[Fact]
-		public async Task Fails_For_Same_Value()
+		public async Task WhenValuesAreTheSame_ShouldFail()
 		{
 			TimeSpan value = CurrentTime();
 			TimeSpan unexpected = value;
@@ -28,7 +28,7 @@ public sealed partial class ThatTimeSpan
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Different_Value()
+		public async Task WhenValuesAreDifferent_ShouldSucceed()
 		{
 			TimeSpan value = CurrentTime();
 			TimeSpan unexpected = LaterTime();

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsNotTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Testably.Expectations.Core.Formatting;
 using Xunit;
 using Xunit.Sdk;
 
@@ -21,8 +22,8 @@ public sealed partial class ThatTimeSpan
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
 				                   Expected that value
-				                   is not {unexpected:g},
-				                   but found {value:g}
+				                   is not {Formatter.Format(unexpected)},
+				                   but found {Formatter.Format(value)}
 				                   at Expect.That(value).IsNot(unexpected)
 				                   """);
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsNotTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatTimeSpan
+{
+	public sealed class IsNotTests
+	{
+		[Fact]
+		public async Task Fails_For_Same_Value()
+		{
+			TimeSpan value = CurrentTime();
+			TimeSpan unexpected = value;
+
+			async Task Act()
+				=> await Expect.That(value).IsNot(unexpected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is not {unexpected:g},
+				                   but found {value:g}
+				                   at Expect.That(value).IsNot(unexpected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task Succeeds_For_Different_Value()
+		{
+			TimeSpan value = CurrentTime();
+			TimeSpan unexpected = LaterTime();
+			
+			async Task Act()
+				=> await Expect.That(value).IsNot(unexpected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsTests.cs
@@ -10,7 +10,7 @@ public sealed partial class ThatTimeSpan
 	public sealed class IsTests
 	{
 		[Fact]
-		public async Task Fails_For_Different_Value()
+		public async Task WhenValuesAreDifferent_ShouldFail()
 		{
 			TimeSpan value = CurrentTime();
 			TimeSpan expected = LaterTime();
@@ -28,7 +28,7 @@ public sealed partial class ThatTimeSpan
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Same_Value()
+		public async Task WhenValuesAreTheSame_ShouldSucceed()
 		{
 			TimeSpan value = CurrentTime();
 			TimeSpan expected = value;

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Testably.Expectations.Core.Formatting;
 using Xunit;
 using Xunit.Sdk;
 
@@ -21,8 +22,8 @@ public sealed partial class ThatTimeSpan
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
 				                   Expected that value
-				                   is {expected:g},
-				                   but found {value:g}
+				                   is {Formatter.Format(expected)},
+				                   but found {Formatter.Format(value)}
 				                   at Expect.That(value).Is(expected)
 				                   """);
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatTimeSpan
+{
+	public sealed class IsTests
+	{
+		[Fact]
+		public async Task Fails_For_Different_Value()
+		{
+			TimeSpan value = CurrentTime();
+			TimeSpan expected = LaterTime();
+
+			async Task Act()
+				=> await Expect.That(value).Is(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that value
+				                   is {expected:g},
+				                   but found {value:g}
+				                   at Expect.That(value).Is(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task Succeeds_For_Same_Value()
+		{
+			TimeSpan value = CurrentTime();
+			TimeSpan expected = value;
+
+			async Task Act()
+				=> await Expect.That(value).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Testably.Expectations.Tests.Primitives.Chronology;
+
+public sealed partial class ThatTimeSpan
+{
+	/// <summary>
+	/// Use a fixed random time in each test run to ensure, that the tests don't rely on special times.
+	/// </summary>
+	private static readonly Lazy<TimeSpan> CurrentTimeLazy = new(
+		() => TimeSpan.FromSeconds(new Random().Next(500)));
+
+	private static TimeSpan EarlierTime(int seconds = 1)
+		=> CurrentTime() + TimeSpan.FromSeconds(-1 * seconds);
+
+	private static TimeSpan CurrentTime()
+		=> CurrentTimeLazy.Value;
+
+	private static TimeSpan LaterTime(int seconds = 1)
+		=> CurrentTime() + TimeSpan.FromSeconds(seconds);
+}


### PR DESCRIPTION
Add assertions on DateTime:
- `Is`, `IsNot`
- `IsAfter`, `IsNotAfter`
- `IsBefore`, `IsNotBefore`
- `IsOnOrAfter`, `IsNotOnOrAfter`
- `IsOnOrBefore`, `IsNotOnOrBefore`

all allow specifying a tolerance with the `.Within(TimeSpan)` method.