### PR TITLE
feat: add chronology extensions to create timespans

### DIFF
--- a/Source/Testably.Expectations/Extensions/ChronologyExtensions.cs
+++ b/Source/Testably.Expectations/Extensions/ChronologyExtensions.cs
@@ -1,0 +1,139 @@
+﻿using System;
+
+namespace Testably.Expectations.Extensions;
+
+/// <summary>
+///     Extension methods for chronology methods.
+/// </summary>
+public static class ChronologyExtensions
+{
+	/// <summary>
+	///     Converts the <paramref name="days" /> into a corresponding <see cref="TimeSpan" />.
+	/// </summary>
+	public static TimeSpan Days(this int days)
+		=> TimeSpan.FromDays(days);
+
+	/// <summary>
+	///     Converts the <paramref name="days" /> into a corresponding <see cref="TimeSpan" />.
+	/// </summary>
+	public static TimeSpan Days(this double days)
+		=> TimeSpan.FromDays(days);
+
+	/// <summary>
+	///     Converts the <paramref name="days" /> into a corresponding <see cref="TimeSpan" /> and add the given
+	///     <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Days(this int days, TimeSpan offset)
+		=> TimeSpan.FromDays(days).Add(offset);
+
+	/// <summary>
+	///     Converts the <paramref name="days" /> into a corresponding <see cref="TimeSpan" /> and add the given
+	///     <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Days(this double days, TimeSpan offset)
+		=> TimeSpan.FromDays(days).Add(offset);
+
+	/// <summary>
+	///     Converts the <paramref name="hours" /> into a corresponding <see cref="TimeSpan" />.
+	/// </summary>
+	public static TimeSpan Hours(this int hours)
+		=> TimeSpan.FromHours(hours);
+
+	/// <summary>
+	///     Converts the <paramref name="hours" /> into a corresponding <see cref="TimeSpan" />.
+	/// </summary>
+	public static TimeSpan Hours(this double hours)
+		=> TimeSpan.FromHours(hours);
+
+	/// <summary>
+	///     Converts the <paramref name="hours" /> into a corresponding <see cref="TimeSpan" /> and add the given
+	///     <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Hours(this int hours, TimeSpan offset)
+		=> TimeSpan.FromHours(hours).Add(offset);
+
+	/// <summary>
+	///     Converts the <paramref name="hours" /> into a corresponding <see cref="TimeSpan" /> and add the given
+	///     <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Hours(this double hours, TimeSpan offset)
+		=> TimeSpan.FromHours(hours).Add(offset);
+
+	/// <summary>
+	///     Converts the <paramref name="milliseconds" /> into a corresponding <see cref="TimeSpan" />.
+	/// </summary>
+	public static TimeSpan Milliseconds(this int milliseconds)
+		=> TimeSpan.FromMilliseconds(milliseconds);
+
+	/// <summary>
+	///     Converts the <paramref name="milliseconds" /> into a corresponding <see cref="TimeSpan" />.
+	/// </summary>
+	public static TimeSpan Milliseconds(this double milliseconds)
+		=> TimeSpan.FromMilliseconds(milliseconds);
+
+	/// <summary>
+	///     Converts the <paramref name="milliseconds" /> into a corresponding <see cref="TimeSpan" /> and add the given
+	///     <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Milliseconds(this int milliseconds, TimeSpan offset)
+		=> TimeSpan.FromMilliseconds(milliseconds).Add(offset);
+
+	/// <summary>
+	///     Converts the <paramref name="milliseconds" /> into a corresponding <see cref="TimeSpan" /> and add the given
+	///     <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Milliseconds(this double milliseconds, TimeSpan offset)
+		=> TimeSpan.FromMilliseconds(milliseconds).Add(offset);
+
+	/// <summary>
+	///     Converts the <paramref name="minutes" /> into a corresponding <see cref="TimeSpan" />.
+	/// </summary>
+	public static TimeSpan Minutes(this int minutes)
+		=> TimeSpan.FromMinutes(minutes);
+
+	/// <summary>
+	///     Converts the <paramref name="minutes" /> into a corresponding <see cref="TimeSpan" />.
+	/// </summary>
+	public static TimeSpan Minutes(this double minutes)
+		=> TimeSpan.FromMinutes(minutes);
+
+	/// <summary>
+	///     Converts the <paramref name="minutes" /> into a corresponding <see cref="TimeSpan" /> and add the given
+	///     <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Minutes(this int minutes, TimeSpan offset)
+		=> TimeSpan.FromMinutes(minutes).Add(offset);
+
+	/// <summary>
+	///     Converts the <paramref name="minutes" /> into a corresponding <see cref="TimeSpan" /> and add the given
+	///     <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Minutes(this double minutes, TimeSpan offset)
+		=> TimeSpan.FromMinutes(minutes).Add(offset);
+
+	/// <summary>
+	///     Converts the <paramref name="seconds" /> into a corresponding <see cref="TimeSpan" />.
+	/// </summary>
+	public static TimeSpan Seconds(this int seconds)
+		=> TimeSpan.FromSeconds(seconds);
+
+	/// <summary>
+	///     Converts the <paramref name="seconds" /> into a corresponding <see cref="TimeSpan" />.
+	/// </summary>
+	public static TimeSpan Seconds(this double seconds)
+		=> TimeSpan.FromSeconds(seconds);
+
+	/// <summary>
+	///     Converts the <paramref name="seconds" /> into a corresponding <see cref="TimeSpan" /> and add the given
+	///     <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Seconds(this int seconds, TimeSpan offset)
+		=> TimeSpan.FromSeconds(seconds).Add(offset);
+
+	/// <summary>
+	///     Converts the <paramref name="seconds" /> into a corresponding <see cref="TimeSpan" /> and add the given
+	///     <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Seconds(this double seconds, TimeSpan offset)
+		=> TimeSpan.FromSeconds(seconds).Add(offset);
+}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AllAreEquivalentTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AllAreEquivalentTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Collections;
+﻿namespace Testably.Expectations.Tests.Collections;
 
 public sealed partial class ThatCollection
 {

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AllAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AllAreTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Collections;
+﻿namespace Testably.Expectations.Tests.Collections;
 
 public sealed partial class ThatCollection
 {

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AtLeastAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AtLeastAreTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Collections;
+﻿namespace Testably.Expectations.Tests.Collections;
 
 public sealed partial class ThatCollection
 {

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AtMostAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AtMostAreTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Collections;
+﻿namespace Testably.Expectations.Tests.Collections;
 
 public sealed partial class ThatCollection
 {

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.BetweenAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.BetweenAreTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Collections;
+﻿namespace Testably.Expectations.Tests.Collections;
 
 public sealed partial class ThatCollection
 {

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.ContainsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.ContainsTests.cs
@@ -1,8 +1,4 @@
-﻿using AutoFixture.Xunit2;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
+﻿using System.Collections.Generic;
 
 namespace Testably.Expectations.Tests.Collections;
 

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.IsEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.IsEmptyTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Collections;
+﻿namespace Testably.Expectations.Tests.Collections;
 
 public sealed partial class ThatCollection
 {

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.IsNotEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.IsNotEmptyTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Collections;
+﻿namespace Testably.Expectations.Tests.Collections;
 
 public sealed partial class ThatCollection
 {

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.NoneAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.NoneAreTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Collections;
+﻿namespace Testably.Expectations.Tests.Collections;
 
 public sealed partial class ThatCollection
 {

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Testably.Expectations.Tests.Collections;
 public partial class ThatCollection

--- a/Tests/Testably.Expectations.Tests/Core/Ambient/InitializationTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Ambient/InitializationTests.cs
@@ -1,8 +1,6 @@
 ﻿#if NET6_0_OR_GREATER
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace Testably.Expectations.Tests.Core.Ambient;
 

--- a/Tests/Testably.Expectations.Tests/Core/BecauseTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/BecauseTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Testably.Expectations.Tests.TestHelpers;
-using Xunit;
+﻿using Testably.Expectations.Tests.TestHelpers;
 
 namespace Testably.Expectations.Tests.Core;
 

--- a/Tests/Testably.Expectations.Tests/Core/ConstraintResultTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/ConstraintResultTests.cs
@@ -1,7 +1,4 @@
-﻿using AutoFixture.Xunit2;
-using System.Threading.Tasks;
-using Testably.Expectations.Core.Constraints;
-using Xunit;
+﻿using Testably.Expectations.Core.Constraints;
 
 namespace Testably.Expectations.Tests.Core;
 

--- a/Tests/Testably.Expectations.Tests/Core/Exceptions/FailExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Exceptions/FailExceptionTests.cs
@@ -1,8 +1,4 @@
-﻿using AutoFixture.Xunit2;
-using System.Threading.Tasks;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Core.Exceptions;
+﻿namespace Testably.Expectations.Tests.Core.Exceptions;
 
 public sealed class FailExceptionTests
 {

--- a/Tests/Testably.Expectations.Tests/Core/Exceptions/SkipExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Exceptions/SkipExceptionTests.cs
@@ -1,8 +1,4 @@
-﻿using AutoFixture.Xunit2;
-using System.Threading.Tasks;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Core.Exceptions;
+﻿namespace Testably.Expectations.Tests.Core.Exceptions;
 
 public sealed class SkipExceptionTests
 {

--- a/Tests/Testably.Expectations.Tests/Core/ExpectationTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/ExpectationTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Core;
+﻿namespace Testably.Expectations.Tests.Core;
 
 public sealed class ExpectationTests
 {

--- a/Tests/Testably.Expectations.Tests/Core/Formatting/DefaultFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Formatting/DefaultFormatterTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Testably.Expectations.Core.Formatting;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Core.Formatting;
+﻿namespace Testably.Expectations.Tests.Core.Formatting;
 
 public sealed class DefaultFormatterTests
 {

--- a/Tests/Testably.Expectations.Tests/Core/Formatting/Formatters/BooleanFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Formatting/Formatters/BooleanFormatterTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Testably.Expectations.Core.Formatting;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Core.Formatting.Formatters;
+﻿namespace Testably.Expectations.Tests.Core.Formatting.Formatters;
 
 public sealed class BooleanFormatterTests
 {

--- a/Tests/Testably.Expectations.Tests/Core/Formatting/Formatters/CollectionFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Formatting/Formatters/CollectionFormatterTests.cs
@@ -1,8 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Testably.Expectations.Core.Formatting;
-using Xunit;
 
 namespace Testably.Expectations.Tests.Core.Formatting.Formatters;
 

--- a/Tests/Testably.Expectations.Tests/Core/Formatting/Formatters/NumberFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Formatting/Formatters/NumberFormatterTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Testably.Expectations.Core.Formatting;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Core.Formatting.Formatters;
+﻿namespace Testably.Expectations.Tests.Core.Formatting.Formatters;
 
 public sealed class NumberFormatterTests
 {

--- a/Tests/Testably.Expectations.Tests/Core/Formatting/Formatters/StringFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Formatting/Formatters/StringFormatterTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Testably.Expectations.Core.Formatting;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Core.Formatting.Formatters;
+﻿namespace Testably.Expectations.Tests.Core.Formatting.Formatters;
 
 public sealed class StringFormatterTests
 {

--- a/Tests/Testably.Expectations.Tests/Core/Formatting/Formatters/TypeFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Formatting/Formatters/TypeFormatterTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Testably.Expectations.Core.Formatting;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Core.Formatting.Formatters;
+﻿namespace Testably.Expectations.Tests.Core.Formatting.Formatters;
 
 public sealed class TypeFormatterTests
 {

--- a/Tests/Testably.Expectations.Tests/Core/Nodes/AndNodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Nodes/AndNodeTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Core.Nodes;
+﻿namespace Testably.Expectations.Tests.Core.Nodes;
 
 public sealed class AndNodeTests
 {

--- a/Tests/Testably.Expectations.Tests/Core/Nodes/OrNodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Nodes/OrNodeTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Core.Nodes;
+﻿namespace Testably.Expectations.Tests.Core.Nodes;
 
 public sealed class OrNodeTests
 {

--- a/Tests/Testably.Expectations.Tests/Core/Nodes/PrecedenceTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Nodes/PrecedenceTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Core.Nodes;
+﻿namespace Testably.Expectations.Tests.Core.Nodes;
 
 public sealed class PrecedenceTests
 {

--- a/Tests/Testably.Expectations.Tests/Core/Nodes/WhichNodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Nodes/WhichNodeTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Core.Nodes;
+﻿namespace Testably.Expectations.Tests.Core.Nodes;
 
 public sealed class WhichNodeTests
 {

--- a/Tests/Testably.Expectations.Tests/Core/StringMatcherTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/StringMatcherTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Testably.Expectations.Tests.TestHelpers;
-using Xunit;
+﻿using Testably.Expectations.Tests.TestHelpers;
 
 namespace Testably.Expectations.Tests.Core;
 

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.DoesNotThrowTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.DoesNotThrowTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Delegates;
+﻿namespace Testably.Expectations.Tests.Delegates;
 
 public sealed partial class ThatDelegate
 {

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.OnlyIfTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.OnlyIfTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Delegates;
+﻿namespace Testably.Expectations.Tests.Delegates;
 
 public sealed partial class ThatDelegate
 {

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsExactlyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsExactlyTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Delegates;
+﻿namespace Testably.Expectations.Tests.Delegates;
 
 public sealed partial class ThatDelegate
 {

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsExceptionTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Delegates;
+﻿namespace Testably.Expectations.Tests.Delegates;
 
 public sealed partial class ThatDelegate
 {

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Delegates;
+﻿namespace Testably.Expectations.Tests.Delegates;
 
 public sealed partial class ThatDelegate
 {

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace Testably.Expectations.Tests.Delegates;
 

--- a/Tests/Testably.Expectations.Tests/Extensions/ChronologyExtensionsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Extensions/ChronologyExtensionsTests.cs
@@ -1,0 +1,246 @@
+﻿using AutoFixture.Xunit2;
+using System;
+using Testably.Expectations.Extensions;
+
+namespace Testably.Expectations.Tests.Extensions;
+
+public class ChronologyExtensionsTests
+{
+	[Fact]
+	public async Task CommonUsage()
+	{
+		TimeSpan expected = new(2, 5, 13);
+
+		TimeSpan result = 2.Hours(5.Minutes(13.Seconds()));
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Double_Days_ShouldReturnCorrectTimeSpan(double days)
+	{
+		TimeSpan expected = TimeSpan.FromDays(days);
+
+		TimeSpan result = days.Days();
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Double_Days_WithOffset_ShouldReturnCorrectTimeSpan(double days,
+		TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromDays(days) + offset;
+
+		TimeSpan result = days.Days(offset);
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Double_Hours_ShouldReturnCorrectTimeSpan(double hours)
+	{
+		TimeSpan expected = TimeSpan.FromHours(hours);
+
+		TimeSpan result = hours.Hours();
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Double_Hours_WithOffset_ShouldReturnCorrectTimeSpan(double hours,
+		TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromHours(hours) + offset;
+
+		TimeSpan result = hours.Hours(offset);
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Double_Milliseconds_ShouldReturnCorrectTimeSpan(double milliseconds)
+	{
+		TimeSpan expected = TimeSpan.FromMilliseconds(milliseconds);
+
+		TimeSpan result = milliseconds.Milliseconds();
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Double_Milliseconds_WithOffset_ShouldReturnCorrectTimeSpan(
+		double milliseconds, TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromMilliseconds(milliseconds) + offset;
+
+		TimeSpan result = milliseconds.Milliseconds(offset);
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Double_Minutes_ShouldReturnCorrectTimeSpan(double minutes)
+	{
+		TimeSpan expected = TimeSpan.FromMinutes(minutes);
+
+		TimeSpan result = minutes.Minutes();
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Double_Minutes_WithOffset_ShouldReturnCorrectTimeSpan(double minutes,
+		TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromMinutes(minutes) + offset;
+
+		TimeSpan result = minutes.Minutes(offset);
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Double_Seconds_ShouldReturnCorrectTimeSpan(double seconds)
+	{
+		TimeSpan expected = TimeSpan.FromSeconds(seconds);
+
+		TimeSpan result = seconds.Seconds();
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Double_Seconds_WithOffset_ShouldReturnCorrectTimeSpan(double seconds,
+		TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromSeconds(seconds) + offset;
+
+		TimeSpan result = seconds.Seconds(offset);
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Int_Days_ShouldReturnCorrectTimeSpan(int days)
+	{
+		TimeSpan expected = TimeSpan.FromDays(days);
+
+		TimeSpan result = days.Days();
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Int_Days_WithOffset_ShouldReturnCorrectTimeSpan(int days, TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromDays(days) + offset;
+
+		TimeSpan result = days.Days(offset);
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Int_Hours_ShouldReturnCorrectTimeSpan(int hours)
+	{
+		TimeSpan expected = TimeSpan.FromHours(hours);
+
+		TimeSpan result = hours.Hours();
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Int_Hours_WithOffset_ShouldReturnCorrectTimeSpan(int hours, TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromHours(hours) + offset;
+
+		TimeSpan result = hours.Hours(offset);
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Int_Milliseconds_ShouldReturnCorrectTimeSpan(int milliseconds)
+	{
+		TimeSpan expected = TimeSpan.FromMilliseconds(milliseconds);
+
+		TimeSpan result = milliseconds.Milliseconds();
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Int_Milliseconds_WithOffset_ShouldReturnCorrectTimeSpan(int milliseconds,
+		TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromMilliseconds(milliseconds) + offset;
+
+		TimeSpan result = milliseconds.Milliseconds(offset);
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Int_Minutes_ShouldReturnCorrectTimeSpan(int minutes)
+	{
+		TimeSpan expected = TimeSpan.FromMinutes(minutes);
+
+		TimeSpan result = minutes.Minutes();
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Int_Minutes_WithOffset_ShouldReturnCorrectTimeSpan(int minutes,
+		TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromMinutes(minutes) + offset;
+
+		TimeSpan result = minutes.Minutes(offset);
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Int_Seconds_ShouldReturnCorrectTimeSpan(int seconds)
+	{
+		TimeSpan expected = TimeSpan.FromSeconds(seconds);
+
+		TimeSpan result = seconds.Seconds();
+
+		await Expect.That(result).Is(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Int_Seconds_WithOffset_ShouldReturnCorrectTimeSpan(int seconds,
+		TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromSeconds(seconds) + offset;
+
+		TimeSpan result = seconds.Seconds(offset);
+
+		await Expect.That(result).Is(expected);
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Extensions/ChronologyExtensionsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Extensions/ChronologyExtensionsTests.cs
@@ -4,16 +4,6 @@ namespace Testably.Expectations.Tests.Extensions;
 
 public class ChronologyExtensionsTests
 {
-	[Fact]
-	public async Task CommonUsage()
-	{
-		TimeSpan expected = new(2, 5, 13);
-
-		TimeSpan result = 2.Hours(5.Minutes(13.Seconds()));
-
-		await Expect.That(result).Is(expected);
-	}
-
 	[Theory]
 	[AutoData]
 	public async Task Double_Days_ShouldReturnCorrectTimeSpan(double days)

--- a/Tests/Testably.Expectations.Tests/Extensions/ChronologyExtensionsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Extensions/ChronologyExtensionsTests.cs
@@ -1,6 +1,4 @@
-﻿using AutoFixture.Xunit2;
-using System;
-using Testably.Expectations.Extensions;
+﻿using Testably.Expectations.Extensions;
 
 namespace Testably.Expectations.Tests.Extensions;
 

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.ImpliesTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.ImpliesTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsFalseTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsFalseTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsNotTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsTrueTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsTrueTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsFalseTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsFalseTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatNullableBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotFalseTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotFalseTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatNullableBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotNullTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatNullableBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatNullableBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotTrueTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotTrueTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatNullableBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNullTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatNullableBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatNullableBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsTrueTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsTrueTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Booleans;
+﻿namespace Testably.Expectations.Tests.Primitives.Booleans;
 
 public sealed partial class ThatNullableBool
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsNotTests.cs
@@ -1,9 +1,4 @@
 ﻿#if NET6_0_OR_GREATER
-using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
 namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateOnly

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsTests.cs
@@ -1,9 +1,4 @@
 ﻿#if NET6_0_OR_GREATER
-using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
 namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateOnly

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.cs
@@ -1,9 +1,4 @@
 ﻿#if NET6_0_OR_GREATER
-using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
 namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateOnly

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsAfterTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTime
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsBeforeTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTime
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotAfterTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTime
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotBeforeTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTime
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrAfterTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTime
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrBeforeTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTime
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTime
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrAfterTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTime
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrBeforeTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTime
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTime
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTime
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsNotTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTimeOffset
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTimeOffset
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatDateTimeOffset
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsNotTests.cs
@@ -1,9 +1,4 @@
 ﻿#if NET6_0_OR_GREATER
-using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
 namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatTimeOnly

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsTests.cs
@@ -1,9 +1,4 @@
 ﻿#if NET6_0_OR_GREATER
-using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
 namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatTimeOnly

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.cs
@@ -1,9 +1,4 @@
 ﻿#if NET6_0_OR_GREATER
-using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
 namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatTimeOnly

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsNotTests.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Testably.Expectations.Core.Formatting;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatTimeSpan
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsTests.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Testably.Expectations.Core.Formatting;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatTimeSpan
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Chronology;
+﻿namespace Testably.Expectations.Tests.Primitives.Chronology;
 
 public sealed partial class ThatTimeSpan
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Exceptions/ThatException.HasInnerExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Exceptions/ThatException.HasInnerExceptionTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Exceptions;
+﻿namespace Testably.Expectations.Tests.Primitives.Exceptions;
 
 public sealed partial class ThatException
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Exceptions/ThatException.HasMessageTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Exceptions/ThatException.HasMessageTests.cs
@@ -1,10 +1,4 @@
-﻿using AutoFixture.Xunit2;
-using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Exceptions;
+﻿namespace Testably.Expectations.Tests.Primitives.Exceptions;
 
 public sealed partial class ThatException
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Numbers/ThatNumber.IsNaNTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Numbers/ThatNumber.IsNaNTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Numbers;
+﻿namespace Testably.Expectations.Tests.Primitives.Numbers;
 
 public sealed partial class ThatNumber
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Numbers/ThatNumber.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Numbers/ThatNumber.IsNotTests.cs
@@ -1,9 +1,4 @@
-﻿using AutoFixture.Xunit2;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Numbers;
+﻿namespace Testably.Expectations.Tests.Primitives.Numbers;
 
 public sealed partial class ThatNumber
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Numbers/ThatNumber.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Numbers/ThatNumber.IsTests.cs
@@ -1,9 +1,4 @@
-﻿using AutoFixture.Xunit2;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Numbers;
+﻿namespace Testably.Expectations.Tests.Primitives.Numbers;
 
 public sealed partial class ThatNumber
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Objects/ThatObject.IsEquivalentToTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Objects/ThatObject.IsEquivalentToTests.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Threading.Tasks;
 using Testably.Expectations.Tests.TestHelpers;
-using Xunit;
 
 namespace Testably.Expectations.Tests.Primitives.Objects;
 

--- a/Tests/Testably.Expectations.Tests/Primitives/Objects/ThatObject.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Objects/ThatObject.IsTests.cs
@@ -1,8 +1,4 @@
-﻿using AutoFixture.Xunit2;
-using System.Threading.Tasks;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Primitives.Objects;
+﻿namespace Testably.Expectations.Tests.Primitives.Objects;
 
 public sealed partial class ThatObject
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.ContainsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.ContainsTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Strings;
+﻿namespace Testably.Expectations.Tests.Primitives.Strings;
 
 public sealed partial class ThatString
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotContainTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotContainTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Strings;
+﻿namespace Testably.Expectations.Tests.Primitives.Strings;
 
 public sealed partial class ThatString
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsNotNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsNotNullTests.cs
@@ -1,9 +1,4 @@
-﻿using AutoFixture.Xunit2;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Strings;
+﻿namespace Testably.Expectations.Tests.Primitives.Strings;
 
 public sealed partial class ThatString
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsNullTests.cs
@@ -1,9 +1,4 @@
-﻿using AutoFixture.Xunit2;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Strings;
+﻿namespace Testably.Expectations.Tests.Primitives.Strings;
 
 public sealed partial class ThatString
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsTests.cs
@@ -1,9 +1,4 @@
-﻿using AutoFixture.Xunit2;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Strings;
+﻿namespace Testably.Expectations.Tests.Primitives.Strings;
 
 public sealed partial class ThatString
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/ThatGeneric.IsSameAsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/ThatGeneric.IsSameAsTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Generics;
+﻿namespace Testably.Expectations.Tests.Primitives.Generics;
 
 public sealed partial class ThatGeneric
 {

--- a/Tests/Testably.Expectations.Tests/Primitives/ThatGeneric.SatisfiesTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/ThatGeneric.SatisfiesTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
-
-namespace Testably.Expectations.Tests.Primitives.Generics;
+﻿namespace Testably.Expectations.Tests.Primitives.Generics;
 
 public sealed partial class ThatGeneric
 {

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.DoesNotHaveStatusCodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.DoesNotHaveStatusCodeTests.cs
@@ -1,8 +1,5 @@
 ﻿using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
 
 namespace Testably.Expectations.Tests.Specialized.Http;
 

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasClientErrorTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasClientErrorTests.cs
@@ -1,8 +1,5 @@
 ﻿using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
 
 namespace Testably.Expectations.Tests.Specialized.Http;
 

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasContentTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasContentTests.cs
@@ -1,7 +1,4 @@
 ﻿using System.Net.Http;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
 
 namespace Testably.Expectations.Tests.Specialized.Http;
 

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasErrorTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasErrorTests.cs
@@ -1,8 +1,5 @@
 ﻿using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
 
 namespace Testably.Expectations.Tests.Specialized.Http;
 

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasServerErrorTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasServerErrorTests.cs
@@ -1,8 +1,5 @@
 ﻿using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
 
 namespace Testably.Expectations.Tests.Specialized.Http;
 

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasStatusCodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasStatusCodeTests.cs
@@ -1,8 +1,5 @@
 ﻿using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
 
 namespace Testably.Expectations.Tests.Specialized.Http;
 

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsRedirectionTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsRedirectionTests.cs
@@ -1,8 +1,5 @@
 ﻿using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
 
 namespace Testably.Expectations.Tests.Specialized.Http;
 

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsSuccessfulTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsSuccessfulTests.cs
@@ -1,8 +1,5 @@
 ﻿using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Sdk;
 
 namespace Testably.Expectations.Tests.Specialized.Http;
 

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using System.Net.Http;
-using Xunit;
 
 namespace Testably.Expectations.Tests.Specialized.Http;
 

--- a/Tests/Testably.Expectations.Tests/TestHelpers/ThrowHelper.cs
+++ b/Tests/Testably.Expectations.Tests/TestHelpers/ThrowHelper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Testably.Expectations.Core;
+﻿using Testably.Expectations.Core;
 using Testably.Expectations.Core.Results;
 
 namespace Testably.Expectations.Tests.TestHelpers;

--- a/Tests/Testably.Expectations.Tests/Usings.cs
+++ b/Tests/Testably.Expectations.Tests/Usings.cs
@@ -1,3 +1,6 @@
-﻿#if NET8_0_OR_GREATER
-global using System.Numerics;
-#endif
+﻿global using System;
+global using System.Threading.Tasks;
+global using AutoFixture.Xunit2;
+global using Xunit;
+global using Xunit.Sdk;
+global using Testably.Expectations.Core.Formatting;


### PR DESCRIPTION
Add extension methods on `int` and `double` to create `TimeSpan`s, e.g.
```csharp
var timeSpan = 2.Hours(5.Minutes(13.Seconds()));
```

*Also cleanup the using statements in the test project.*