### PR TITLE
feat: avoid materializing `IEnumerable`s

### DIFF
--- a/Source/Testably.Expectations/Collections/QuantifiableCollection.AreEquivalentToConstraint.cs
+++ b/Source/Testably.Expectations/Collections/QuantifiableCollection.AreEquivalentToConstraint.cs
@@ -7,7 +7,7 @@ using Testably.Expectations.Core.Formatting;
 
 namespace Testably.Expectations.Collections;
 
-public partial class QuantifiableCollection<TItem>
+public partial class QuantifiableCollection<TItem, TCollection>
 {
 	private readonly struct AreEquivalentToConstraint(
 		TItem expected,

--- a/Source/Testably.Expectations/Collections/QuantifiableCollection.SatisfyConstraint.cs
+++ b/Source/Testably.Expectations/Collections/QuantifiableCollection.SatisfyConstraint.cs
@@ -7,7 +7,7 @@ using Testably.Expectations.Core.Formatting;
 
 namespace Testably.Expectations.Collections;
 
-public partial class QuantifiableCollection<TItem>
+public partial class QuantifiableCollection<TItem, TCollection>
 {
 	private readonly struct SatisfyConstraint(
 		Func<TItem, bool> predicate,

--- a/Source/Testably.Expectations/Collections/QuantifiableCollection.cs
+++ b/Source/Testably.Expectations/Collections/QuantifiableCollection.cs
@@ -10,14 +10,15 @@ namespace Testably.Expectations.Collections;
 /// <summary>
 ///     A quantifiable collection matching items against the expected <paramref name="quantity" />.
 /// </summary>
-public partial class QuantifiableCollection<TItem>(
-	That<IEnumerable<TItem>> source,
+public partial class QuantifiableCollection<TItem, TCollection>(
+	That<TCollection> source,
 	CollectionQuantifier quantity)
+	where TCollection : IEnumerable<TItem>
 {
 	/// <summary>
 	///     ...are equal to <paramref name="expected" />.
 	/// </summary>
-	public AndOrExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>> Are(
+	public AndOrExpectationResult<TCollection, That<TCollection>> Are(
 		TItem expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		=> new(source.ExpectationBuilder.Add(new AreEqualConstraint(expected, quantity),
@@ -27,12 +28,12 @@ public partial class QuantifiableCollection<TItem>(
 	/// <summary>
 	///     ...are equivalent to <paramref name="expected" />.
 	/// </summary>
-	public EquivalencyOptionsExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>> AreEquivalentTo(
+	public EquivalencyOptionsExpectationResult<TCollection, That<TCollection>> AreEquivalentTo(
 		TItem expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		var options = new EquivalencyOptions();
-		return new EquivalencyOptionsExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>>(
+		return new EquivalencyOptionsExpectationResult<TCollection, That<TCollection>>(
 			source.ExpectationBuilder.Add(new AreEquivalentToConstraint(expected, doNotPopulateThisValue, quantity, options),
 				b => b.AppendMethod(nameof(AreEquivalentTo), doNotPopulateThisValue)),
 			source,
@@ -42,7 +43,7 @@ public partial class QuantifiableCollection<TItem>(
 	/// <summary>
 	///     ...satisfy the <paramref name="predicate" />.
 	/// </summary>
-	public AndOrExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>> Satisfy(
+	public AndOrExpectationResult<TCollection, That<TCollection>> Satisfy(
 		Func<TItem, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")

--- a/Source/Testably.Expectations/Collections/ThatCollectionExtensions.ContainsConstraint.cs
+++ b/Source/Testably.Expectations/Collections/ThatCollectionExtensions.ContainsConstraint.cs
@@ -9,14 +9,14 @@ namespace Testably.Expectations;
 public static partial class ThatCollectionExtensions
 {
 	private readonly struct ContainsConstraint<TItem>(TItem expected)
-		: IConstraint<IEnumerable<TItem>>
+		: IConstraint<ICollection<TItem>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<TItem> actual)
+		public ConstraintResult IsMetBy(ICollection<TItem> actual)
 		{
 			List<TItem> list = actual.ToList();
 			if (list.Contains(expected))
 			{
-				return new ConstraintResult.Success<IEnumerable<TItem>>(list, ToString());
+				return new ConstraintResult.Success<ICollection<TItem>>(list, ToString());
 			}
 
 			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(list)}");

--- a/Source/Testably.Expectations/Collections/ThatCollectionExtensions.IsEmptyConstraint.cs
+++ b/Source/Testably.Expectations/Collections/ThatCollectionExtensions.IsEmptyConstraint.cs
@@ -8,14 +8,14 @@ namespace Testably.Expectations;
 
 public static partial class ThatCollectionExtensions
 {
-	private readonly struct IsEmptyConstraint<TItem> : IConstraint<IEnumerable<TItem>>
+	private readonly struct IsEmptyConstraint<TItem> : IConstraint<ICollection<TItem>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<TItem> actual)
+		public ConstraintResult IsMetBy(ICollection<TItem> actual)
 		{
 			List<TItem> list = actual.ToList();
 			if (!list.Any())
 			{
-				return new ConstraintResult.Success<IEnumerable<TItem>>(list, ToString());
+				return new ConstraintResult.Success<ICollection<TItem>>(list, ToString());
 			}
 
 			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(list)}");

--- a/Source/Testably.Expectations/Collections/ThatCollectionExtensions.IsNotEmptyConstraint.cs
+++ b/Source/Testably.Expectations/Collections/ThatCollectionExtensions.IsNotEmptyConstraint.cs
@@ -7,14 +7,14 @@ namespace Testably.Expectations;
 
 public static partial class ThatCollectionExtensions
 {
-	private readonly struct IsNotEmptyConstraint<TItem> : IConstraint<IEnumerable<TItem>>
+	private readonly struct IsNotEmptyConstraint<TItem> : IConstraint<ICollection<TItem>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<TItem> actual)
+		public ConstraintResult IsMetBy(ICollection<TItem> actual)
 		{
 			List<TItem> list = actual.ToList();
 			if (list.Any())
 			{
-				return new ConstraintResult.Success<IEnumerable<TItem>>(list, ToString());
+				return new ConstraintResult.Success<ICollection<TItem>>(list, ToString());
 			}
 
 			return new ConstraintResult.Failure(ToString(), "it was");

--- a/Source/Testably.Expectations/Collections/ThatCollectionExtensions.cs
+++ b/Source/Testably.Expectations/Collections/ThatCollectionExtensions.cs
@@ -16,53 +16,53 @@ public static partial class ThatCollectionExtensions
 	/// <summary>
 	///     Verifies that all items in the collection...
 	/// </summary>
-	public static QuantifiableCollection<TItem> All<TItem>(this That<IEnumerable<TItem>> source)
+	public static QuantifiableCollection<TItem, ICollection<TItem>> All<TItem>(this That<ICollection<TItem>> source)
 	{
 		source.ExpectationBuilder.AppendExpression(b => b.AppendMethod(nameof(All)));
-		return new QuantifiableCollection<TItem>(source, CollectionQuantifier.All);
+		return new QuantifiableCollection<TItem, ICollection<TItem>>(source, CollectionQuantifier.All);
 	}
 
 	/// <summary>
 	///     Verifies that at least <paramref name="minimum" /> items in the collection...
 	/// </summary>
-	public static QuantifiableCollection<TItem> AtLeast<TItem>(this That<IEnumerable<TItem>> source,
+	public static QuantifiableCollection<TItem, ICollection<TItem>> AtLeast<TItem>(this That<ICollection<TItem>> source,
 		int minimum, [CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
 	{
 		source.ExpectationBuilder.AppendExpression(b
 			=> b.AppendMethod(nameof(AtLeast), doNotPopulateThisValue));
-		return new QuantifiableCollection<TItem>(source, CollectionQuantifier.AtLeast(minimum));
+		return new QuantifiableCollection<TItem, ICollection<TItem>>(source, CollectionQuantifier.AtLeast(minimum));
 	}
 
 	/// <summary>
 	///     Verifies that at most <paramref name="maximum" /> items in the collection...
 	/// </summary>
-	public static QuantifiableCollection<TItem> AtMost<TItem>(this That<IEnumerable<TItem>> source,
+	public static QuantifiableCollection<TItem, ICollection<TItem>> AtMost<TItem>(this That<ICollection<TItem>> source,
 		int maximum, [CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "")
 	{
 		source.ExpectationBuilder.AppendExpression(b
 			=> b.AppendMethod(nameof(AtMost), doNotPopulateThisValue));
-		return new QuantifiableCollection<TItem>(source, CollectionQuantifier.AtMost(maximum));
+		return new QuantifiableCollection<TItem, ICollection<TItem>>(source, CollectionQuantifier.AtMost(maximum));
 	}
 
 	/// <summary>
 	///     Verifies that between <paramref name="minimum" /> and <paramref name="maximum" /> items in the collection...
 	/// </summary>
-	public static QuantifiableCollection<TItem> Between<TItem>(this That<IEnumerable<TItem>> source,
+	public static QuantifiableCollection<TItem, ICollection<TItem>> Between<TItem>(this That<ICollection<TItem>> source,
 		int minimum, int maximum,
 		[CallerArgumentExpression("minimum")] string doNotPopulateThisValue1 = "",
 		[CallerArgumentExpression("maximum")] string doNotPopulateThisValue2 = "")
 	{
 		source.ExpectationBuilder.AppendExpression(b
 			=> b.AppendMethod(nameof(Between), doNotPopulateThisValue1, doNotPopulateThisValue2));
-		return new QuantifiableCollection<TItem>(source, CollectionQuantifier.Between(minimum, maximum));
+		return new QuantifiableCollection<TItem, ICollection<TItem>>(source, CollectionQuantifier.Between(minimum, maximum));
 	}
 
 	/// <summary>
 	///     Verifies that the actual collection contains the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>>
+	public static AndOrExpectationResult<ICollection<TItem>, That<ICollection<TItem>>>
 		Contains<TItem>(
-			this That<IEnumerable<TItem>> source,
+			this That<ICollection<TItem>> source,
 			TItem expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		=> new(source.ExpectationBuilder.Add(new ContainsConstraint<TItem>(expected),
@@ -72,9 +72,9 @@ public static partial class ThatCollectionExtensions
 	/// <summary>
 	///     Verifies that the actual collection is empty.
 	/// </summary>
-	public static AndOrExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>>
+	public static AndOrExpectationResult<ICollection<TItem>, That<ICollection<TItem>>>
 		IsEmpty<TItem>(
-			this That<IEnumerable<TItem>> source)
+			this That<ICollection<TItem>> source)
 		=> new(source.ExpectationBuilder.Add(new IsEmptyConstraint<TItem>(),
 				b => b.AppendMethod(nameof(IsEmpty))),
 			source);
@@ -82,9 +82,9 @@ public static partial class ThatCollectionExtensions
 	/// <summary>
 	///     Verifies that the actual collection is not empty.
 	/// </summary>
-	public static AndOrExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>>
+	public static AndOrExpectationResult<ICollection<TItem>, That<ICollection<TItem>>>
 		IsNotEmpty<TItem>(
-			this That<IEnumerable<TItem>> source)
+			this That<ICollection<TItem>> source)
 		=> new(source.ExpectationBuilder.Add(new IsNotEmptyConstraint<TItem>(),
 				b => b.AppendMethod(nameof(IsNotEmpty))),
 			source);
@@ -92,9 +92,9 @@ public static partial class ThatCollectionExtensions
 	/// <summary>
 	///     Verifies that no items in the collection...
 	/// </summary>
-	public static QuantifiableCollection<TItem> None<TItem>(this That<IEnumerable<TItem>> source)
+	public static QuantifiableCollection<TItem, ICollection<TItem>> None<TItem>(this That<ICollection<TItem>> source)
 	{
 		source.ExpectationBuilder.AppendExpression(b => b.AppendMethod(nameof(None)));
-		return new QuantifiableCollection<TItem>(source, CollectionQuantifier.None);
+		return new QuantifiableCollection<TItem, ICollection<TItem>>(source, CollectionQuantifier.None);
 	}
 }

--- a/Source/Testably.Expectations/Collections/ThatEnumerableExtensions.ContainsConstraint.cs
+++ b/Source/Testably.Expectations/Collections/ThatEnumerableExtensions.ContainsConstraint.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatEnumerableExtensions
+{
+	private readonly struct ContainsConstraint<TItem>(TItem expected)
+		: IConstraint<IEnumerable<TItem>>
+	{
+		public ConstraintResult IsMetBy(IEnumerable<TItem> actual)
+		{
+			foreach (var item in actual)
+			{
+				if (item?.Equals(expected) == true)
+				{
+					return new ConstraintResult.Success<IEnumerable<TItem>>(actual, ToString());
+				}
+			}
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual.Take(10).ToArray())}");
+		}
+
+		public override string ToString()
+			=> $"contains {Formatter.Format(expected)}";
+	}
+}

--- a/Source/Testably.Expectations/Collections/ThatEnumerableExtensions.IsEmptyConstraint.cs
+++ b/Source/Testably.Expectations/Collections/ThatEnumerableExtensions.IsEmptyConstraint.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatEnumerableExtensions
+{
+	private readonly struct IsEmptyConstraint<TItem> : IConstraint<IEnumerable<TItem>>
+	{
+		public ConstraintResult IsMetBy(IEnumerable<TItem> actual)
+		{
+			using var enumerator = actual.GetEnumerator();
+			if (enumerator.MoveNext())
+			{
+				return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual.Take(11))}");
+			}
+
+			return new ConstraintResult.Success<IEnumerable<TItem>>(actual, ToString());
+		}
+
+		public override string ToString()
+			=> "is empty";
+	}
+}

--- a/Source/Testably.Expectations/Collections/ThatEnumerableExtensions.IsNotEmptyConstraint.cs
+++ b/Source/Testably.Expectations/Collections/ThatEnumerableExtensions.IsNotEmptyConstraint.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using Testably.Expectations.Core.Constraints;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatEnumerableExtensions
+{
+	private readonly struct IsNotEmptyConstraint<TItem> : IConstraint<IEnumerable<TItem>>
+	{
+		public ConstraintResult IsMetBy(IEnumerable<TItem> actual)
+		{
+			using IEnumerator<TItem> enumerator = actual.GetEnumerator();
+			if (enumerator.MoveNext())
+			{
+				return new ConstraintResult.Success<IEnumerable<TItem>>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), "it was");
+		}
+
+		public override string ToString()
+			=> "is not empty";
+	}
+}

--- a/Source/Testably.Expectations/Collections/ThatEnumerableExtensions.cs
+++ b/Source/Testably.Expectations/Collections/ThatEnumerableExtensions.cs
@@ -1,0 +1,91 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Collections;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Core.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on enumerables.
+/// </summary>
+public static partial class ThatEnumerableExtensions
+{
+	/// <summary>
+	///     Verifies that at least <paramref name="minimum" /> items in the enumerable...
+	/// </summary>
+	public static QuantifiableCollection<TItem, IEnumerable<TItem>> AtLeast<TItem>(this That<IEnumerable<TItem>> source,
+		int minimum, [CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
+	{
+		source.ExpectationBuilder.AppendExpression(b
+			=> b.AppendMethod(nameof(AtLeast), doNotPopulateThisValue));
+		return new QuantifiableCollection<TItem, IEnumerable<TItem>>(source, CollectionQuantifier.AtLeast(minimum));
+	}
+
+	/// <summary>
+	///     Verifies that at most <paramref name="maximum" /> items in the enumerable...
+	/// </summary>
+	public static QuantifiableCollection<TItem, IEnumerable<TItem>> AtMost<TItem>(this That<IEnumerable<TItem>> source,
+		int maximum, [CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "")
+	{
+		source.ExpectationBuilder.AppendExpression(b
+			=> b.AppendMethod(nameof(AtMost), doNotPopulateThisValue));
+		return new QuantifiableCollection<TItem, IEnumerable<TItem>>(source, CollectionQuantifier.AtMost(maximum));
+	}
+
+	/// <summary>
+	///     Verifies that between <paramref name="minimum" /> and <paramref name="maximum" /> items in the enumerable...
+	/// </summary>
+	public static QuantifiableCollection<TItem, IEnumerable<TItem>> Between<TItem>(this That<IEnumerable<TItem>> source,
+		int minimum, int maximum,
+		[CallerArgumentExpression("minimum")] string doNotPopulateThisValue1 = "",
+		[CallerArgumentExpression("maximum")] string doNotPopulateThisValue2 = "")
+	{
+		source.ExpectationBuilder.AppendExpression(b
+			=> b.AppendMethod(nameof(Between), doNotPopulateThisValue1, doNotPopulateThisValue2));
+		return new QuantifiableCollection<TItem, IEnumerable<TItem>>(source, CollectionQuantifier.Between(minimum, maximum));
+	}
+
+	/// <summary>
+	///     Verifies that the actual enumerable contains the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>>
+		Contains<TItem>(
+			this That<IEnumerable<TItem>> source,
+			TItem expected,
+			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new ContainsConstraint<TItem>(expected),
+				b => b.AppendMethod(nameof(Contains), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the actual enumerable is empty.
+	/// </summary>
+	public static AndOrExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>>
+		IsEmpty<TItem>(
+			this That<IEnumerable<TItem>> source)
+		=> new(source.ExpectationBuilder.Add(new IsEmptyConstraint<TItem>(),
+				b => b.AppendMethod(nameof(IsEmpty))),
+			source);
+
+	/// <summary>
+	///     Verifies that the actual enumerable is not empty.
+	/// </summary>
+	public static AndOrExpectationResult<IEnumerable<TItem>, That<IEnumerable<TItem>>>
+		IsNotEmpty<TItem>(
+			this That<IEnumerable<TItem>> source)
+		=> new(source.ExpectationBuilder.Add(new IsNotEmptyConstraint<TItem>(),
+				b => b.AppendMethod(nameof(IsNotEmpty))),
+			source);
+
+	/// <summary>
+	///     Verifies that no items in the enumerable...
+	/// </summary>
+	public static QuantifiableCollection<TItem, IEnumerable<TItem>> None<TItem>(this That<IEnumerable<TItem>> source)
+	{
+		source.ExpectationBuilder.AppendExpression(b => b.AppendMethod(nameof(None)));
+		return new QuantifiableCollection<TItem, IEnumerable<TItem>>(source, CollectionQuantifier.None);
+	}
+}

--- a/Source/Testably.Expectations/Core/MaterializingEnumerable.cs
+++ b/Source/Testably.Expectations/Core/MaterializingEnumerable.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Testably.Expectations.Core;
+
+internal class MaterializingEnumerable<T> : IEnumerable<T>
+{
+	private readonly IEnumerator<T> _enumerator;
+	private readonly List<T> _materializedItems = new();
+
+	private MaterializingEnumerable(IEnumerable<T> enumerable)
+	{
+		_enumerator = enumerable.GetEnumerator();
+	}
+
+	#region IEnumerable<T> Members
+
+	/// <inheritdoc />
+	IEnumerator IEnumerable.GetEnumerator()
+		=> GetEnumerator();
+
+	/// <inheritdoc />
+	public IEnumerator<T> GetEnumerator()
+	{
+		foreach (T materializedItem in _materializedItems)
+		{
+			yield return materializedItem;
+		}
+
+		while (_enumerator.MoveNext())
+		{
+			T item = _enumerator.Current;
+			_materializedItems.Add(item);
+			yield return item;
+		}
+	}
+
+	#endregion
+
+	public static IEnumerable<T> Wrap(IEnumerable<T> enumerable)
+	{
+		if (enumerable is ICollection<T>)
+		{
+			return enumerable;
+		}
+
+		return new MaterializingEnumerable<T>(enumerable);
+	}
+}

--- a/Source/Testably.Expectations/Expect.Collections.cs
+++ b/Source/Testably.Expectations/Expect.Collections.cs
@@ -7,9 +7,17 @@ namespace Testably.Expectations;
 public static partial class Expect
 {
 	/// <summary>
-	///     Start delegate expectations on the current collection of <typeparamref name="TItem"/> values.
+	///     Start delegate expectations on the current enumerable of <typeparamref name="TItem" /> values.
 	/// </summary>
 	public static That<IEnumerable<TItem>> That<TItem>(IEnumerable<TItem> subject,
 		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
-		=> new(new ExpectationBuilder<IEnumerable<TItem>>(subject, doNotPopulateThisValue));
+		=> new(new ExpectationBuilder<IEnumerable<TItem>>(
+			MaterializingEnumerable<TItem>.Wrap(subject), doNotPopulateThisValue));
+
+	/// <summary>
+	///     Start delegate expectations on the current collection of <typeparamref name="TItem" /> values.
+	/// </summary>
+	public static That<ICollection<TItem>> That<TItem>(ICollection<TItem> subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<ICollection<TItem>>(subject, doNotPopulateThisValue));
 }

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.cs
@@ -1,20 +1,20 @@
 ﻿using System.Collections.Generic;
 
 namespace Testably.Expectations.Tests.Collections;
+
 public partial class ThatCollection
 {
 	public class MyClass
 	{
-		public string? Value { get; set; }
 		public InnerClass? Inner { get; set; }
+		public string? Value { get; set; }
 	}
 
 	public class InnerClass
 	{
-		public string? Value { get; set; }
+		public IEnumerable<string>? Collection { get; set; }
 
 		public InnerClass? Inner { get; set; }
-
-		public IEnumerable<string>? Collection { get; set; }
+		public string? Value { get; set; }
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.AtLeastAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.AtLeastAreTests.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using Testably.Expectations.Tests.TestHelpers;
+
+namespace Testably.Expectations.Tests.Collections;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed class AtLeastAreTests
+	{
+		[Fact]
+		public async Task DoesNotEnumerateTwice()
+		{
+			ThrowWhenIteratingTwiceEnumerable enumerable = new ThrowWhenIteratingTwiceEnumerable();
+
+			async Task Act()
+				=> await Expect.That(enumerable).AtLeast(0).Are(1)
+					.And.AtLeast(0).Are(1);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task DoesNotMaterializeEnumerable()
+		{
+			async Task Act()
+				=> await Expect.That(Factory.GetFibonacciNumbers()).AtLeast(2).Are(1);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenEnumerableContainsEnoughEqualItems_ShouldSucceed()
+		{
+			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+
+			async Task Act()
+				=> await Expect.That(enumerable).AtLeast(3).Are(1);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenEnumerableContainsTooFewEqualItems_ShouldFail()
+		{
+			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+
+			async Task Act()
+				=> await Expect.That(enumerable).AtLeast(5).Are(1);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that enumerable
+				                  has at least 5 items equal to 1,
+				                  but only 4 of 7 items were equal
+				                  at Expect.That(enumerable).AtLeast(5).Are(1)
+				                  """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.AtMostAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.AtMostAreTests.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Testably.Expectations.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Expectations.Tests.Collections;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed class AtMostAreTests
+	{
+		[Fact]
+		public async Task DoesNotEnumerateTwice()
+		{
+			ThrowWhenIteratingTwiceEnumerable enumerable = new ThrowWhenIteratingTwiceEnumerable();
+
+			async Task Act()
+				=> await Expect.That(enumerable).AtMost(3).Are(1)
+					.And.AtMost(3).Are(1);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task DoesNotMaterializeEnumerable()
+		{
+			async Task Act()
+				=> await Expect.That(Factory.GetFibonacciNumbers()).AtMost(1).Are(1);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that Factory.GetFibonacciNumbers()
+				                  has at most 1 item equal to 1,
+				                  but at least 2 items were equal
+				                  at Expect.That(Factory.GetFibonacciNumbers()).AtMost(1).Are(1)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenEnumerableContainsSufficientlyFewEqualItems_ShouldSucceed()
+		{
+			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+
+			async Task Act()
+				=> await Expect.That(enumerable).AtMost(3).Are(2);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenEnumerableContainsTooManyEqualItems_ShouldFail()
+		{
+			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+
+			async Task Act()
+				=> await Expect.That(enumerable).AtMost(3).Are(1);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that enumerable
+				                  has at most 3 items equal to 1,
+				                  but at least 4 items were equal
+				                  at Expect.That(enumerable).AtMost(3).Are(1)
+				                  """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.BetweenAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.BetweenAreTests.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Testably.Expectations.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Expectations.Tests.Collections;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed class BetweenAreTests
+	{
+		[Fact]
+		public async Task DoesNotEnumerateTwice()
+		{
+			ThrowWhenIteratingTwiceEnumerable enumerable = new ThrowWhenIteratingTwiceEnumerable();
+
+			async Task Act()
+				=> await Expect.That(enumerable).Between(0,2).Are(1)
+					.And.Between(0,1).Are(1);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task DoesNotMaterializeEnumerable()
+		{
+			async Task Act()
+				=> await Expect.That(Factory.GetFibonacciNumbers()).Between(0, 1).Are(1);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that Factory.GetFibonacciNumbers()
+				                  has between 0 and 1 items equal to 1,
+				                  but at least 2 items were equal
+				                  at Expect.That(Factory.GetFibonacciNumbers()).Between(0, 1).Are(1)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenEnumerableContainsSufficientlyEqualItems_ShouldSucceed()
+		{
+			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+
+			async Task Act()
+				=> await Expect.That(enumerable).Between(3, 4).Are(1);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenEnumerableContainsTooFewEqualItems_ShouldFail()
+		{
+			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+
+			async Task Act()
+				=> await Expect.That(enumerable).Between(3, 4).Are(2);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that enumerable
+				                  has between 3 and 4 items equal to 2,
+				                  but only 2 items were equal
+				                  at Expect.That(enumerable).Between(3, 4).Are(2)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenEnumerableContainsTooManyEqualItems_ShouldFail()
+		{
+			int[] enumerable = [1, 1, 1, 1, 2, 2, 3];
+
+			async Task Act()
+				=> await Expect.That(enumerable).Between(1, 3).Are(1);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that enumerable
+				                  has between 1 and 3 items equal to 1,
+				                  but 4 items were equal
+				                  at Expect.That(enumerable).Between(1, 3).Are(1)
+				                  """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.ContainsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.ContainsTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Testably.Expectations.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Expectations.Tests.Collections;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed class ContainsTests
+	{
+		[Fact]
+		public async Task DoesNotEnumerateTwice()
+		{
+			ThrowWhenIteratingTwiceEnumerable enumerable = new ThrowWhenIteratingTwiceEnumerable();
+
+			async Task Act()
+				=> await Expect.That(enumerable).Contains(1)
+					.And.Contains(1);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task DoesNotMaterializeEnumerable()
+		{
+			async Task Act()
+				=> await Expect.That(Factory.GetFibonacciNumbers()).Contains(5);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenEnumerableContainsExpectedValue_ShouldSucceed(List<string> enumerable,
+			string expected)
+		{
+			enumerable.Add(expected);
+
+			async Task Act()
+				=> await Expect.That(enumerable).Contains(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenEnumerableDoesNotContainsExpectedValue_ShouldFail(string[] enumerable,
+			string expected)
+		{
+			async Task Act()
+				=> await Expect.That(enumerable).Contains(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that enumerable
+				                   contains "{expected}",
+				                   but found ["{string.Join("\", \"", enumerable)}"]
+				                   at Expect.That(enumerable).Contains(expected)
+				                   """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.IsEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.IsEmptyTests.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Testably.Expectations.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Expectations.Tests.Collections;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed class IsEmptyTests
+	{
+		[Fact]
+		public async Task DoesNotMaterializeEnumerable()
+		{
+			async Task Act()
+				=> await Expect.That(Factory.GetFibonacciNumbers()).IsEmpty();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that Factory.GetFibonacciNumbers()
+				                  is empty,
+				                  but found [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, …]
+				                  at Expect.That(Factory.GetFibonacciNumbers()).IsEmpty()
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenEnumerableContainsValues_ShouldFail()
+		{
+			IEnumerable<int> enumerable = ToEnumerable([1, 1, 2]);
+
+			async Task Act()
+				=> await Expect.That(enumerable).IsEmpty();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that enumerable
+				                  is empty,
+				                  but found [1, 1, 2]
+				                  at Expect.That(enumerable).IsEmpty()
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenEnumerableIsEmpty_ShouldSucceed()
+		{
+			IEnumerable<int> enumerable = ToEnumerable([]);
+
+			async Task Act()
+				=> await Expect.That(enumerable).IsEmpty();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.IsNotEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.IsNotEmptyTests.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Testably.Expectations.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Expectations.Tests.Collections;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed class IsNotEmptyTests
+	{
+		[Fact]
+		public async Task DoesNotEnumerateTwice()
+		{
+			ThrowWhenIteratingTwiceEnumerable enumerable = new ThrowWhenIteratingTwiceEnumerable();
+
+			async Task Act()
+				=> await Expect.That(enumerable).IsNotEmpty()
+					.And.IsNotEmpty();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task DoesNotMaterializeEnumerable()
+		{
+			async Task Act()
+				=> await Expect.That(Factory.GetFibonacciNumbers()).IsNotEmpty();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenEnumerableContainsValues_ShouldSucceed()
+		{
+			IEnumerable<int> enumerable = ToEnumerable([1, 1, 2]);
+
+			async Task Act()
+				=> await Expect.That(enumerable).IsNotEmpty();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenEnumerableIsEmpty_ShouldFail()
+		{
+			IEnumerable<int> enumerable = ToEnumerable([]);
+
+			async Task Act()
+				=> await Expect.That(enumerable).IsNotEmpty();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that enumerable
+				                  is not empty,
+				                  but it was
+				                  at Expect.That(enumerable).IsNotEmpty()
+				                  """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.NoneAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.NoneAreTests.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Testably.Expectations.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Expectations.Tests.Collections;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed class NoneAreTests
+	{
+		[Fact]
+		public async Task DoesNotEnumerateTwice()
+		{
+			ThrowWhenIteratingTwiceEnumerable enumerable = new ThrowWhenIteratingTwiceEnumerable();
+
+			async Task Act()
+				=> await Expect.That(enumerable).None().Are(15)
+					.And.None().Are(81);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task DoesNotMaterializeEnumerable()
+		{
+			async Task Act()
+				=> await Expect.That(Factory.GetFibonacciNumbers()).None().Are(5);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that Factory.GetFibonacciNumbers()
+				                  has no items equal to 5,
+				                  but at least one items were equal
+				                  at Expect.That(Factory.GetFibonacciNumbers()).None().Are(5)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenEnumerableContainsEqualValues_ShouldFail()
+		{
+			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+
+			async Task Act()
+				=> await Expect.That(enumerable).None().Are(1);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that enumerable
+				                  has no items equal to 1,
+				                  but at least one items were equal
+				                  at Expect.That(enumerable).None().Are(1)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenEnumerableOnlyContainsDifferentValues_ShouldSucceed()
+		{
+			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+
+			async Task Act()
+				=> await Expect.That(enumerable).None().Are(42);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Testably.Expectations.Tests.Collections;
+
+public partial class ThatEnumerable
+{
+	public static IEnumerable<int> ToEnumerable(int[] items)
+	{
+		foreach (int item in items)
+		{
+			yield return item;
+		}
+	}
+
+	public sealed class ThrowWhenIteratingTwiceEnumerable : IEnumerable<int>
+	{
+		private bool _isEnumerated = false;
+
+		public IEnumerator<int> GetEnumerator()
+		{
+			if (_isEnumerated)
+			{ 
+				Fail.Test("The enumerable was enumerated twice!");
+			}
+
+			_isEnumerated = true;
+			yield return 1;
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+
+	public class MyClass
+	{
+		public InnerClass? Inner { get; set; }
+		public string? Value { get; set; }
+	}
+
+	public class InnerClass
+	{
+		public IEnumerable<string>? Collection { get; set; }
+
+		public InnerClass? Inner { get; set; }
+		public string? Value { get; set; }
+	}
+}

--- a/Tests/Testably.Expectations.Tests/TestHelpers/Factory.cs
+++ b/Tests/Testably.Expectations.Tests/TestHelpers/Factory.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace Testably.Expectations.Tests.TestHelpers;
+
+internal static class Factory
+{
+	/// <summary>
+	///     Returns an infinite <see cref="IEnumerable{T}" /> of fibonacci numbers.
+	/// </summary>
+	public static IEnumerable<int> GetFibonacciNumbers()
+	{
+		int a = 0, b = 1;
+
+		do
+		{
+			yield return b;
+			(a, b) = (b, a + b);
+		} while (true);
+	}
+}


### PR DESCRIPTION
Separate `IEnumerable` and `ICollection` and make sure, that `IEnumerable`s are only iterated twice and never fully materialized.