### PR TITLE
fix: `OnlyIf` for chained constraints on exceptions

### DIFF
--- a/Source/Testably.Expectations/Core/Constraints/ConstraintResult.cs
+++ b/Source/Testably.Expectations/Core/Constraints/ConstraintResult.cs
@@ -11,14 +11,14 @@ public abstract class ConstraintResult
 	private const string InvertDefaultResultText = "it did";
 
 	/// <summary>
-	/// Specifies if further processing of chained constraints should be ignored.
-	/// </summary>
-	public bool IgnoreFurtherProcessing { get; }
-
-	/// <summary>
 	///     A human-readable representation of the expectation.
 	/// </summary>
 	public string ExpectationText { get; }
+
+	/// <summary>
+	///     Specifies if further processing of chained constraints should be ignored.
+	/// </summary>
+	public bool IgnoreFurtherProcessing { get; }
 
 	/// <summary>
 	///     Initializes a new instance of <see cref="ConstraintResult" />.
@@ -62,7 +62,7 @@ public abstract class ConstraintResult
 			bool ignoreFurtherProcessing = false)
 			: base(
 				expectationText,
-			ignoreFurtherProcessing)
+				ignoreFurtherProcessing)
 		{
 		}
 

--- a/Source/Testably.Expectations/Core/Constraints/ConstraintResult.cs
+++ b/Source/Testably.Expectations/Core/Constraints/ConstraintResult.cs
@@ -11,6 +11,11 @@ public abstract class ConstraintResult
 	private const string InvertDefaultResultText = "it did";
 
 	/// <summary>
+	/// Specifies if further processing of chained constraints should be ignored.
+	/// </summary>
+	public bool IgnoreFurtherProcessing { get; }
+
+	/// <summary>
 	///     A human-readable representation of the expectation.
 	/// </summary>
 	public string ExpectationText { get; }
@@ -18,9 +23,12 @@ public abstract class ConstraintResult
 	/// <summary>
 	///     Initializes a new instance of <see cref="ConstraintResult" />.
 	/// </summary>
-	protected ConstraintResult(string expectationText)
+	protected ConstraintResult(
+		string expectationText,
+		bool ignoreFurtherProcessing)
 	{
 		ExpectationText = expectationText;
+		IgnoreFurtherProcessing = ignoreFurtherProcessing;
 	}
 
 	/// <summary>
@@ -47,9 +55,14 @@ public abstract class ConstraintResult
 	public class Success : ConstraintResult
 	{
 		/// <summary>
-		///     Initializes a new instance of <see cref="Success" />.
+		///     Initializes a new instance of <see cref="ConstraintResult.Success" />.
 		/// </summary>
-		public Success(string expectationText) : base(expectationText)
+		public Success(
+			string expectationText,
+			bool ignoreFurtherProcessing = false)
+			: base(
+				expectationText,
+			ignoreFurtherProcessing)
 		{
 		}
 
@@ -96,9 +109,15 @@ public abstract class ConstraintResult
 		public T Value { get; }
 
 		/// <summary>
-		///     Initializes a new instance of <see cref="Success{T}" />.
+		///     Initializes a new instance of <see cref="ConstraintResult.Success{T}" />.
 		/// </summary>
-		public Success(T value, string expectationText) : base(expectationText)
+		public Success(
+			T value,
+			string expectationText,
+			bool ignoreFurtherProcessing = false)
+			: base(
+				expectationText,
+				ignoreFurtherProcessing)
 		{
 			Value = value;
 		}
@@ -149,9 +168,15 @@ public abstract class ConstraintResult
 		public string ResultText { get; }
 
 		/// <summary>
-		///     Initializes a new instance of <see cref="Failure" />.
+		///     Initializes a new instance of <see cref="ConstraintResult.Failure" />.
 		/// </summary>
-		public Failure(string expectationText, string resultText) : base(expectationText)
+		public Failure(
+			string expectationText,
+			string resultText,
+			bool ignoreFurtherProcessing = false)
+			: base(
+				expectationText,
+				ignoreFurtherProcessing)
 		{
 			ResultText = resultText;
 		}
@@ -192,10 +217,17 @@ public abstract class ConstraintResult
 		public T Value { get; }
 
 		/// <summary>
-		///     Initializes a new instance of <see cref="Failure{T}" />.
+		///     Initializes a new instance of <see cref="ConstraintResult.Failure{T}" />.
 		/// </summary>
-		public Failure(T value, string expectationText, string resultText) : base(expectationText,
-			resultText)
+		public Failure(
+			T value,
+			string expectationText,
+			string resultText,
+			bool ignoreFurtherProcessing = false)
+			: base(
+				expectationText,
+				resultText,
+				ignoreFurtherProcessing)
 		{
 			Value = value;
 		}

--- a/Source/Testably.Expectations/Core/Nodes/AndNode.cs
+++ b/Source/Testably.Expectations/Core/Nodes/AndNode.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Testably.Expectations.Core.Constraints;
 
 namespace Testably.Expectations.Core.Nodes;
@@ -22,6 +21,11 @@ internal class AndNode : CombinationNode
 		where TValue : default
 	{
 		ConstraintResult leftResult = await Left.IsMetBy(value);
+		if (leftResult.IgnoreFurtherProcessing)
+		{
+			return leftResult;
+		}
+
 		ConstraintResult rightResult = await Right.IsMetBy(value);
 
 		string combinedExpectation =

--- a/Source/Testably.Expectations/Core/Nodes/CastNode.cs
+++ b/Source/Testably.Expectations/Core/Nodes/CastNode.cs
@@ -19,7 +19,7 @@ internal class CastNode<T1, T2> : ManipulationNode
 		where TValue : default
 	{
 		ConstraintResult? result = await TryMeet(Constraint, value);
-		if (Inner != None && result is ConstraintResult.Success<T2> success)
+		if (!result.IgnoreFurtherProcessing && Inner != None && result is ConstraintResult.Success<T2> success)
 		{
 			return await Inner.IsMetBy(new SourceValue<T2>(success.Value, value.Exception));
 		}

--- a/Source/Testably.Expectations/Core/Nodes/OrNode.cs
+++ b/Source/Testably.Expectations/Core/Nodes/OrNode.cs
@@ -21,6 +21,11 @@ internal class OrNode : CombinationNode
 		where TValue : default
 	{
 		ConstraintResult leftResult = await Left.IsMetBy(value);
+		if (leftResult.IgnoreFurtherProcessing)
+		{
+			return leftResult;
+		}
+
 		ConstraintResult rightResult = await Right.IsMetBy(value);
 
 		string combinedExpectation =

--- a/Source/Testably.Expectations/Core/Results/DelegateExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/DelegateExpectationResult.cs
@@ -7,17 +7,16 @@ namespace Testably.Expectations.Core.Results;
 /// <summary>
 ///     An <see cref="ExpectationResult" /> when an exception was thrown.
 /// </summary>
-/// <typeparam name="TException"></typeparam>
 public class
 	DelegateExpectationResult<TException> : ExpectationResult<TException,
 	DelegateExpectationResult<TException>>
-	where TException : Exception
+	where TException : Exception?
 {
 	/// <summary>
 	///     Additional expectations on the thrown <typeparamref name="TException" />.
 	/// </summary>
-	public That<TException?> Which
-		=> new(_expectationBuilder.Which<TException?, TException?>(
+	public That<TException> Which
+		=> new(_expectationBuilder.Which<TException, TException>(
 			PropertyAccessor<TException?, TException?>.FromFunc(p => p.Value, ""),
 			null,
 			b => b.Append(".").Append(nameof(Which)),
@@ -38,13 +37,13 @@ public class
 	///     Verifies, that the exception was thrown only if the <paramref name="predicate" /> is <see langword="true" />,
 	///     otherwise it verifies, that no exception was thrown.
 	/// </summary>
-	public DelegateExpectationResult<TException> OnlyIf(bool predicate,
+	public DelegateExpectationResult<TException?> OnlyIf(bool predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
 		_throwOptions.CheckThrow(predicate);
 		_expectationBuilder.AppendExpression(b
 			=> b.AppendMethod(nameof(OnlyIf), doNotPopulateThisValue));
-		return this;
+		return new DelegateExpectationResult<TException?>(_expectationBuilder, _throwOptions);
 	}
 }

--- a/Source/Testably.Expectations/Delegates/ThatDelegate.DoesNotThrowConstraint.cs
+++ b/Source/Testably.Expectations/Delegates/ThatDelegate.DoesNotThrowConstraint.cs
@@ -15,10 +15,10 @@ public abstract partial class ThatDelegate
 		if (exception is not null)
 		{
 			return new ConstraintResult.Failure<Exception?>(exception, DoesNotThrowExpectation,
-				$"it did throw {exception.FormatForMessage()}");
+				$"it did throw {exception.FormatForMessage()}", true);
 		}
 
-		return new ConstraintResult.Success<Exception?>(null, DoesNotThrowExpectation);
+		return new ConstraintResult.Success<Exception?>(null, DoesNotThrowExpectation, true);
 	}
 
 	private readonly struct DoesNotThrowConstraint<TValue> : IDelegateConstraint<TValue>

--- a/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.HasInnerExceptionConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.HasInnerExceptionConstraint.cs
@@ -13,7 +13,7 @@ public static partial class ThatExceptionExtensions
 	private readonly struct HasInnerExceptionConstraint<TInnerException>
 		: IConstraint<Exception?>,
 			IDelegateConstraint<DelegateSource.NoValue>
-		where TInnerException : Exception
+		where TInnerException : Exception?
 	{
 		/// <inheritdoc />
 		public ConstraintResult IsMetBy(Exception? actual)

--- a/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.HasMessageConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.HasMessageConstraint.cs
@@ -10,7 +10,7 @@ public static partial class ThatExceptionExtensions
 {
 	private readonly struct HasMessageConstraint<T>(StringMatcher expected) : IConstraint<T>,
 		IDelegateConstraint<DelegateSource.NoValue>
-		where T : Exception
+		where T : Exception?
 	{
 		public ConstraintResult IsMetBy(SourceValue<DelegateSource.NoValue> value)
 		{

--- a/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.HasParamNameConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.HasParamNameConstraint.cs
@@ -11,7 +11,7 @@ public static partial class ThatExceptionExtensions
 {
 	private readonly struct HasParamNameConstraint<T>(string expected) : IConstraint<T>,
 		IDelegateConstraint<DelegateSource.NoValue>
-		where T : ArgumentException
+		where T : ArgumentException?
 	{
 		public ConstraintResult IsMetBy(SourceValue<DelegateSource.NoValue> value)
 		{

--- a/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.cs
@@ -17,12 +17,12 @@ public static partial class ThatExceptionExtensions
 	///     Verifies that the actual exception has an inner exception of type <typeparamref name="TException" /> which
 	///     satisfies the <paramref name="expectations" />.
 	/// </summary>
-	public static AndOrExpectationResult<Exception, That<Exception?>> HasInner<TException>(
-		this That<Exception?> source,
+	public static AndOrExpectationResult<Exception, That<Exception>> HasInner<TException>(
+		this That<Exception> source,
 		Action<That<TException?>> expectations,
 		[CallerArgumentExpression("expectations")]
 		string doNotPopulateThisValue = "")
-		where TException : Exception
+		where TException : Exception?
 		=> new(source.ExpectationBuilder.WhichCast<Exception, Exception?, TException?>(
 				PropertyAccessor<Exception, Exception?>.FromFunc(e => e.Value?.InnerException,
 					$"has an inner {typeof(TException).Name} which "),
@@ -35,9 +35,9 @@ public static partial class ThatExceptionExtensions
 	/// <summary>
 	///     Verifies that the actual exception has an inner exception of type <typeparamref name="TException" />.
 	/// </summary>
-	public static AndOrExpectationResult<Exception, That<Exception?>> HasInner<TException>(
-		this That<Exception?> source)
-		where TException : Exception
+	public static AndOrExpectationResult<Exception, That<Exception>> HasInner<TException>(
+		this That<Exception> source)
+		where TException : Exception?
 		=> new(source.ExpectationBuilder.Add(
 				new HasInnerExceptionConstraint<TException>(),
 				b => b.AppendGenericMethod<TException>(nameof(HasInner))),
@@ -46,8 +46,8 @@ public static partial class ThatExceptionExtensions
 	/// <summary>
 	///     Verifies that the actual exception has an inner exception.
 	/// </summary>
-	public static AndOrExpectationResult<Exception, That<Exception?>> HasInnerException(
-		this That<Exception?> source)
+	public static AndOrExpectationResult<Exception, That<Exception>> HasInnerException(
+		this That<Exception> source)
 		=> new(source.ExpectationBuilder.Add(
 				new HasInnerExceptionConstraint<Exception>(),
 				b => b.AppendMethod(nameof(HasInnerException))),
@@ -56,7 +56,7 @@ public static partial class ThatExceptionExtensions
 	/// <summary>
 	///     Verifies that the actual exception has an inner exception which satisfies the <paramref name="expectations" />.
 	/// </summary>
-	public static AndOrExpectationResult<Exception, That<Exception?>> HasInnerException(
+	public static AndOrExpectationResult<Exception?, That<Exception?>> HasInnerException(
 		this That<Exception?> source,
 		Action<That<Exception?>> expectations,
 		[CallerArgumentExpression("expectations")]
@@ -72,11 +72,11 @@ public static partial class ThatExceptionExtensions
 	/// <summary>
 	///     Verifies that the actual exception has a message equal to <paramref name="expected" />
 	/// </summary>
-	public static StringMatcherExpectationResult<TException, That<TException?>> HasMessage<TException>(
-		this That<TException?> source,
+	public static StringMatcherExpectationResult<TException, That<TException>> HasMessage<TException>(
+		this That<TException> source,
 		StringMatcher expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		where TException : Exception
+		where TException : Exception?
 		=> new(source.ExpectationBuilder.Add(
 				new HasMessageConstraint<TException>(expected),
 				b => b.AppendMethod(nameof(HasMessage), doNotPopulateThisValue)),
@@ -86,11 +86,11 @@ public static partial class ThatExceptionExtensions
 	/// <summary>
 	///     Verifies that the actual exception has a message equal to <paramref name="expected" />
 	/// </summary>
-	public static AndOrExpectationResult<TException, That<TException?>> HasParamName<TException>(
+	public static AndOrExpectationResult<TException?, That<TException?>> HasParamName<TException>(
 		this That<TException?> source,
 		string expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		where TException : ArgumentException
+		where TException : ArgumentException?
 		=> new(source.ExpectationBuilder.Add(
 				new HasParamNameConstraint<TException>(expected),
 				b => b.AppendMethod(nameof(HasMessage), doNotPopulateThisValue)),
@@ -98,7 +98,7 @@ public static partial class ThatExceptionExtensions
 
 	private class CastException<TBase, TTarget> : IConstraint<TBase?, TTarget?>
 		where TBase : Exception
-		where TTarget : Exception
+		where TTarget : Exception?
 	{
 		#region IExpectation<TBase?,TTarget?> Members
 

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.OnlyIfTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.OnlyIfTests.cs
@@ -5,6 +5,16 @@ public sealed partial class ThatDelegate
 	public sealed class OnlyIfTests
 	{
 		[Fact]
+		public async Task ShouldSupportChainedConstraints()
+		{
+			Action action = () => { };
+
+			await Expect.That(action).ThrowsException()
+				.OnlyIf(false)
+				.Which.HasMessage("foo");
+		}
+
+		[Fact]
 		public async Task WhenTrue_ShouldSucceedWhenAnExceptionWasThrow()
 		{
 			Exception exception = new("");


### PR DESCRIPTION
Fixes #34
The following test which currently fails with an `InvalidOperationException`, now succeeds:
```csharp
  [Fact]
  public async Task ShouldSupportChainedConstraints()
  {
    Action action = () => { };
  
    await Expect.That(action).ThrowsException()
      .OnlyIf(false)
      .Which.HasMessage("foo");
  }
``` 