### PR TITLE
fix: `OnlyIf` for chained constraints on typed exceptions

### DIFF
--- a/Source/Testably.Expectations/Delegates/ThatDelegate.DoesNotThrowConstraint.cs
+++ b/Source/Testably.Expectations/Delegates/ThatDelegate.DoesNotThrowConstraint.cs
@@ -10,7 +10,8 @@ public abstract partial class ThatDelegate
 {
 	private static readonly string DoesNotThrowExpectation = "does not throw any exception";
 
-	private static ConstraintResult DoesNotThrowResult(Exception? exception)
+	private static ConstraintResult DoesNotThrowResult<TException>(Exception? exception)
+		where TException : Exception?
 	{
 		if (exception is not null)
 		{
@@ -18,7 +19,7 @@ public abstract partial class ThatDelegate
 				$"it did throw {exception.FormatForMessage()}", true);
 		}
 
-		return new ConstraintResult.Success<Exception?>(null, DoesNotThrowExpectation, true);
+		return new ConstraintResult.Success<TException?>(default, DoesNotThrowExpectation, true);
 	}
 
 	private readonly struct DoesNotThrowConstraint<TValue> : IDelegateConstraint<TValue>

--- a/Source/Testably.Expectations/Delegates/ThatDelegate.ThrowsConstraint.cs
+++ b/Source/Testably.Expectations/Delegates/ThatDelegate.ThrowsConstraint.cs
@@ -19,7 +19,7 @@ public abstract partial class ThatDelegate
 		{
 			if (!throwOptions.DoCheckThrow)
 			{
-				return DoesNotThrowResult(exception);
+				return DoesNotThrowResult<TException>(exception);
 			}
 
 			if (exception is TException typedException)

--- a/Source/Testably.Expectations/Delegates/ThatDelegate.ThrowsExactlyConstraint.cs
+++ b/Source/Testably.Expectations/Delegates/ThatDelegate.ThrowsExactlyConstraint.cs
@@ -19,7 +19,7 @@ public abstract partial class ThatDelegate
 		{
 			if (!throwOptions.DoCheckThrow)
 			{
-				return DoesNotThrowResult(exception);
+				return DoesNotThrowResult<Exception>(exception);
 			}
 
 			if (exception is TException typedException && exception.GetType() == typeof(TException))

--- a/Source/Testably.Expectations/Delegates/ThatDelegate.ThrowsOption.cs
+++ b/Source/Testably.Expectations/Delegates/ThatDelegate.ThrowsOption.cs
@@ -1,9 +1,6 @@
 ﻿// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
-/// <summary>
-///     Expectations on delegate values.
-/// </summary>
 public abstract partial class ThatDelegate
 {
 	internal class ThrowsOption

--- a/Source/Testably.Expectations/Delegates/ThatDelegate.ThrowsOption.cs
+++ b/Source/Testably.Expectations/Delegates/ThatDelegate.ThrowsOption.cs
@@ -1,0 +1,18 @@
+﻿// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on delegate values.
+/// </summary>
+public abstract partial class ThatDelegate
+{
+	internal class ThrowsOption
+	{
+		public bool DoCheckThrow { get; private set; } = true;
+
+		public void CheckThrow(bool doCheckThrow)
+		{
+			DoCheckThrow = doCheckThrow;
+		}
+	}
+}

--- a/Source/Testably.Expectations/Delegates/ThatDelegate.cs
+++ b/Source/Testably.Expectations/Delegates/ThatDelegate.cs
@@ -58,14 +58,4 @@ public abstract partial class ThatDelegate
 			b => b.AppendMethod(nameof(ThrowsException))),
 			throwOptions);
 	}
-
-	internal class ThrowsOption
-	{
-		public bool DoCheckThrow { get; private set; } = true;
-
-		public void CheckThrow(bool doCheckThrow)
-		{
-			DoCheckThrow = doCheckThrow;
-		}
-	}
 }

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.OnlyIfTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.OnlyIfTests.cs
@@ -15,42 +15,13 @@ public sealed partial class ThatDelegate
 		}
 
 		[Fact]
-		public async Task WhenTrue_ShouldSucceedWhenAnExceptionWasThrow()
-		{
-			Exception exception = new("");
-			Action action = () => throw exception;
-
-			async Task Act()
-				=> await Expect.That(action).ThrowsException().OnlyIf(true);
-
-			await Expect.That(Act).DoesNotThrow();
-		}
-
-		[Fact]
-		public async Task WhenFalse_ShouldSucceedWhenNoExceptionWasThrown()
+		public async Task ShouldSupportChainedConstraintsForTypedException()
 		{
 			Action action = () => { };
 
-			async Task Act()
-				=> await Expect.That(action).ThrowsException().OnlyIf(false);
-
-			await Expect.That(Act).DoesNotThrow();
-		}
-		[Fact]
-		public async Task WhenTrue_ShouldFailWhenNoExceptionWasThrow()
-		{
-			Action action = () => { };
-
-			async Task Act()
-				=> await Expect.That(action).ThrowsException().OnlyIf(true);
-
-			await Expect.That(Act).ThrowsException()
-				.Which.HasMessage("""
-				                  Expected that action
-				                  throws an Exception,
-				                  but it did not
-				                  at Expect.That(action).ThrowsException().OnlyIf(true)
-				                  """);
+			await Expect.That(action).Throws<ArgumentException>()
+				.OnlyIf(false)
+				.Which.HasMessage("foo");
 		}
 
 		[Fact]
@@ -69,6 +40,46 @@ public sealed partial class ThatDelegate
 				                  but it did throw an Exception
 				                  at Expect.That(action).ThrowsException().OnlyIf(false)
 				                  """);
+		}
+
+		[Fact]
+		public async Task WhenFalse_ShouldSucceedWhenNoExceptionWasThrown()
+		{
+			Action action = () => { };
+
+			async Task Act()
+				=> await Expect.That(action).ThrowsException().OnlyIf(false);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenTrue_ShouldFailWhenNoExceptionWasThrow()
+		{
+			Action action = () => { };
+
+			async Task Act()
+				=> await Expect.That(action).ThrowsException().OnlyIf(true);
+
+			await Expect.That(Act).ThrowsException()
+				.Which.HasMessage("""
+				                  Expected that action
+				                  throws an Exception,
+				                  but it did not
+				                  at Expect.That(action).ThrowsException().OnlyIf(true)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenTrue_ShouldSucceedWhenAnExceptionWasThrow()
+		{
+			Exception exception = new("");
+			Action action = () => throw exception;
+
+			async Task Act()
+				=> await Expect.That(action).ThrowsException().OnlyIf(true);
+
+			await Expect.That(Act).DoesNotThrow();
 		}
 	}
 }


### PR DESCRIPTION
Building on top of #35 fixes #34 also for typed exceptions:
```csharp
  [Fact]
  public async Task ShouldSupportChainedConstraints()
  {
    Action action = () => { };
  
    await Expect.That(action).Throws<MyCustomException>()
      .OnlyIf(false)
      .Which.HasMessage("foo");
  }
``` 