### PR TITLE
feat: add string `StartsWith` and `EndsWith`

### DIFF
--- a/Source/Testably.Expectations/Core/Results/StringExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/StringExpectationResult.cs
@@ -35,7 +35,7 @@ public class StringExpectationResult<TResult, TValue, TSelf>(
 	: AndOrExpectationResult<TResult, TValue, TSelf>(expectationBuilder, returnValue)
 	where TSelf : StringExpectationResult<TResult, TValue, TSelf>
 {
-	private readonly IExpectationBuilder _expectationBuilder1 = expectationBuilder;
+	private readonly IExpectationBuilder _expectationBuilder = expectationBuilder;
 
 	/// <summary>
 	///     Ignores casing when comparing the <see langword="string" />s.
@@ -43,7 +43,7 @@ public class StringExpectationResult<TResult, TValue, TSelf>(
 	public StringExpectationResult<TResult, TValue, TSelf> IgnoringCase()
 	{
 		options.IgnoringCase();
-		_expectationBuilder1.AppendExpression(b => b.AppendMethod(nameof(IgnoringCase)));
+		_expectationBuilder.AppendExpression(b => b.AppendMethod(nameof(IgnoringCase)));
 		return this;
 	}
 
@@ -55,7 +55,7 @@ public class StringExpectationResult<TResult, TValue, TSelf>(
 		[CallerArgumentExpression("ignoreCase")] string doNotPopulateThisValue = "")
 	{
 		options.IgnoringCase(ignoreCase);
-		_expectationBuilder1.AppendExpression(b => b.AppendMethod(nameof(IgnoringCase), doNotPopulateThisValue));
+		_expectationBuilder.AppendExpression(b => b.AppendMethod(nameof(IgnoringCase), doNotPopulateThisValue));
 		return this;
 	}
 
@@ -67,7 +67,7 @@ public class StringExpectationResult<TResult, TValue, TSelf>(
 		[CallerArgumentExpression("comparer")] string doNotPopulateThisValue = "")
 	{
 		options.UsingComparer(comparer);
-		_expectationBuilder1.AppendExpression(b
+		_expectationBuilder.AppendExpression(b
 			=> b.AppendMethod(nameof(Using), doNotPopulateThisValue));
 		return this;
 	}

--- a/Source/Testably.Expectations/Core/Results/StringExpectationResult.cs
+++ b/Source/Testably.Expectations/Core/Results/StringExpectationResult.cs
@@ -48,6 +48,18 @@ public class StringExpectationResult<TResult, TValue, TSelf>(
 	}
 
 	/// <summary>
+	///     Ignores casing when comparing the <see langword="string" />s, according to the <paramref name="ignoreCase" /> parameter.
+	/// </summary>
+	public StringExpectationResult<TResult, TValue, TSelf> IgnoringCase(
+		bool ignoreCase,
+		[CallerArgumentExpression("ignoreCase")] string doNotPopulateThisValue = "")
+	{
+		options.IgnoringCase(ignoreCase);
+		_expectationBuilder1.AppendExpression(b => b.AppendMethod(nameof(IgnoringCase), doNotPopulateThisValue));
+		return this;
+	}
+
+	/// <summary>
 	///     Uses the provided <paramref name="comparer" /> for comparing <see langword="string" />s.
 	/// </summary>
 	public StringExpectationResult<TResult, TValue, TSelf> Using(

--- a/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Exceptions/ThatExceptionExtensions.cs
@@ -86,8 +86,8 @@ public static partial class ThatExceptionExtensions
 	/// <summary>
 	///     Verifies that the actual exception has a message equal to <paramref name="expected" />
 	/// </summary>
-	public static AndOrExpectationResult<TException?, That<TException?>> HasParamName<TException>(
-		this That<TException?> source,
+	public static AndOrExpectationResult<TException, That<TException>> HasParamName<TException>(
+		this That<TException> source,
 		string expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		where TException : ArgumentException?

--- a/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.DoesNotEndWithConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.DoesNotEndWithConstraint.cs
@@ -1,0 +1,41 @@
+﻿using Testably.Expectations.Core;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatStringExtensions
+{
+	private readonly struct DoesNotEndWithConstraint(
+		string expected,
+		StringOptions options)
+		: IConstraint<string?>
+	{
+		/// <inheritdoc />
+		public ConstraintResult IsMetBy(string? actual)
+		{
+			if (actual is null)
+			{
+				return new ConstraintResult.Failure<string?>(actual, ToString(),
+					"found <null>");
+			}
+
+			if (expected.Length <= actual.Length &&
+			    options.Comparer.Equals(
+				    actual.Substring(actual.Length - expected.Length, expected.Length), expected))
+			{
+				return new ConstraintResult.Failure<string?>(actual, ToString(),
+					$"found {Formatter.Format(actual)}");
+			}
+
+			return new ConstraintResult.Success<string?>(actual, ToString());
+		}
+
+		/// <inheritdoc />
+		public override string ToString()
+		{
+			return $"does not end with {Formatter.Format(expected)}{options}";
+		}
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.DoesNotStartWithConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.DoesNotStartWithConstraint.cs
@@ -1,0 +1,40 @@
+﻿using Testably.Expectations.Core;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatStringExtensions
+{
+	private readonly struct DoesNotStartWithConstraint(
+		string expected,
+		StringOptions options)
+		: IConstraint<string?>
+	{
+		/// <inheritdoc />
+		public ConstraintResult IsMetBy(string? actual)
+		{
+			if (actual is null)
+			{
+				return new ConstraintResult.Failure<string?>(actual, ToString(),
+					"found <null>");
+			}
+
+			if (expected.Length <= actual.Length &&
+			    options.Comparer.Equals(actual.Substring(0, expected.Length), expected))
+			{
+				return new ConstraintResult.Failure<string?>(actual, ToString(),
+					$"found {Formatter.Format(actual)}");
+			}
+
+			return new ConstraintResult.Success<string?>(actual, ToString());
+		}
+
+		/// <inheritdoc />
+		public override string ToString()
+		{
+			return $"does not start with {Formatter.Format(expected)}{options}";
+		}
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.EndsWithConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.EndsWithConstraint.cs
@@ -1,0 +1,45 @@
+﻿using Testably.Expectations.Core;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatStringExtensions
+{
+	private readonly struct EndsWithConstraint(
+		string expected,
+		StringOptions options)
+		: IConstraint<string?>
+	{
+		/// <inheritdoc />
+		public ConstraintResult IsMetBy(string? actual)
+		{
+			if (actual is null)
+			{
+				return new ConstraintResult.Failure<string?>(actual, ToString(),
+					"found <null>");
+			}
+
+			if (expected.Length > actual.Length)
+			{
+				return new ConstraintResult.Failure<string?>(actual, ToString(),
+					$"it had only length {actual.Length} which is shorter than the expected length of {expected.Length}");
+			}
+
+			if (options.Comparer.Equals(actual.Substring(actual.Length - expected.Length, expected.Length), expected))
+			{
+				return new ConstraintResult.Success<string?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure<string?>(actual, ToString(),
+				$"found {Formatter.Format(actual)}");
+		}
+
+		/// <inheritdoc />
+		public override string ToString()
+		{
+			return $"ends with {Formatter.Format(expected)}{options}";
+		}
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.StartsWithConstraint.cs
+++ b/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.StartsWithConstraint.cs
@@ -1,0 +1,45 @@
+﻿using Testably.Expectations.Core;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatStringExtensions
+{
+	private readonly struct StartsWithConstraint(
+		string expected,
+		StringOptions options)
+		: IConstraint<string?>
+	{
+		/// <inheritdoc />
+		public ConstraintResult IsMetBy(string? actual)
+		{
+			if (actual is null)
+			{
+				return new ConstraintResult.Failure<string?>(actual, ToString(),
+					"found <null>");
+			}
+
+			if (expected.Length > actual.Length)
+			{
+				return new ConstraintResult.Failure<string?>(actual, ToString(),
+					$"it had only length {actual.Length} which is shorter than the expected length of {expected.Length}");
+			}
+
+			if (options.Comparer.Equals(actual.Substring(0, expected.Length), expected))
+			{
+				return new ConstraintResult.Success<string?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure<string?>(actual, ToString(),
+				$"found {Formatter.Format(actual)}");
+		}
+
+		/// <inheritdoc />
+		public override string ToString()
+		{
+			return $"starts with {Formatter.Format(expected)}{options}";
+		}
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.cs
@@ -43,6 +43,24 @@ public static partial class ThatStringExtensions
 	}
 
 	/// <summary>
+	///     Verifies that the subject contains the <paramref name="unexpected" /> <see langword="string" />.
+	/// </summary>
+	public static StringExpectationResult<string?, That<string?>> DoesNotContain(
+		this That<string?> source,
+		string unexpected,
+		[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+	{
+		var quantifier = new Quantifier();
+		quantifier.Exactly(0);
+		var options = new StringOptions();
+		return new StringExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
+				new ContainsConstraint(unexpected, quantifier, options),
+				b => b.AppendMethod(nameof(DoesNotContain), doNotPopulateThisValue)),
+			source,
+			options);
+	}
+
+	/// <summary>
 	///     Verifies that the subject starts with the <paramref name="expected" /> <see langword="string" />.
 	/// </summary>
 	public static StringExpectationResult<string?, That<string?>> StartsWith(
@@ -54,6 +72,22 @@ public static partial class ThatStringExtensions
 		return new StringExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
 				new StartsWithConstraint(expected, options),
 				b => b.AppendMethod(nameof(StartsWith), doNotPopulateThisValue)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject does not start with the <paramref name="unexpected" /> <see langword="string" />.
+	/// </summary>
+	public static StringExpectationResult<string?, That<string?>> DoesNotStartWith(
+		this That<string?> source,
+		string unexpected,
+		[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+	{
+		var options = new StringOptions();
+		return new StringExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
+				new DoesNotStartWithConstraint(unexpected, options),
+				b => b.AppendMethod(nameof(DoesNotStartWith), doNotPopulateThisValue)),
 			source,
 			options);
 	}
@@ -75,64 +109,20 @@ public static partial class ThatStringExtensions
 	}
 
 	/// <summary>
-	///     Verifies that the subject does not start with the <paramref name="expected" /> <see langword="string" />.
-	/// </summary>
-	public static StringExpectationResult<string?, That<string?>> DoesNotStartWith(
-		this That<string?> source,
-		string expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-	{
-		var options = new StringOptions();
-		return new StringExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
-				new DoesNotStartWithConstraint(expected, options),
-				b => b.AppendMethod(nameof(DoesNotStartWith), doNotPopulateThisValue)),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject does not end with the <paramref name="expected" /> <see langword="string" />.
+	///     Verifies that the subject does not end with the <paramref name="unexpected" /> <see langword="string" />.
 	/// </summary>
 	public static StringExpectationResult<string?, That<string?>> DoesNotEndWith(
-		this That<string?> source,
-		string expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-	{
-		var options = new StringOptions();
-		return new StringExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
-				new DoesNotEndWithConstraint(expected, options),
-				b => b.AppendMethod(nameof(DoesNotEndWith), doNotPopulateThisValue)),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject contains the <paramref name="unexpected" /> <see langword="string" />.
-	/// </summary>
-	public static StringExpectationResult<string?, That<string?>> DoesNotContain(
 		this That<string?> source,
 		string unexpected,
 		[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		var quantifier = new Quantifier();
-		quantifier.Exactly(0);
 		var options = new StringOptions();
 		return new StringExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
-				new ContainsConstraint(unexpected, quantifier, options),
-				b => b.AppendMethod(nameof(DoesNotContain), doNotPopulateThisValue)),
+				new DoesNotEndWithConstraint(unexpected, options),
+				b => b.AppendMethod(nameof(DoesNotEndWith), doNotPopulateThisValue)),
 			source,
 			options);
 	}
-
-	/// <summary>
-	///     Verifies that the subject is not <see langword="null" />.
-	/// </summary>
-	public static AndOrExpectationResult<string, That<string?>> IsNotNull(
-		this That<string?> source)
-		=> new(source.ExpectationBuilder.Add(
-				new IsNotNullConstraint(),
-				b => b.AppendMethod(nameof(IsNotNull))),
-			source);
 
 	/// <summary>
 	///     Verifies that the subject is <see langword="null" />.
@@ -142,5 +132,15 @@ public static partial class ThatStringExtensions
 		=> new(source.ExpectationBuilder.Add(
 				new IsNullConstraint(),
 				b => b.AppendMethod(nameof(IsNull))),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not <see langword="null" />.
+	/// </summary>
+	public static AndOrExpectationResult<string, That<string?>> IsNotNull(
+		this That<string?> source)
+		=> new(source.ExpectationBuilder.Add(
+				new IsNotNullConstraint(),
+				b => b.AppendMethod(nameof(IsNotNull))),
 			source);
 }

--- a/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Strings/ThatStringExtensions.cs
@@ -43,6 +43,70 @@ public static partial class ThatStringExtensions
 	}
 
 	/// <summary>
+	///     Verifies that the subject starts with the <paramref name="expected" /> <see langword="string" />.
+	/// </summary>
+	public static StringExpectationResult<string?, That<string?>> StartsWith(
+		this That<string?> source,
+		string expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		var options = new StringOptions();
+		return new StringExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
+				new StartsWithConstraint(expected, options),
+				b => b.AppendMethod(nameof(StartsWith), doNotPopulateThisValue)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject ends with the <paramref name="expected" /> <see langword="string" />.
+	/// </summary>
+	public static StringExpectationResult<string?, That<string?>> EndsWith(
+		this That<string?> source,
+		string expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		var options = new StringOptions();
+		return new StringExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
+				new EndsWithConstraint(expected, options),
+				b => b.AppendMethod(nameof(EndsWith), doNotPopulateThisValue)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject does not start with the <paramref name="expected" /> <see langword="string" />.
+	/// </summary>
+	public static StringExpectationResult<string?, That<string?>> DoesNotStartWith(
+		this That<string?> source,
+		string expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		var options = new StringOptions();
+		return new StringExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
+				new DoesNotStartWithConstraint(expected, options),
+				b => b.AppendMethod(nameof(DoesNotStartWith), doNotPopulateThisValue)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject does not end with the <paramref name="expected" /> <see langword="string" />.
+	/// </summary>
+	public static StringExpectationResult<string?, That<string?>> DoesNotEndWith(
+		this That<string?> source,
+		string expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		var options = new StringOptions();
+		return new StringExpectationResult<string?, That<string?>>(source.ExpectationBuilder.Add(
+				new DoesNotEndWithConstraint(expected, options),
+				b => b.AppendMethod(nameof(DoesNotEndWith), doNotPopulateThisValue)),
+			source,
+			options);
+	}
+
+	/// <summary>
 	///     Verifies that the subject contains the <paramref name="unexpected" /> <see langword="string" />.
 	/// </summary>
 	public static StringExpectationResult<string?, That<string?>> DoesNotContain(

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.ContainsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.ContainsTests.cs
@@ -422,6 +422,42 @@ public sealed partial class ThatString
 		}
 
 		[Fact]
+		public async Task
+			Using_WhenExpectedStringOccursEnoughTimesForTheComparer_ShouldSucceed()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Exactly(4)
+					.Using(new IgnoreCaseForVocalsComparer());
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task
+			Using_WhenExpectedStringOccursIncorrectTimesForTheComparer_ShouldIncludeComparerInMessage()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "in";
+
+			async Task Act()
+				=> await Expect.That(actual).Contains(expected).Exactly(5)
+					.Using(new IgnoreCaseForVocalsComparer());
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  contains "in" exactly 5 times using IgnoreCaseForVocalsComparer,
+				                  but found it 4 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).Contains(expected).Exactly(5).Using(new IgnoreCaseForVocalsComparer())
+				                  """);
+		}
+
+		[Fact]
 		public async Task WhenExpectedStringIsContained_ShouldSucceed()
 		{
 			string actual = "some text";

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotContainTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotContainTests.cs
@@ -22,6 +22,25 @@ public sealed partial class ThatString
 				                  at Expect.That(actual).DoesNotContain(expected).IgnoringCase()
 				                  """);
 		}
+		[Fact]
+		public async Task Using_ShouldIncludeComparerInExpectationText()
+		{
+			string actual =
+				"In this text in between the word an investigator should find the word 'IN' multiple times.";
+			string expected = "InvEstIgAtOr";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotContain(expected).Using(new IgnoreCaseForVocalsComparer());
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  does not contain "InvEstIgAtOr" using IgnoreCaseForVocalsComparer,
+				                  but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+				                  at Expect.That(actual).DoesNotContain(expected).Using(new IgnoreCaseForVocalsComparer())
+				                  """);
+		}
+
 
 		[Fact]
 		public async Task WhenExpectedStringIsContained_ShouldFail()

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotEndWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotEndWithTests.cs
@@ -1,25 +1,9 @@
-﻿using System.Threading.Tasks;
-using Xunit.Sdk;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Primitives.Strings;
+﻿namespace Testably.Expectations.Tests.Primitives.Strings;
 
 public sealed partial class ThatString
 {
 	public class DoesNotEndWithTests
 	{
-		[Fact]
-		public async Task IgnoringCase_WhenSubjectDoesNotEndWithWithExpected_ShouldSucceed()
-		{
-			string actual = "some text";
-			string expected = "some";
-
-			async Task Act()
-				=> await Expect.That(actual).DoesNotEndWith(expected);
-
-			await Expect.That(Act).DoesNotThrow();
-		}
-
 		[Fact]
 		public async Task IgnoringCase_WhenSubjectDoesEndWithExpected_ShouldFail()
 		{
@@ -37,14 +21,49 @@ public sealed partial class ThatString
 				                  at Expect.That(actual).DoesNotEndWith(expected)
 				                  """);
 		}
+
 		[Fact]
-		public async Task WhenSubjectDoesNotEndWithWithExpected_ShouldSucceed()
+		public async Task IgnoringCase_WhenSubjectDoesNotEndWithWithExpected_ShouldSucceed()
 		{
 			string actual = "some text";
 			string expected = "some";
 
 			async Task Act()
 				=> await Expect.That(actual).DoesNotEndWith(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task
+			Using_WhenSubjectDoesEndWithExpected_ShouldFail()
+		{
+			string actual = "some arbitrary text";
+			string expected = "tExt";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotEndWith(expected)
+					.Using(new IgnoreCaseForVocalsComparer());
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  does not end with "tExt" using IgnoreCaseForVocalsComparer,
+				                  but found "some arbitrary text"
+				                  at Expect.That(actual).DoesNotEndWith(expected).Using(new IgnoreCaseForVocalsComparer())
+				                  """);
+		}
+
+		[Fact]
+		public async Task
+			Using_WhenSubjectDoesNotEndWithWithExpected_ShouldSucceed()
+		{
+			string actual = "some arbitrary text";
+			string expected = "TEXT";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotEndWith(expected)
+					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -65,6 +84,18 @@ public sealed partial class ThatString
 				                  but found "some text"
 				                  at Expect.That(actual).DoesNotEndWith(expected)
 				                  """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectDoesNotEndWithWithExpected_ShouldSucceed()
+		{
+			string actual = "some text";
+			string expected = "some";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotEndWith(expected);
+
+			await Expect.That(Act).DoesNotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotEndWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotEndWithTests.cs
@@ -1,0 +1,70 @@
+﻿using System.Threading.Tasks;
+using Xunit.Sdk;
+using Xunit;
+
+namespace Testably.Expectations.Tests.Primitives.Strings;
+
+public sealed partial class ThatString
+{
+	public class DoesNotEndWithTests
+	{
+		[Fact]
+		public async Task IgnoringCase_WhenSubjectDoesNotEndWithWithExpected_ShouldSucceed()
+		{
+			string actual = "some text";
+			string expected = "some";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotEndWith(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task IgnoringCase_WhenSubjectDoesEndWithExpected_ShouldFail()
+		{
+			string actual = "some text";
+			string expected = "text";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotEndWith(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  does not end with "text",
+				                  but found "some text"
+				                  at Expect.That(actual).DoesNotEndWith(expected)
+				                  """);
+		}
+		[Fact]
+		public async Task WhenSubjectDoesNotEndWithWithExpected_ShouldSucceed()
+		{
+			string actual = "some text";
+			string expected = "some";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotEndWith(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectDoesEndWithExpected_ShouldFail()
+		{
+			string actual = "some text";
+			string expected = "text";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotEndWith(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  does not end with "text",
+				                  but found "some text"
+				                  at Expect.That(actual).DoesNotEndWith(expected)
+				                  """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotStartWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotStartWithTests.cs
@@ -1,0 +1,37 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Strings;
+
+public sealed partial class ThatString
+{
+	public class DoesNotStartWithTests
+	{
+		[Fact]
+		public async Task WhenSubjectDoesNotStartWithExpected_ShouldSucceed()
+		{
+			string actual = "some text";
+			string expected = "text";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotStartWith(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectDoesStartWithExpected_ShouldFail()
+		{
+			string actual = "some text";
+			string expected = "some";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotStartWith(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  does not start with "some",
+				                  but found "some text"
+				                  at Expect.That(actual).DoesNotStartWith(expected)
+				                  """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotStartWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotStartWithTests.cs
@@ -5,6 +5,70 @@ public sealed partial class ThatString
 	public class DoesNotStartWithTests
 	{
 		[Fact]
+		public async Task IgnoringCase_WhenSubjectDoesStartWithExpected_ShouldFail()
+		{
+			string actual = "some text";
+			string expected = "some";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotStartWith(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  does not start with "some",
+				                  but found "some text"
+				                  at Expect.That(actual).DoesNotStartWith(expected)
+				                  """);
+		}
+
+		[Fact]
+		public async Task IgnoringCase_WhenSubjectDoesNotStartWithWithExpected_ShouldSucceed()
+		{
+			string actual = "some text";
+			string expected = "text";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotStartWith(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task
+			Using_WhenSubjectDoesStartWithExpected_ShouldFail()
+		{
+			string actual = "some arbitrary text";
+			string expected = "sOmE";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotStartWith(expected)
+					.Using(new IgnoreCaseForVocalsComparer());
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  does not start with "sOmE" using IgnoreCaseForVocalsComparer,
+				                  but found "some arbitrary text"
+				                  at Expect.That(actual).DoesNotStartWith(expected).Using(new IgnoreCaseForVocalsComparer())
+				                  """);
+		}
+
+		[Fact]
+		public async Task
+			Using_WhenSubjectDoesNotStartWithWithExpected_ShouldSucceed()
+		{
+			string actual = "some arbitrary text";
+			string expected = "SOME";
+
+			async Task Act()
+				=> await Expect.That(actual).DoesNotStartWith(expected)
+					.Using(new IgnoreCaseForVocalsComparer());
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
 		public async Task WhenSubjectDoesNotStartWithExpected_ShouldSucceed()
 		{
 			string actual = "some text";

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.EndsWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.EndsWithTests.cs
@@ -1,0 +1,37 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Strings;
+
+public sealed partial class ThatString
+{
+	public class EndsWithTests
+	{
+		[Fact]
+		public async Task WhenSubjectEndsWithExpected_ShouldSucceed()
+		{
+			string actual = "some text";
+			string expected = "text";
+
+			async Task Act()
+				=> await Expect.That(actual).EndsWith(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectDoesNotEndWithExpected_ShouldFail()
+		{
+			string actual = "some text";
+			string expected = "some";
+
+			async Task Act()
+				=> await Expect.That(actual).EndsWith(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  ends with "some",
+				                  but found "some text"
+				                  at Expect.That(actual).EndsWith(expected)
+				                  """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.EndsWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.EndsWithTests.cs
@@ -4,14 +4,78 @@ public sealed partial class ThatString
 {
 	public class EndsWithTests
 	{
-		[Fact]
-		public async Task WhenSubjectEndsWithExpected_ShouldSucceed()
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public async Task
+			IgnoringCase_WhenSubjectEndsWithDifferentCase_ShouldFailUnlessCaseIsIgnored(
+				bool ignoreCase)
 		{
-			string actual = "some text";
-			string expected = "text";
+			string actual = "some arbitrary text";
+			string expected = "TEXT";
 
 			async Task Act()
-				=> await Expect.That(actual).EndsWith(expected);
+				=> await Expect.That(actual).EndsWith(expected).IgnoringCase(ignoreCase);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.OnlyIf(!ignoreCase)
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  ends with "TEXT",
+				                  but found "some arbitrary text"
+				                  at Expect.That(actual).EndsWith(expected).IgnoringCase(ignoreCase)
+				                  """);
+		}
+
+		[Fact]
+		public async Task
+			IgnoringCase_WhenSubjectEndsWithDifferentString_ShouldIncludeIgnoringCaseInMessage()
+		{
+			string actual = "some arbitrary text";
+			string expected = "SOME";
+
+			async Task Act()
+				=> await Expect.That(actual).EndsWith(expected).IgnoringCase();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  ends with "SOME" ignoring case,
+				                  but found "some arbitrary text"
+				                  at Expect.That(actual).EndsWith(expected).IgnoringCase()
+				                  """);
+		}
+
+		[Fact]
+		public async Task
+			Using_WhenSubjectEndsWithIncorrectMatchAccordingToComparer_ShouldIncludeComparerInMessage()
+		{
+			string actual = "some arbitrary text";
+			string expected = "TEXT";
+
+			async Task Act()
+				=> await Expect.That(actual).EndsWith(expected)
+					.Using(new IgnoreCaseForVocalsComparer());
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  ends with "TEXT" using IgnoreCaseForVocalsComparer,
+				                  but found "some arbitrary text"
+				                  at Expect.That(actual).EndsWith(expected).Using(new IgnoreCaseForVocalsComparer())
+				                  """);
+		}
+
+		[Fact]
+		public async Task
+			Using_WhenSubjectEndsWithMatchAccordingToComparer_ShouldSucceed()
+		{
+			string actual = "some arbitrary text";
+			string expected = "tExt";
+
+			async Task Act()
+				=> await Expect.That(actual).EndsWith(expected)
+					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -19,7 +83,7 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenSubjectDoesNotEndWithExpected_ShouldFail()
 		{
-			string actual = "some text";
+			string actual = "some arbitrary text";
 			string expected = "some";
 
 			async Task Act()
@@ -29,9 +93,21 @@ public sealed partial class ThatString
 				.Which.HasMessage("""
 				                  Expected that actual
 				                  ends with "some",
-				                  but found "some text"
+				                  but found "some arbitrary text"
 				                  at Expect.That(actual).EndsWith(expected)
 				                  """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectEndsWithExpected_ShouldSucceed()
+		{
+			string actual = "some arbitrary text";
+			string expected = "text";
+
+			async Task Act()
+				=> await Expect.That(actual).EndsWith(expected);
+
+			await Expect.That(Act).DoesNotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.StartsWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.StartsWithTests.cs
@@ -1,0 +1,115 @@
+﻿using System.Threading.Tasks;
+using Xunit.Sdk;
+using Xunit;
+
+namespace Testably.Expectations.Tests.Primitives.Strings;
+
+public sealed partial class ThatString
+{
+	public class StartsWithTests
+	{
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public async Task
+			IgnoringCase_WhenSubjectStartsWithDifferentCase_ShouldFailUnlessCaseIsIgnored(
+				bool ignoreCase)
+		{
+			string actual = "some text";
+			string expected = "SOME";
+
+			async Task Act()
+				=> await Expect.That(actual).StartsWith(expected).IgnoringCase(ignoreCase);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.OnlyIf(!ignoreCase)
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  starts with "SOME",
+				                  but found "some text"
+				                  at Expect.That(actual).StartsWith(expected).IgnoringCase(ignoreCase)
+				                  """);
+		}
+
+		[Fact]
+		public async Task
+			IgnoringCase_WhenSubjectStartsWithDifferentString_ShouldIncludeIgnoringCaseInMessage()
+		{
+			string actual = "some text";
+			string expected = "TEXT";
+
+			async Task Act()
+				=> await Expect.That(actual).StartsWith(expected).IgnoringCase();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  starts with "TEXT" ignoring case,
+				                  but found "some text"
+				                  at Expect.That(actual).StartsWith(expected).IgnoringCase()
+				                  """);
+		}
+
+		[Fact]
+		public async Task
+			Using_WhenSubjectStartsWithDifferentCase_ShouldFailUnlessCaseIsIgnored()
+		{
+			string actual = "some text";
+			string expected = "SOME";
+
+			async Task Act()
+				=> await Expect.That(actual).StartsWith(expected).Using(new IgnoreCaseForVocalsComparer());
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  starts with "SOME" using IgnoreCaseForVocalsComparer,
+				                  but found "some text"
+				                  at Expect.That(actual).StartsWith(expected).Using(new IgnoreCaseForVocalsComparer())
+				                  """);
+		}
+
+		[Fact]
+		public async Task
+			Using_WhenSubjectStartsWithDifferentString_ShouldIncludeIgnoringCaseInMessage()
+		{
+			string actual = "some text";
+			string expected = "sOmE";
+
+			async Task Act()
+				=> await Expect.That(actual).StartsWith(expected).Using(new IgnoreCaseForVocalsComparer());
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectDoesNotStartWithExpected_ShouldFail()
+		{
+			string actual = "some text";
+			string expected = "text";
+
+			async Task Act()
+				=> await Expect.That(actual).StartsWith(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that actual
+				                  starts with "text",
+				                  but found "some text"
+				                  at Expect.That(actual).StartsWith(expected)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectStartsWithExpected_ShouldSucceed()
+		{
+			string actual = "some text";
+			string expected = "some";
+
+			async Task Act()
+				=> await Expect.That(actual).StartsWith(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.StartsWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.StartsWithTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Threading.Tasks;
-using Xunit.Sdk;
-using Xunit;
-
-namespace Testably.Expectations.Tests.Primitives.Strings;
+﻿namespace Testably.Expectations.Tests.Primitives.Strings;
 
 public sealed partial class ThatString
 {
@@ -15,7 +11,7 @@ public sealed partial class ThatString
 			IgnoringCase_WhenSubjectStartsWithDifferentCase_ShouldFailUnlessCaseIsIgnored(
 				bool ignoreCase)
 		{
-			string actual = "some text";
+			string actual = "some arbitrary text";
 			string expected = "SOME";
 
 			async Task Act()
@@ -26,7 +22,7 @@ public sealed partial class ThatString
 				.Which.HasMessage("""
 				                  Expected that actual
 				                  starts with "SOME",
-				                  but found "some text"
+				                  but found "some arbitrary text"
 				                  at Expect.That(actual).StartsWith(expected).IgnoringCase(ignoreCase)
 				                  """);
 		}
@@ -35,7 +31,7 @@ public sealed partial class ThatString
 		public async Task
 			IgnoringCase_WhenSubjectStartsWithDifferentString_ShouldIncludeIgnoringCaseInMessage()
 		{
-			string actual = "some text";
+			string actual = "some arbitrary text";
 			string expected = "TEXT";
 
 			async Task Act()
@@ -45,39 +41,41 @@ public sealed partial class ThatString
 				.Which.HasMessage("""
 				                  Expected that actual
 				                  starts with "TEXT" ignoring case,
-				                  but found "some text"
+				                  but found "some arbitrary text"
 				                  at Expect.That(actual).StartsWith(expected).IgnoringCase()
 				                  """);
 		}
 
 		[Fact]
 		public async Task
-			Using_WhenSubjectStartsWithDifferentCase_ShouldFailUnlessCaseIsIgnored()
+			Using_WhenSubjectStartsWithIncorrectMatchAccordingToComparer_ShouldIncludeComparerInMessage()
 		{
-			string actual = "some text";
+			string actual = "some arbitrary text";
 			string expected = "SOME";
 
 			async Task Act()
-				=> await Expect.That(actual).StartsWith(expected).Using(new IgnoreCaseForVocalsComparer());
+				=> await Expect.That(actual).StartsWith(expected)
+					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
 				                  Expected that actual
 				                  starts with "SOME" using IgnoreCaseForVocalsComparer,
-				                  but found "some text"
+				                  but found "some arbitrary text"
 				                  at Expect.That(actual).StartsWith(expected).Using(new IgnoreCaseForVocalsComparer())
 				                  """);
 		}
 
 		[Fact]
 		public async Task
-			Using_WhenSubjectStartsWithDifferentString_ShouldIncludeIgnoringCaseInMessage()
+			Using_WhenSubjectStartsWithMatchAccordingToComparer_ShouldSucceed()
 		{
-			string actual = "some text";
+			string actual = "some arbitrary text";
 			string expected = "sOmE";
 
 			async Task Act()
-				=> await Expect.That(actual).StartsWith(expected).Using(new IgnoreCaseForVocalsComparer());
+				=> await Expect.That(actual).StartsWith(expected)
+					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -85,7 +83,7 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenSubjectDoesNotStartWithExpected_ShouldFail()
 		{
-			string actual = "some text";
+			string actual = "some arbitrary text";
 			string expected = "text";
 
 			async Task Act()
@@ -95,7 +93,7 @@ public sealed partial class ThatString
 				.Which.HasMessage("""
 				                  Expected that actual
 				                  starts with "text",
-				                  but found "some text"
+				                  but found "some arbitrary text"
 				                  at Expect.That(actual).StartsWith(expected)
 				                  """);
 		}
@@ -103,7 +101,7 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenSubjectStartsWithExpected_ShouldSucceed()
 		{
-			string actual = "some text";
+			string actual = "some arbitrary text";
 			string expected = "some";
 
 			async Task Act()

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+
+namespace Testably.Expectations.Tests.Primitives.Strings;
+
+public sealed partial class ThatString
+{
+	/// <summary>
+	///     A test <see cref="IEqualityComparer{T}" /> for <see langword="string" />s that
+	///     ignores case differences only in vocals.
+	/// </summary>
+	public sealed class IgnoreCaseForVocalsComparer : IEqualityComparer<string>
+	{
+		#region IEqualityComparer<string> Members
+
+		public bool Equals(string x, string y)
+		{
+			string adjustedX = LowercaseVocals(x);
+			string adjustedY = LowercaseVocals(y);
+
+			return adjustedX.Equals(adjustedY, StringComparison.Ordinal);
+		}
+
+		public int GetHashCode(string obj)
+		{
+			return obj.GetHashCode();
+		}
+
+		#endregion
+
+		private static string LowercaseVocals(string input)
+			=> input.Replace('A', 'a')
+				.Replace('E', 'e')
+				.Replace('I', 'i')
+				.Replace('O', 'o')
+				.Replace('U', 'u');
+	}
+}


### PR DESCRIPTION
Add string expectations:
- `StartsWith(string)`
- `EndsWith(string)`
- `DoesNotStartWith(string)`
- `DoesNotEndWith(string)`

which support string extensions
- `.Using(IComparer<string>)`
- `.IgnoringCase()`