### PR TITLE
feat: add support for TUnit

### DIFF
--- a/Source/Testably.Expectations/Core/Adapters/NUnitTestFrameworkAdapter.cs
+++ b/Source/Testably.Expectations/Core/Adapters/NUnitTestFrameworkAdapter.cs
@@ -35,22 +35,22 @@ internal class NUnitTestFrameworkAdapter : ITestFrameworkAdapter
 
 	[DoesNotReturn]
 	[StackTraceHidden]
-	public void Throw(string message)
+	public void Skip(string message)
 	{
-		Type exceptionType = _assembly?.GetType("NUnit.Framework.AssertionException")
+		Type exceptionType = _assembly?.GetType("NUnit.Framework.IgnoreException")
 		                     ?? throw new NotSupportedException(
-			                     "Failed to create the NUnit fail assertion type");
+			                     "Failed to create the NUnit skip assertion type");
 
 		throw (Exception)Activator.CreateInstance(exceptionType, message)!;
 	}
 
 	[DoesNotReturn]
 	[StackTraceHidden]
-	public void Skip(string message)
+	public void Throw(string message)
 	{
-		Type exceptionType = _assembly?.GetType("NUnit.Framework.IgnoreException")
+		Type exceptionType = _assembly?.GetType("NUnit.Framework.AssertionException")
 		                     ?? throw new NotSupportedException(
-			                     "Failed to create the NUnit skip assertion type");
+			                     "Failed to create the NUnit fail assertion type");
 
 		throw (Exception)Activator.CreateInstance(exceptionType, message)!;
 	}

--- a/Source/Testably.Expectations/Core/Adapters/TUnitTestFrameworkAdapter.cs
+++ b/Source/Testably.Expectations/Core/Adapters/TUnitTestFrameworkAdapter.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace Testably.Expectations.Core.Adapters;
+
+/// <summary>
+///     Implements the TUnit test framework adapter.
+/// </summary>
+/// <remarks>
+///     <see href="https://github.com/thomhurst/TUnit" />
+/// </remarks>
+// ReSharper disable once UnusedMember.Global
+internal class TUnitTestFrameworkAdapter : ITestFrameworkAdapter
+{
+	private Assembly? _assertionsAssembly;
+	private Assembly? _coreAssembly;
+
+	#region ITestFrameworkAdapter Members
+
+	public bool IsAvailable
+	{
+		get
+		{
+			try
+			{
+				// For netfx the assembly is not in AppDomain by default, so we can't just scan AppDomain.CurrentDomain
+				_coreAssembly = Assembly.Load(new AssemblyName("TUnit.Core"));
+				_assertionsAssembly = Assembly.Load(new AssemblyName("TUnit.Assertions"));
+				return _coreAssembly is not null;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+	}
+
+	[DoesNotReturn]
+	[StackTraceHidden]
+	public void Skip(string message)
+	{
+		Type exceptionType = _coreAssembly?.GetType("TUnit.Core.Exceptions.SkipTestException")
+		                     ?? throw new NotSupportedException(
+			                     "Failed to create the TUnit skip assertion type");
+
+		throw (Exception)Activator.CreateInstance(exceptionType, message)!;
+	}
+
+	[DoesNotReturn]
+	[StackTraceHidden]
+	public void Throw(string message)
+	{
+		if (_assertionsAssembly == null)
+		{
+			// When TUnit is used without its assertions library, use the default exception.
+			throw new FailException(message);
+		}
+
+		Type exceptionType =
+			_assertionsAssembly?.GetType("TUnit.Assertions.Exceptions.AssertionException")
+			?? throw new NotSupportedException(
+				"Failed to create the TUnit fail assertion type");
+
+		throw (Exception)Activator.CreateInstance(exceptionType, message)!;
+	}
+
+	#endregion
+}

--- a/Source/Testably.Expectations/Core/Adapters/XUnitTestFrameworkAdapter.cs
+++ b/Source/Testably.Expectations/Core/Adapters/XUnitTestFrameworkAdapter.cs
@@ -38,6 +38,13 @@ internal class XUnitTestFrameworkAdapter : ITestFrameworkAdapter
 
 	[DoesNotReturn]
 	[StackTraceHidden]
+	public void Skip(string message)
+	{
+		throw new SkipException($"SKIPPED: {message} (xunit v2 does not support skipping test)");
+	}
+
+	[DoesNotReturn]
+	[StackTraceHidden]
 	public void Throw(string message)
 	{
 		Type exceptionType = _assembly?.GetType("Xunit.Sdk.XunitException")
@@ -46,14 +53,6 @@ internal class XUnitTestFrameworkAdapter : ITestFrameworkAdapter
 
 		throw (Exception)Activator.CreateInstance(exceptionType, message)!;
 	}
-
-	[DoesNotReturn]
-	[StackTraceHidden]
-	public void Skip(string message)
-	{
-		throw new SkipException($"SKIPPED: {message} (xunit v2 does not support skipping test)");
-	}
-
 
 	#endregion
 }

--- a/Testably.Expectations.sln
+++ b/Testably.Expectations.sln
@@ -67,6 +67,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestFramework.NUnit4.Tests"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestFramework.FallbackTest", "Tests\TestFrameworks\TestFramework.FallbackTest\TestFramework.FallbackTest.csproj", "{8BCA1B9C-5687-4F5A-8F7F-F6270D12B83B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestFramework.TUnit.Tests", "Tests\TestFrameworks\TestFramework.TUnit.Tests\TestFramework.TUnit.Tests.csproj", "{00855432-F973-4823-9F57-BC3FE53F5D9D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +99,10 @@ Global
 		{8BCA1B9C-5687-4F5A-8F7F-F6270D12B83B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8BCA1B9C-5687-4F5A-8F7F-F6270D12B83B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8BCA1B9C-5687-4F5A-8F7F-F6270D12B83B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00855432-F973-4823-9F57-BC3FE53F5D9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00855432-F973-4823-9F57-BC3FE53F5D9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00855432-F973-4823-9F57-BC3FE53F5D9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00855432-F973-4823-9F57-BC3FE53F5D9D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -114,6 +120,7 @@ Global
 		{4913DD7C-18AC-402C-9A6D-27D5EA797AD3} = {93C35842-4266-467E-AE87-3E91F83D5DDD}
 		{9B940AB8-47CE-46C9-90D7-2866E280441A} = {93C35842-4266-467E-AE87-3E91F83D5DDD}
 		{8BCA1B9C-5687-4F5A-8F7F-F6270D12B83B} = {93C35842-4266-467E-AE87-3E91F83D5DDD}
+		{00855432-F973-4823-9F57-BC3FE53F5D9D} = {93C35842-4266-467E-AE87-3E91F83D5DDD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {65C0CC2C-5F10-4F18-9057-176DC70833FA}

--- a/Tests/TestFrameworks/Directory.Build.props
+++ b/Tests/TestFrameworks/Directory.Build.props
@@ -21,16 +21,4 @@
 		<Nullable>annotations</Nullable>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="Nullable" Version="1.3.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
-
 </Project>

--- a/Tests/TestFrameworks/TestFramework.FallbackTest/TestFramework.FallbackTest.csproj
+++ b/Tests/TestFrameworks/TestFramework.FallbackTest/TestFramework.FallbackTest.csproj
@@ -14,4 +14,16 @@
 		<ProjectReference Include="..\..\..\Source\Testably.Expectations\Testably.Expectations.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="Nullable" Version="1.3.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
 </Project>

--- a/Tests/TestFrameworks/TestFramework.NUnit3.Tests/TestFramework.NUnit3.Tests.csproj
+++ b/Tests/TestFrameworks/TestFramework.NUnit3.Tests/TestFramework.NUnit3.Tests.csproj
@@ -16,4 +16,16 @@
 		<ProjectReference Include="..\..\..\Source\Testably.Expectations\Testably.Expectations.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="Nullable" Version="1.3.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
 </Project>

--- a/Tests/TestFrameworks/TestFramework.NUnit4.Tests/TestFramework.NUnit4.Tests.csproj
+++ b/Tests/TestFrameworks/TestFramework.NUnit4.Tests/TestFramework.NUnit4.Tests.csproj
@@ -16,4 +16,16 @@
 		<ProjectReference Include="..\..\..\Source\Testably.Expectations\Testably.Expectations.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="Nullable" Version="1.3.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
 </Project>

--- a/Tests/TestFrameworks/TestFramework.TUnit.Tests/TUnitTestFrameworkTests.cs
+++ b/Tests/TestFrameworks/TestFramework.TUnit.Tests/TUnitTestFrameworkTests.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+using Testably.Expectations;
+using TUnit.Assertions.Exceptions;
+using TUnit.Core.Exceptions;
+
+namespace TestFramework.TUnit.Tests;
+
+public sealed class TUnitTestFrameworkTests
+{
+	[Test]
+	public async Task OnFail_WhenUsingXunit2AsTestFramework_ShouldThrowXunitException()
+	{
+		void Act()
+			=> Testably.Expectations.Fail.Test("my message");
+
+		await Expect.That(Act).Throws<AssertionException>();
+	}
+
+	[Test]
+	public async Task OnSkip_WhenUsingXunit2AsTestFramework_ShouldThrowSkipException()
+	{
+		void Act()
+			=> Testably.Expectations.Skip.Test("my message");
+
+		await Expect.That(Act).Throws<SkipTestException>();
+	}
+}

--- a/Tests/TestFrameworks/TestFramework.TUnit.Tests/TestFramework.TUnit.Tests.csproj
+++ b/Tests/TestFrameworks/TestFramework.TUnit.Tests/TestFramework.TUnit.Tests.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net8.0</TargetFrameworks>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="TUnit" Version="0.1.1099" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\Source\Testably.Expectations\Testably.Expectations.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/Tests/TestFrameworks/TestFramework.XUnit2.Tests/TestFramework.XUnit2.Tests.csproj
+++ b/Tests/TestFrameworks/TestFramework.XUnit2.Tests/TestFramework.XUnit2.Tests.csproj
@@ -16,4 +16,16 @@
 		<ProjectReference Include="..\..\..\Source\Testably.Expectations\Testably.Expectations.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="Nullable" Version="1.3.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
When [TUnit](https://github.com/thomhurst/TUnit) is used, throw the corresponding exceptions:
- `TUnit.Core.Exceptions.SkipTestException` for skipping tests
- `TUnit.Assertions.Exceptions.AssertionException` for failing tests