### PR TITLE
refactor: consolidate test names

### DIFF
--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AllAreEquivalentTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AllAreEquivalentTests.cs
@@ -7,7 +7,7 @@ public sealed partial class ThatCollection
 		[Fact]
 		public async Task WhenCollectionContainsOtherValues_ShouldFail()
 		{
-			MyClass[] collection =
+			MyClass[] subject =
 			[
 				new() { Value = "Foo" },
 				new() { Value = "Foo" },
@@ -18,21 +18,21 @@ public sealed partial class ThatCollection
 			MyClass expected = new() { Value = "Foo" };
 
 			async Task Act()
-				=> await Expect.That(collection).All().AreEquivalentTo(expected);
+				=> await Expect.That(subject).All().AreEquivalentTo(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that collection
+				                  Expected that subject
 				                  has all items equivalent to expected,
 				                  but only 3 of 4 items were equivalent
-				                  at Expect.That(collection).All().AreEquivalentTo(expected)
+				                  at Expect.That(subject).All().AreEquivalentTo(expected)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenCollectionOnlyContainsEqualValues_ShouldSucceed()
 		{
-			MyClass[] collection =
+			MyClass[] subject =
 			[
 				new() { Value = "Foo" },
 				new() { Value = "Foo" },
@@ -42,7 +42,7 @@ public sealed partial class ThatCollection
 			MyClass expected = new() { Value = "Foo" };
 
 			async Task Act()
-				=> await Expect.That(collection).All().AreEquivalentTo(expected);
+				=> await Expect.That(subject).All().AreEquivalentTo(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AllAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AllAreTests.cs
@@ -7,27 +7,27 @@ public sealed partial class ThatCollection
 		[Fact]
 		public async Task WhenCollectionContainsOtherValues_ShouldFail()
 		{
-			int[] collection = [1, 1, 1, 1, 2, 2, 3];
+			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await Expect.That(collection).All().Are(1);
+				=> await Expect.That(subject).All().Are(1);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that collection
+				                  Expected that subject
 				                  has all items equal to 1,
 				                  but only 4 of 7 items were equal
-				                  at Expect.That(collection).All().Are(1)
+				                  at Expect.That(subject).All().Are(1)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenCollectionOnlyContainsEqualValues_ShouldSucceed()
 		{
-			int[] collection = [1, 1, 1, 1];
+			int[] subject = [1, 1, 1, 1];
 
 			async Task Act()
-				=> await Expect.That(collection).All().Are(1);
+				=> await Expect.That(subject).All().Are(1);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AtLeastAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AtLeastAreTests.cs
@@ -7,10 +7,10 @@ public sealed partial class ThatCollection
 		[Fact]
 		public async Task WhenCollectionContainsEnoughEqualItems_ShouldSucceed()
 		{
-			int[] collection = [1, 1, 1, 1, 2, 2, 3];
+			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await Expect.That(collection).AtLeast(3).Are(1);
+				=> await Expect.That(subject).AtLeast(3).Are(1);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -18,17 +18,17 @@ public sealed partial class ThatCollection
 		[Fact]
 		public async Task WhenCollectionContainsTooFewEqualItems_ShouldFail()
 		{
-			int[] collection = [1, 1, 1, 1, 2, 2, 3];
+			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await Expect.That(collection).AtLeast(5).Are(1);
+				=> await Expect.That(subject).AtLeast(5).Are(1);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that collection
+				                  Expected that subject
 				                  has at least 5 items equal to 1,
 				                  but only 4 of 7 items were equal
-				                  at Expect.That(collection).AtLeast(5).Are(1)
+				                  at Expect.That(subject).AtLeast(5).Are(1)
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AtMostAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.AtMostAreTests.cs
@@ -7,10 +7,10 @@ public sealed partial class ThatCollection
 		[Fact]
 		public async Task WhenCollectionContainsSufficientlyFewEqualItems_ShouldSucceed()
 		{
-			int[] collection = [1, 1, 1, 1, 2, 2, 3];
+			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await Expect.That(collection).AtMost(3).Are(2);
+				=> await Expect.That(subject).AtMost(3).Are(2);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -18,17 +18,17 @@ public sealed partial class ThatCollection
 		[Fact]
 		public async Task WhenCollectionContainsTooManyEqualItems_ShouldFail()
 		{
-			int[] collection = [1, 1, 1, 1, 2, 2, 3];
+			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await Expect.That(collection).AtMost(3).Are(1);
+				=> await Expect.That(subject).AtMost(3).Are(1);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that collection
+				                  Expected that subject
 				                  has at most 3 items equal to 1,
 				                  but 4 of 7 items were equal
-				                  at Expect.That(collection).AtMost(3).Are(1)
+				                  at Expect.That(subject).AtMost(3).Are(1)
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.BetweenAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.BetweenAreTests.cs
@@ -7,10 +7,10 @@ public sealed partial class ThatCollection
 		[Fact]
 		public async Task WhenCollectionContainsSufficientlyEqualItems_ShouldSucceed()
 		{
-			int[] collection = [1, 1, 1, 1, 2, 2, 3];
+			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await Expect.That(collection).Between(3).And(4).Are(1);
+				=> await Expect.That(subject).Between(3).And(4).Are(1);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -18,34 +18,34 @@ public sealed partial class ThatCollection
 		[Fact]
 		public async Task WhenCollectionContainsTooFewEqualItems_ShouldFail()
 		{
-			int[] collection = [1, 1, 1, 1, 2, 2, 3];
+			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await Expect.That(collection).Between(3).And(4).Are(2);
+				=> await Expect.That(subject).Between(3).And(4).Are(2);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that collection
+				                  Expected that subject
 				                  has between 3 and 4 items equal to 2,
 				                  but only 2 items were equal
-				                  at Expect.That(collection).Between(3).And(4).Are(2)
+				                  at Expect.That(subject).Between(3).And(4).Are(2)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenCollectionContainsTooManyEqualItems_ShouldFail()
 		{
-			int[] collection = [1, 1, 1, 1, 2, 2, 3];
+			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await Expect.That(collection).Between(1).And(3).Are(1);
+				=> await Expect.That(subject).Between(1).And(3).Are(1);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that collection
+				                  Expected that subject
 				                  has between 1 and 3 items equal to 1,
 				                  but 4 items were equal
-				                  at Expect.That(collection).Between(1).And(3).Are(1)
+				                  at Expect.That(subject).Between(1).And(3).Are(1)
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.ContainsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.ContainsTests.cs
@@ -8,28 +8,28 @@ public sealed partial class ThatCollection
 	{
 		[Theory]
 		[AutoData]
-		public async Task Fails(string[] collection, string expected)
+		public async Task Fails(string[] subject, string expected)
 		{
 			async Task Act()
-				=> await Expect.That(collection).Contains(expected);
+				=> await Expect.That(subject).Contains(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that collection
+				                   Expected that subject
 				                   contains "{expected}",
-				                   but found ["{string.Join("\", \"", collection)}"]
-				                   at Expect.That(collection).Contains(expected)
+				                   but found ["{string.Join("\", \"", subject)}"]
+				                   at Expect.That(subject).Contains(expected)
 				                   """);
 		}
 
 		[Theory]
 		[AutoData]
-		public async Task Succeeds(List<string> collection, string expected)
+		public async Task Succeeds(List<string> subject, string expected)
 		{
-			collection.Add(expected);
+			subject.Add(expected);
 
 			async Task Act()
-				=> await Expect.That(collection).Contains(expected);
+				=> await Expect.That(subject).Contains(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.IsEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.IsEmptyTests.cs
@@ -7,27 +7,27 @@ public sealed partial class ThatCollection
 		[Fact]
 		public async Task WhenCollectionContainsValues_ShouldFail()
 		{
-			int[] collection = [1, 1, 2];
+			int[] subject = [1, 1, 2];
 
 			async Task Act()
-				=> await Expect.That(collection).IsEmpty();
+				=> await Expect.That(subject).IsEmpty();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that collection
+				                  Expected that subject
 				                  is empty,
 				                  but found [1, 1, 2]
-				                  at Expect.That(collection).IsEmpty()
+				                  at Expect.That(subject).IsEmpty()
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenCollectionIsEmpty_ShouldSucceed()
 		{
-			int[] collection = [];
+			int[] subject = [];
 
 			async Task Act()
-				=> await Expect.That(collection).IsEmpty();
+				=> await Expect.That(subject).IsEmpty();
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.IsNotEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.IsNotEmptyTests.cs
@@ -7,10 +7,10 @@ public sealed partial class ThatCollection
 		[Fact]
 		public async Task WhenCollectionContainsValues_ShouldSucceed()
 		{
-			int[] collection = [1, 1, 2];
+			int[] subject = [1, 1, 2];
 
 			async Task Act()
-				=> await Expect.That(collection).IsNotEmpty();
+				=> await Expect.That(subject).IsNotEmpty();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -18,17 +18,17 @@ public sealed partial class ThatCollection
 		[Fact]
 		public async Task WhenCollectionIsEmpty_ShouldFail()
 		{
-			int[] collection = [];
+			int[] subject = [];
 
 			async Task Act()
-				=> await Expect.That(collection).IsNotEmpty();
+				=> await Expect.That(subject).IsNotEmpty();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that collection
+				                  Expected that subject
 				                  is not empty,
 				                  but it was
-				                  at Expect.That(collection).IsNotEmpty()
+				                  at Expect.That(subject).IsNotEmpty()
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatCollection.NoneAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatCollection.NoneAreTests.cs
@@ -7,27 +7,27 @@ public sealed partial class ThatCollection
 		[Fact]
 		public async Task WhenCollectionContainsEqualValues_ShouldFail()
 		{
-			int[] collection = [1, 1, 1, 1, 2, 2, 3];
+			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await Expect.That(collection).None().Are(1);
+				=> await Expect.That(subject).None().Are(1);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that collection
+				                  Expected that subject
 				                  has no items equal to 1,
 				                  but 4 items were equal
-				                  at Expect.That(collection).None().Are(1)
+				                  at Expect.That(subject).None().Are(1)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenCollectionOnlyContainsDifferentValues_ShouldSucceed()
 		{
-			int[] collection = [1, 1, 1, 1, 2, 2, 3];
+			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await Expect.That(collection).None().Are(42);
+				=> await Expect.That(subject).None().Are(42);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.AtLeastAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.AtLeastAreTests.cs
@@ -11,10 +11,10 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotEnumerateTwice()
 		{
-			ThrowWhenIteratingTwiceEnumerable enumerable = new ThrowWhenIteratingTwiceEnumerable();
+			ThrowWhenIteratingTwiceEnumerable subject = new();
 
 			async Task Act()
-				=> await Expect.That(enumerable).AtLeast(0).Are(1)
+				=> await Expect.That(subject).AtLeast(0).Are(1)
 					.And.AtLeast(0).Are(1);
 
 			await Expect.That(Act).DoesNotThrow();
@@ -23,8 +23,10 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotMaterializeEnumerable()
 		{
+			var subject = Factory.GetFibonacciNumbers();
+
 			async Task Act()
-				=> await Expect.That(Factory.GetFibonacciNumbers()).AtLeast(2).Are(1);
+				=> await Expect.That(subject).AtLeast(2).Are(1);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -32,10 +34,10 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task WhenEnumerableContainsEnoughEqualItems_ShouldSucceed()
 		{
-			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await Expect.That(enumerable).AtLeast(3).Are(1);
+				=> await Expect.That(subject).AtLeast(3).Are(1);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -43,17 +45,17 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task WhenEnumerableContainsTooFewEqualItems_ShouldFail()
 		{
-			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await Expect.That(enumerable).AtLeast(5).Are(1);
+				=> await Expect.That(subject).AtLeast(5).Are(1);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that enumerable
+				                  Expected that subject
 				                  has at least 5 items equal to 1,
 				                  but only 4 of 7 items were equal
-				                  at Expect.That(enumerable).AtLeast(5).Are(1)
+				                  at Expect.That(subject).AtLeast(5).Are(1)
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.AtMostAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.AtMostAreTests.cs
@@ -11,10 +11,10 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotEnumerateTwice()
 		{
-			ThrowWhenIteratingTwiceEnumerable enumerable = new();
+			ThrowWhenIteratingTwiceEnumerable subject = new();
 
 			async Task Act()
-				=> await Expect.That(enumerable).AtMost(3).Are(1)
+				=> await Expect.That(subject).AtMost(3).Are(1)
 					.And.AtMost(3).Are(1);
 
 			await Expect.That(Act).DoesNotThrow();
@@ -23,25 +23,27 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotMaterializeEnumerable()
 		{
+			var subject = Factory.GetFibonacciNumbers();
+
 			async Task Act()
-				=> await Expect.That(Factory.GetFibonacciNumbers()).AtMost(1).Are(1);
+				=> await Expect.That(subject).AtMost(1).Are(1);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that Factory.GetFibonacciNumbers()
+				                  Expected that subject
 				                  has at most 1 item equal to 1,
 				                  but at least 2 items were equal
-				                  at Expect.That(Factory.GetFibonacciNumbers()).AtMost(1).Are(1)
+				                  at Expect.That(subject).AtMost(1).Are(1)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenEnumerableContainsSufficientlyFewEqualItems_ShouldSucceed()
 		{
-			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await Expect.That(enumerable).AtMost(3).Are(2);
+				=> await Expect.That(subject).AtMost(3).Are(2);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -49,17 +51,17 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task WhenEnumerableContainsTooManyEqualItems_ShouldFail()
 		{
-			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await Expect.That(enumerable).AtMost(3).Are(1);
+				=> await Expect.That(subject).AtMost(3).Are(1);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that enumerable
+				                  Expected that subject
 				                  has at most 3 items equal to 1,
 				                  but at least 4 items were equal
-				                  at Expect.That(enumerable).AtMost(3).Are(1)
+				                  at Expect.That(subject).AtMost(3).Are(1)
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.BetweenAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.BetweenAreTests.cs
@@ -11,10 +11,10 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotEnumerateTwice()
 		{
-			ThrowWhenIteratingTwiceEnumerable enumerable = new ThrowWhenIteratingTwiceEnumerable();
+			ThrowWhenIteratingTwiceEnumerable subject = new();
 
 			async Task Act()
-				=> await Expect.That(enumerable).Between(0).And(2).Are(1)
+				=> await Expect.That(subject).Between(0).And(2).Are(1)
 					.And.Between(0).And(1).Are(1);
 
 			await Expect.That(Act).DoesNotThrow();
@@ -23,25 +23,27 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotMaterializeEnumerable()
 		{
+			var subject = Factory.GetFibonacciNumbers();
+
 			async Task Act()
-				=> await Expect.That(Factory.GetFibonacciNumbers()).Between(0).And(1).Are(1);
+				=> await Expect.That(subject).Between(0).And(1).Are(1);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that Factory.GetFibonacciNumbers()
+				                  Expected that subject
 				                  has between 0 and 1 items equal to 1,
 				                  but at least 2 items were equal
-				                  at Expect.That(Factory.GetFibonacciNumbers()).Between(0).And(1).Are(1)
+				                  at Expect.That(subject).Between(0).And(1).Are(1)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenEnumerableContainsSufficientlyEqualItems_ShouldSucceed()
 		{
-			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await Expect.That(enumerable).Between(3).And(4).Are(1);
+				=> await Expect.That(subject).Between(3).And(4).Are(1);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -49,34 +51,34 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task WhenEnumerableContainsTooFewEqualItems_ShouldFail()
 		{
-			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await Expect.That(enumerable).Between(3).And(4).Are(2);
+				=> await Expect.That(subject).Between(3).And(4).Are(2);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that enumerable
+				                  Expected that subject
 				                  has between 3 and 4 items equal to 2,
 				                  but only 2 items were equal
-				                  at Expect.That(enumerable).Between(3).And(4).Are(2)
+				                  at Expect.That(subject).Between(3).And(4).Are(2)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenEnumerableContainsTooManyEqualItems_ShouldFail()
 		{
-			int[] enumerable = [1, 1, 1, 1, 2, 2, 3];
+			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await Expect.That(enumerable).Between(1).And(3).Are(1);
+				=> await Expect.That(subject).Between(1).And(3).Are(1);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that enumerable
+				                  Expected that subject
 				                  has between 1 and 3 items equal to 1,
 				                  but 4 items were equal
-				                  at Expect.That(enumerable).Between(1).And(3).Are(1)
+				                  at Expect.That(subject).Between(1).And(3).Are(1)
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.ContainsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.ContainsTests.cs
@@ -11,10 +11,10 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotEnumerateTwice()
 		{
-			ThrowWhenIteratingTwiceEnumerable enumerable = new();
+			ThrowWhenIteratingTwiceEnumerable subject = new();
 
 			async Task Act()
-				=> await Expect.That(enumerable).Contains(1)
+				=> await Expect.That(subject).Contains(1)
 					.And.Contains(1);
 
 			await Expect.That(Act).DoesNotThrow();
@@ -23,39 +23,41 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotMaterializeEnumerable()
 		{
+			var subject = Factory.GetFibonacciNumbers();
+
 			async Task Act()
-				=> await Expect.That(Factory.GetFibonacciNumbers()).Contains(5);
+				=> await Expect.That(subject).Contains(5);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
 
 		[Theory]
 		[AutoData]
-		public async Task WhenEnumerableContainsExpectedValue_ShouldSucceed(List<string> enumerable,
+		public async Task WhenEnumerableContainsExpectedValue_ShouldSucceed(List<string> subject,
 			string expected)
 		{
-			enumerable.Add(expected);
+			subject.Add(expected);
 
 			async Task Act()
-				=> await Expect.That(enumerable).Contains(expected);
+				=> await Expect.That(subject).Contains(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
 
 		[Theory]
 		[AutoData]
-		public async Task WhenEnumerableDoesNotContainsExpectedValue_ShouldFail(string[] enumerable,
+		public async Task WhenEnumerableDoesNotContainsExpectedValue_ShouldFail(string[] subject,
 			string expected)
 		{
 			async Task Act()
-				=> await Expect.That(enumerable).Contains(expected);
+				=> await Expect.That(subject).Contains(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that enumerable
+				                   Expected that subject
 				                   contains "{expected}",
-				                   but found ["{string.Join("\", \"", enumerable)}"]
-				                   at Expect.That(enumerable).Contains(expected)
+				                   but found ["{string.Join("\", \"", subject)}"]
+				                   at Expect.That(subject).Contains(expected)
 				                   """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.IsEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.IsEmptyTests.cs
@@ -11,42 +11,44 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotMaterializeEnumerable()
 		{
+			var subject = Factory.GetFibonacciNumbers();
+
 			async Task Act()
-				=> await Expect.That(Factory.GetFibonacciNumbers()).IsEmpty();
+				=> await Expect.That(subject).IsEmpty();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that Factory.GetFibonacciNumbers()
+				                  Expected that subject
 				                  is empty,
 				                  but found [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, …]
-				                  at Expect.That(Factory.GetFibonacciNumbers()).IsEmpty()
+				                  at Expect.That(subject).IsEmpty()
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenEnumerableContainsValues_ShouldFail()
 		{
-			IEnumerable<int> enumerable = ToEnumerable([1, 1, 2]);
+			IEnumerable<int> subject = ToEnumerable([1, 1, 2]);
 
 			async Task Act()
-				=> await Expect.That(enumerable).IsEmpty();
+				=> await Expect.That(subject).IsEmpty();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that enumerable
+				                  Expected that subject
 				                  is empty,
 				                  but found [1, 1, 2]
-				                  at Expect.That(enumerable).IsEmpty()
+				                  at Expect.That(subject).IsEmpty()
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenEnumerableIsEmpty_ShouldSucceed()
 		{
-			IEnumerable<int> enumerable = ToEnumerable([]);
+			IEnumerable<int> subject = ToEnumerable([]);
 
 			async Task Act()
-				=> await Expect.That(enumerable).IsEmpty();
+				=> await Expect.That(subject).IsEmpty();
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.IsNotEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.IsNotEmptyTests.cs
@@ -11,10 +11,10 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotEnumerateTwice()
 		{
-			ThrowWhenIteratingTwiceEnumerable enumerable = new();
+			ThrowWhenIteratingTwiceEnumerable subject = new();
 
 			async Task Act()
-				=> await Expect.That(enumerable).IsNotEmpty()
+				=> await Expect.That(subject).IsNotEmpty()
 					.And.IsNotEmpty();
 
 			await Expect.That(Act).DoesNotThrow();
@@ -23,8 +23,10 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotMaterializeEnumerable()
 		{
+			var subject = Factory.GetFibonacciNumbers();
+
 			async Task Act()
-				=> await Expect.That(Factory.GetFibonacciNumbers()).IsNotEmpty();
+				=> await Expect.That(subject).IsNotEmpty();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -32,10 +34,10 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task WhenEnumerableContainsValues_ShouldSucceed()
 		{
-			IEnumerable<int> enumerable = ToEnumerable([1, 1, 2]);
+			IEnumerable<int> subject = ToEnumerable([1, 1, 2]);
 
 			async Task Act()
-				=> await Expect.That(enumerable).IsNotEmpty();
+				=> await Expect.That(subject).IsNotEmpty();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -43,17 +45,17 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task WhenEnumerableIsEmpty_ShouldFail()
 		{
-			IEnumerable<int> enumerable = ToEnumerable([]);
+			IEnumerable<int> subject = ToEnumerable([]);
 
 			async Task Act()
-				=> await Expect.That(enumerable).IsNotEmpty();
+				=> await Expect.That(subject).IsNotEmpty();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that enumerable
+				                  Expected that subject
 				                  is not empty,
 				                  but it was
-				                  at Expect.That(enumerable).IsNotEmpty()
+				                  at Expect.That(subject).IsNotEmpty()
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.NoneAreTests.cs
+++ b/Tests/Testably.Expectations.Tests/Collections/ThatEnumerable.NoneAreTests.cs
@@ -11,10 +11,10 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotEnumerateTwice()
 		{
-			ThrowWhenIteratingTwiceEnumerable enumerable = new();
+			ThrowWhenIteratingTwiceEnumerable subject = new();
 
 			async Task Act()
-				=> await Expect.That(enumerable).None().Are(15)
+				=> await Expect.That(subject).None().Are(15)
 					.And.None().Are(81);
 
 			await Expect.That(Act).DoesNotThrow();
@@ -23,42 +23,44 @@ public sealed partial class ThatEnumerable
 		[Fact]
 		public async Task DoesNotMaterializeEnumerable()
 		{
+			var subject = Factory.GetFibonacciNumbers();
+
 			async Task Act()
-				=> await Expect.That(Factory.GetFibonacciNumbers()).None().Are(5);
+				=> await Expect.That(subject).None().Are(5);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that Factory.GetFibonacciNumbers()
+				                  Expected that subject
 				                  has no items equal to 5,
 				                  but at least one items were equal
-				                  at Expect.That(Factory.GetFibonacciNumbers()).None().Are(5)
+				                  at Expect.That(subject).None().Are(5)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenEnumerableContainsEqualValues_ShouldFail()
 		{
-			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await Expect.That(enumerable).None().Are(1);
+				=> await Expect.That(subject).None().Are(1);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that enumerable
+				                  Expected that subject
 				                  has no items equal to 1,
 				                  but at least one items were equal
-				                  at Expect.That(enumerable).None().Are(1)
+				                  at Expect.That(subject).None().Are(1)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenEnumerableOnlyContainsDifferentValues_ShouldSucceed()
 		{
-			IEnumerable<int> enumerable = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await Expect.That(enumerable).None().Are(42);
+				=> await Expect.That(subject).None().Are(42);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Core/BecauseTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/BecauseTests.cs
@@ -8,10 +8,10 @@ public class BecauseTests
 	public async Task Apply_Because_Reason_On_Action()
 	{
 		string because = "this is the reason";
-		Action variable = () => throw new Exception();
+		Action subject = () => throw new Exception();
 
 		async Task Act()
-			=> await Expect.That(variable).DoesNotThrow().Because(because);
+			=> await Expect.That(subject).DoesNotThrow().Because(because);
 
 		await Expect.That(Act).ThrowsWithMessage($"*{because}*");
 	}
@@ -21,10 +21,10 @@ public class BecauseTests
 	{
 		string because1 = "this is the first reason";
 		string because2 = "this is the second reason";
-		bool variable = true;
+		bool subject = true;
 
 		async Task Act()
-			=> await Expect.That(variable).IsTrue().Because(because1)
+			=> await Expect.That(subject).IsTrue().Because(because1)
 				.And.IsFalse().Because(because2);
 
 		await Expect.That(Act).ThrowsWithMessage($"*{because2}*");
@@ -35,10 +35,10 @@ public class BecauseTests
 	{
 		string because1 = "this is the first reason";
 		string because2 = "this is the second reason";
-		bool variable = true;
+		bool subject = true;
 
 		async Task Act()
-			=> await Expect.That(variable).IsTrue().Because(because1)
+			=> await Expect.That(subject).IsTrue().Because(because1)
 				.And.IsFalse().Because(because2);
 
 		await Expect.That(Act).ThrowsWithMessage($"*{because1}*{because2}*");
@@ -48,16 +48,16 @@ public class BecauseTests
 	public async Task Apply_Because_Reasons_Only_On_Previous_Constraints()
 	{
 		string expectedMessage = """
-		                         Expected that variable
+		                         Expected that subject
 		                         is True, because we only apply it to previous constraints and is False,
 		                         but found True
-		                         at Expect.That(variable).IsTrue().And.IsFalse()
+		                         at Expect.That(subject).IsTrue().And.IsFalse()
 		                         """;
 		string because = "we only apply it to previous constraints";
-		bool variable = true;
+		bool subject = true;
 
 		async Task Act()
-			=> await Expect.That(variable).IsTrue().Because(because)
+			=> await Expect.That(subject).IsTrue().Because(because)
 				.And.IsFalse();
 
 		await Expect.That(Act).ThrowsException()
@@ -69,10 +69,10 @@ public class BecauseTests
 	{
 		string because1 = "this is the first reason";
 		string because2 = "this is the second reason";
-		bool variable = false;
+		bool subject = false;
 
 		async Task Act()
-			=> await Expect.That(variable).IsTrue().Because(because1)
+			=> await Expect.That(subject).IsTrue().Because(because1)
 				.And.IsFalse().Because(because2);
 
 		await Expect.That(Act).ThrowsWithMessage($"*{because1}*");
@@ -82,10 +82,10 @@ public class BecauseTests
 	public async Task Honor_Already_Present_Because_Prefix()
 	{
 		string because = "because we honor a leading 'because'";
-		bool variable = true;
+		bool subject = true;
 
 		async Task Act()
-			=> await Expect.That(variable).IsFalse().Because(because);
+			=> await Expect.That(subject).IsFalse().Because(because);
 
 		Exception exception = await Expect.That(Act).ThrowsWithMessage("*because*");
 		await Expect.That(exception.Message).DoesNotContain("because because");
@@ -95,10 +95,10 @@ public class BecauseTests
 	public async Task Include_Because_Reason_In_Message()
 	{
 		string because = "I want to test 'because'";
-		bool variable = true;
+		bool subject = true;
 
 		async Task Act()
-			=> await Expect.That(variable).IsFalse().Because(because);
+			=> await Expect.That(subject).IsFalse().Because(because);
 
 		await Expect.That(Act).ThrowsWithMessage($"*{because}*");
 	}
@@ -109,10 +109,10 @@ public class BecauseTests
 	[InlineData("because we honor a leading 'because'", "because we honor a leading 'because'")]
 	public async Task Prefix_Because_Message(string because, string expectedWithPrefix)
 	{
-		bool variable = true;
+		bool subject = true;
 
 		async Task Act()
-			=> await Expect.That(variable).IsFalse().Because(because);
+			=> await Expect.That(subject).IsFalse().Because(because);
 
 		await Expect.That(Act).ThrowsWithMessage($"*{expectedWithPrefix}*");
 	}
@@ -121,16 +121,16 @@ public class BecauseTests
 	public async Task Without_Because_Use_Empty_String()
 	{
 		string expectedMessage = """
-		                         Expected that variable
+		                         Expected that subject
 		                         is False,
 		                         but found True
-		                         at Expect.That(variable).IsFalse()
+		                         at Expect.That(subject).IsFalse()
 		                         """;
 
-		bool variable = true;
+		bool subject = true;
 
 		async Task Act()
-			=> await Expect.That(variable).IsFalse();
+			=> await Expect.That(subject).IsFalse();
 
 		await Expect.That(Act).ThrowsException()
 			.Which.HasMessage(expectedMessage);

--- a/Tests/Testably.Expectations.Tests/Core/ConstraintResultTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/ConstraintResultTests.cs
@@ -9,10 +9,10 @@ public sealed class ConstraintResultTests
 	public async Task Failure_WithoutValue_ShouldStoreTexts(string expectationText,
 		string resultText)
 	{
-		ConstraintResult.Failure sut = new(expectationText, resultText);
+		ConstraintResult.Failure subject = new(expectationText, resultText);
 
-		await Expect.That(sut.ExpectationText).Is(expectationText);
-		await Expect.That(sut.ResultText).Is(resultText);
+		await Expect.That(subject.ExpectationText).Is(expectationText);
+		await Expect.That(subject.ResultText).Is(resultText);
 	}
 
 	[Theory]
@@ -25,11 +25,11 @@ public sealed class ConstraintResultTests
 			Value = 1
 		};
 
-		ConstraintResult.Failure<Dummy> sut = new(value, expectationText, resultText);
+		ConstraintResult.Failure<Dummy> subject = new(value, expectationText, resultText);
 
-		await Expect.That(sut.Value).IsEquivalentTo(value);
-		await Expect.That(sut.ExpectationText).Is(expectationText);
-		await Expect.That(sut.ResultText).Is(resultText);
+		await Expect.That(subject.Value).IsEquivalentTo(value);
+		await Expect.That(subject.ExpectationText).Is(expectationText);
+		await Expect.That(subject.ResultText).Is(resultText);
 	}
 
 	[Theory]
@@ -37,9 +37,9 @@ public sealed class ConstraintResultTests
 	public async Task Invert_FromFailure_ShouldKeepExpectationText(string expectationText,
 		string resultText)
 	{
-		ConstraintResult.Failure sut = new(expectationText, resultText);
+		ConstraintResult.Failure subject = new(expectationText, resultText);
 
-		ConstraintResult result = sut.Invert();
+		ConstraintResult result = subject.Invert();
 
 		await Expect.That(result).Is<ConstraintResult.Success>()
 			.Which(s => s.ExpectationText, e => e.Is(expectationText));
@@ -50,9 +50,9 @@ public sealed class ConstraintResultTests
 	public async Task Invert_FromFailure_ShouldUpdateExpectationText(string expectationText,
 		string resultText)
 	{
-		ConstraintResult.Failure sut = new("foo", "bar");
+		ConstraintResult.Failure subject = new("foo", "bar");
 
-		ConstraintResult result = sut.Invert(_ => expectationText, _ => resultText);
+		ConstraintResult result = subject.Invert(_ => expectationText, _ => resultText);
 
 		await Expect.That(result).Is<ConstraintResult.Success>()
 			.Which(s => s.ExpectationText, e => e.Is(expectationText));
@@ -67,9 +67,9 @@ public sealed class ConstraintResultTests
 		{
 			Value = 1
 		};
-		ConstraintResult.Failure<Dummy> sut = new(value, expectationText, resultText);
+		ConstraintResult.Failure<Dummy> subject = new(value, expectationText, resultText);
 
-		ConstraintResult result = sut.Invert();
+		ConstraintResult result = subject.Invert();
 
 		await Expect.That(result).Is<ConstraintResult.Success<Dummy>>()
 			.Which(s => s.Value, e => e.IsEquivalentTo(value));
@@ -84,9 +84,9 @@ public sealed class ConstraintResultTests
 		{
 			Value = 1
 		};
-		ConstraintResult.Failure<Dummy> sut = new(value, expectationText, resultText);
+		ConstraintResult.Failure<Dummy> subject = new(value, expectationText, resultText);
 
-		ConstraintResult result = sut.Invert();
+		ConstraintResult result = subject.Invert();
 
 		await Expect.That(result).Is<ConstraintResult.Success<Dummy>>()
 			.Which(s => s.ExpectationText, e => e.Is(expectationText));
@@ -102,9 +102,9 @@ public sealed class ConstraintResultTests
 		{
 			Value = 1
 		};
-		ConstraintResult.Failure<Dummy> sut = new(value, "foo", "bar");
+		ConstraintResult.Failure<Dummy> subject = new(value, "foo", "bar");
 
-		ConstraintResult result = sut.Invert(_ => expectationText, _ => resultText);
+		ConstraintResult result = subject.Invert(_ => expectationText, _ => resultText);
 
 		await Expect.That(result).Is<ConstraintResult.Success<Dummy>>()
 			.Which(s => s.ExpectationText, e => e.Is(expectationText));
@@ -115,9 +115,9 @@ public sealed class ConstraintResultTests
 	public async Task Invert_FromSuccess_ShouldKeepExpectationTextAndUseDefaultResultText(
 		string expectationText)
 	{
-		ConstraintResult.Success sut = new(expectationText);
+		ConstraintResult.Success subject = new(expectationText);
 
-		ConstraintResult result = sut.Invert();
+		ConstraintResult result = subject.Invert();
 
 		await Expect.That(result).Is<ConstraintResult.Failure>()
 			.Which(s => s.ExpectationText, e => e.Is(expectationText))
@@ -129,9 +129,9 @@ public sealed class ConstraintResultTests
 	public async Task Invert_FromSuccess_ShouldUpdateExpectationAndDefaultResultText(
 		string expectationText, string resultText)
 	{
-		ConstraintResult.Success sut = new("foo");
+		ConstraintResult.Success subject = new("foo");
 
-		ConstraintResult result = sut.Invert(_ => expectationText, _ => resultText);
+		ConstraintResult result = subject.Invert(_ => expectationText, _ => resultText);
 
 		await Expect.That(result).Is<ConstraintResult.Failure>()
 			.Which(p => p.ExpectationText, e => e.Is(expectationText))
@@ -146,9 +146,9 @@ public sealed class ConstraintResultTests
 		{
 			Value = 1
 		};
-		ConstraintResult.Success<Dummy> sut = new(value, expectationText);
+		ConstraintResult.Success<Dummy> subject = new(value, expectationText);
 
-		ConstraintResult result = sut.Invert();
+		ConstraintResult result = subject.Invert();
 
 		await Expect.That(result).Is<ConstraintResult.Failure<Dummy>>()
 			.Which(p => p.Value, e => e.IsEquivalentTo(value));
@@ -163,9 +163,9 @@ public sealed class ConstraintResultTests
 		{
 			Value = 1
 		};
-		ConstraintResult.Success<Dummy> sut = new(value, expectationText);
+		ConstraintResult.Success<Dummy> subject = new(value, expectationText);
 
-		ConstraintResult result = sut.Invert();
+		ConstraintResult result = subject.Invert();
 
 		await Expect.That(result).Is<ConstraintResult.Failure<Dummy>>()
 			.Which(p => p.ExpectationText, e => e.Is(expectationText))
@@ -181,9 +181,9 @@ public sealed class ConstraintResultTests
 		{
 			Value = 1
 		};
-		ConstraintResult.Success<Dummy> sut = new(value, "foo");
+		ConstraintResult.Success<Dummy> subject = new(value, "foo");
 
-		ConstraintResult result = sut.Invert(_ => expectationText, _ => resultText);
+		ConstraintResult result = subject.Invert(_ => expectationText, _ => resultText);
 
 		await Expect.That(result).Is<ConstraintResult.Failure<Dummy>>()
 			.Which(p => p.ExpectationText, e => e.Is(expectationText))
@@ -199,10 +199,10 @@ public sealed class ConstraintResultTests
 			Value = 1
 		};
 
-		ConstraintResult.Success<Dummy> sut = new(value, expectationText);
+		ConstraintResult.Success<Dummy> subject = new(value, expectationText);
 
-		await Expect.That(sut.Value).IsEquivalentTo(value);
-		await Expect.That(sut.ExpectationText).Is(expectationText);
+		await Expect.That(subject.Value).IsEquivalentTo(value);
+		await Expect.That(subject.ExpectationText).Is(expectationText);
 	}
 
 	[Theory]
@@ -210,9 +210,9 @@ public sealed class ConstraintResultTests
 	public async Task ToString_Failure_ShouldBeExpectationTextWithPrependedFailed(
 		string expectationText)
 	{
-		ConstraintResult.Failure sut = new(expectationText, "result text");
+		ConstraintResult.Failure subject = new(expectationText, "result text");
 
-		string result = sut.ToString();
+		string result = subject.ToString();
 
 		await Expect.That(result).Is($"FAILED {expectationText}");
 	}
@@ -222,9 +222,9 @@ public sealed class ConstraintResultTests
 	public async Task ToString_Success_ShouldBeExpectationTextWithPrependedSucceeded(
 		string expectationText)
 	{
-		ConstraintResult.Success sut = new(expectationText);
+		ConstraintResult.Success subject = new(expectationText);
 
-		string result = sut.ToString();
+		string result = subject.ToString();
 
 		await Expect.That(result).Is($"SUCCEEDED {expectationText}");
 	}

--- a/Tests/Testably.Expectations.Tests/Core/Exceptions/FailExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Exceptions/FailExceptionTests.cs
@@ -6,8 +6,8 @@ public sealed class FailExceptionTests
 	[AutoData]
 	public async Task Message_ShouldBeSet(string message)
 	{
-		FailException sut = new(message);
+		FailException subject = new(message);
 
-		await Expect.That(sut.Message).Is(message);
+		await Expect.That(subject.Message).Is(message);
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Core/Exceptions/SkipExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Exceptions/SkipExceptionTests.cs
@@ -6,8 +6,8 @@ public sealed class SkipExceptionTests
 	[AutoData]
 	public async Task Message_ShouldBeSet(string message)
 	{
-		SkipException sut = new(message);
+		SkipException subject = new(message);
 
-		await Expect.That(sut.Message).Is(message);
+		await Expect.That(subject.Message).Is(message);
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Core/Nodes/WhichNodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Nodes/WhichNodeTests.cs
@@ -5,7 +5,7 @@ public sealed class WhichNodeTests
 	[Fact]
 	public async Task WhichCreatesGoodMessage()
 	{
-		Dummy sut = new()
+		Dummy subject = new()
 		{
 			Inner = new Dummy.Nested
 			{
@@ -15,19 +15,19 @@ public sealed class WhichNodeTests
 		};
 
 		async Task Act()
-			=> await Expect.That(sut).Is<Dummy>()
+			=> await Expect.That(subject).Is<Dummy>()
 				.Which(p => p.Value, e => e.Is("bar"));
 
 		await Expect.That(Act).Throws<XunitException>()
 			.Which.HasMessage("""
-			                  Expected that sut
+			                  Expected that subject
 			                  is type Dummy which Value is equal to "bar",
 			                  but found "foo" which differs at index 0:
 			                     ↓ (actual)
 			                    "foo"
 			                    "bar"
 			                     ↑ (expected)
-			                  at Expect.That(sut).Is<Dummy>().Which(p => p.Value, e => e.Is("bar"))
+			                  at Expect.That(subject).Is<Dummy>().Which(p => p.Value, e => e.Is("bar"))
 			                  """);
 	}
 

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.DoesNotThrowTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.DoesNotThrowTests.cs
@@ -17,10 +17,10 @@ public sealed partial class ThatDelegate
 			Exception exception = CreateCustomException();
 			Action action = () => throw exception;
 
-			Func<Task> sut = async ()
+			async Task Act()
 				=> await Expect.That(action).DoesNotThrow();
 
-			await Expect.That(sut).ThrowsException()
+			await Expect.That(Act).ThrowsException()
 				.Which.HasMessage(expectedMessage);
 		}
 
@@ -39,10 +39,10 @@ public sealed partial class ThatDelegate
 		{
 			Action action = () => { };
 
-			Func<Task> sut = async ()
+			async Task Act()
 				=> await Expect.That(action).DoesNotThrow();
 
-			await Expect.That(sut).DoesNotThrow();
+			await Expect.That(Act).DoesNotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsExactlyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsExactlyTests.cs
@@ -17,10 +17,10 @@ public sealed partial class ThatDelegate
 			Exception exception = CreateOtherException();
 			Action action = () => throw exception;
 
-			Func<Task<CustomException>> sut = async ()
+			async Task<CustomException> Act()
 				=> await Expect.That(action).ThrowsExactly<CustomException>();
 
-			await Expect.That(sut).ThrowsException()
+			await Expect.That(Act).ThrowsException()
 				.Which.HasMessage(expectedMessage);
 		}
 
@@ -37,10 +37,10 @@ public sealed partial class ThatDelegate
 			Exception exception = CreateSubCustomException();
 			Action action = () => throw exception;
 
-			Func<Task<CustomException>> sut = async ()
+			async Task<CustomException> Act()
 				=> await Expect.That(action).ThrowsExactly<CustomException>();
 
-			await Expect.That(sut).ThrowsException()
+			await Expect.That(Act).ThrowsException()
 				.Which.HasMessage(expectedMessage);
 		}
 
@@ -55,10 +55,10 @@ public sealed partial class ThatDelegate
 			                         """;
 			Action action = () => { };
 
-			Func<Task<CustomException>> sut = async ()
+			async Task<CustomException> Act()
 				=> await Expect.That(action).ThrowsExactly<CustomException>();
 
-			await Expect.That(sut).ThrowsException()
+			await Expect.That(Act).ThrowsException()
 				.Which.HasMessage(expectedMessage);
 		}
 
@@ -79,10 +79,10 @@ public sealed partial class ThatDelegate
 			Exception exception = CreateCustomException();
 			Action action = () => throw exception;
 
-			Func<Task<CustomException>> sut = async ()
+			async Task<CustomException> Act()
 				=> await Expect.That(action).ThrowsExactly<CustomException>();
 
-			await Expect.That(sut).DoesNotThrow();
+			await Expect.That(Act).DoesNotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsExceptionTests.cs
@@ -15,10 +15,10 @@ public sealed partial class ThatDelegate
 			                         """;
 			Action action = () => { };
 
-			Func<Task<Exception>> sut = async ()
+			async Task<Exception> Act()
 				=> await Expect.That(action).ThrowsException();
 
-			await Expect.That(sut).ThrowsException()
+			await Expect.That(Act).ThrowsException()
 				.Which.HasMessage(expectedMessage);
 		}
 
@@ -39,10 +39,10 @@ public sealed partial class ThatDelegate
 			Exception exception = CreateCustomException();
 			Action action = () => throw exception;
 
-			Func<Task<Exception>> sut = async ()
+			async Task<Exception> Act()
 				=> await Expect.That(action).ThrowsException();
 
-			await Expect.That(sut).DoesNotThrow();
+			await Expect.That(Act).DoesNotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Delegates/ThatDelegate.ThrowsTests.cs
@@ -17,10 +17,10 @@ public sealed partial class ThatDelegate
 			Exception exception = CreateOtherException();
 			Action action = () => throw exception;
 
-			Func<Task<CustomException>> sut = async ()
+			async Task<CustomException> Act()
 				=> await Expect.That(action).Throws<CustomException>();
 
-			await Expect.That(sut).ThrowsException()
+			await Expect.That(Act).ThrowsException()
 				.Which.HasMessage(expectedMessage);
 		}
 
@@ -37,10 +37,10 @@ public sealed partial class ThatDelegate
 			Exception exception = CreateCustomException();
 			Action action = () => throw exception;
 
-			Func<Task<SubCustomException>> sut = async ()
+			async Task<SubCustomException> Act()
 				=> await Expect.That(action).Throws<SubCustomException>();
 
-			await Expect.That(sut).ThrowsException()
+			await Expect.That(Act).ThrowsException()
 				.Which.HasMessage(expectedMessage);
 		}
 
@@ -55,10 +55,10 @@ public sealed partial class ThatDelegate
 			                         """;
 			Action action = () => { };
 
-			Func<Task<CustomException>> sut = async ()
+			async Task<CustomException> Act()
 				=> await Expect.That(action).Throws<CustomException>();
 
-			await Expect.That(sut).ThrowsException()
+			await Expect.That(Act).ThrowsException()
 				.Which.HasMessage(expectedMessage);
 		}
 
@@ -79,10 +79,10 @@ public sealed partial class ThatDelegate
 			Exception exception = CreateCustomException();
 			Action action = () => throw exception;
 
-			Func<Task<CustomException>> sut = async ()
+			async Task<CustomException> Act()
 				=> await Expect.That(action).Throws<CustomException>();
 
-			await Expect.That(sut).DoesNotThrow();
+			await Expect.That(Act).DoesNotThrow();
 		}
 
 		[Fact]
@@ -91,10 +91,10 @@ public sealed partial class ThatDelegate
 			Exception exception = CreateSubCustomException();
 			Action action = () => throw exception;
 
-			Func<Task<CustomException>> sut = async ()
+			async Task<CustomException> Act()
 				=> await Expect.That(action).Throws<CustomException>();
 
-			await Expect.That(sut).DoesNotThrow();
+			await Expect.That(Act).DoesNotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.ImpliesTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.ImpliesTests.cs
@@ -5,7 +5,7 @@ public sealed partial class ThatBool
 	public sealed class ImpliesTests
 	{
 		[Fact]
-		public async Task Fails_For_Not_Implying_Values()
+		public async Task WhenAntecedentDoesNotImplyConsequent_ShouldFail()
 		{
 			bool antecedent = true;
 			bool consequent = false;
@@ -26,7 +26,8 @@ public sealed partial class ThatBool
 		[InlineData(false, false)]
 		[InlineData(false, true)]
 		[InlineData(true, true)]
-		public async Task Succeeds_For_Implying_Values(bool antecedent, bool consequent)
+		public async Task WhenAntecedentImpliesConsequent_ShouldSucceed(bool antecedent,
+			bool consequent)
 		{
 			async Task Act()
 				=> await Expect.That(antecedent).Implies(consequent);

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsFalseTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsFalseTests.cs
@@ -5,31 +5,31 @@ public sealed partial class ThatBool
 	public sealed class IsFalseTests
 	{
 		[Fact]
-		public async Task Fails_For_True_Value()
+		public async Task WhenFalse_ShouldSucceed()
 		{
-			bool value = true;
+			bool subject = false;
 
 			async Task Act()
-				=> await Expect.That(value).IsFalse();
+				=> await Expect.That(subject).IsFalse();
 
-			await Expect.That(Act).Throws<XunitException>()
-				.Which.HasMessage("""
-				                  Expected that value
-				                  is False,
-				                  but found True
-				                  at Expect.That(value).IsFalse()
-				                  """);
+			await Expect.That(Act).DoesNotThrow();
 		}
 
 		[Fact]
-		public async Task Succeeds_For_False_Value()
+		public async Task WhenTrue_ShouldFail()
 		{
-			bool value = false;
+			bool subject = true;
 
 			async Task Act()
-				=> await Expect.That(value).IsFalse();
+				=> await Expect.That(subject).IsFalse();
 
-			await Expect.That(Act).DoesNotThrow();
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that subject
+				                  is False,
+				                  but found True
+				                  at Expect.That(subject).IsFalse()
+				                  """);
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsNotTests.cs
@@ -7,33 +7,33 @@ public sealed partial class ThatBool
 		[Theory]
 		[InlineData(true)]
 		[InlineData(false)]
-		public async Task WhenValuesAreTheSame_ShouldFail(bool value)
+		public async Task WhenValuesAreDifferent_ShouldSucceed(bool subject)
 		{
-			bool unexpected = value;
+			bool unexpected = !subject;
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
-			await Expect.That(Act).Throws<XunitException>()
-				.Which.HasMessage($"""
-				                   Expected that value
-				                   is not {unexpected},
-				                   but found {value}
-				                   at Expect.That(value).IsNot(unexpected)
-				                   """);
+			await Expect.That(Act).DoesNotThrow();
 		}
 
 		[Theory]
 		[InlineData(true)]
 		[InlineData(false)]
-		public async Task WhenValuesAreDifferent_ShouldSucceed(bool value)
+		public async Task WhenValuesAreTheSame_ShouldFail(bool subject)
 		{
-			bool unexpected = !value;
+			bool unexpected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
-			await Expect.That(Act).DoesNotThrow();
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   is not {unexpected},
+				                   but found {subject}
+				                   at Expect.That(subject).IsNot(unexpected)
+				                   """);
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsTests.cs
@@ -7,31 +7,31 @@ public sealed partial class ThatBool
 		[Theory]
 		[InlineData(true)]
 		[InlineData(false)]
-		public async Task WhenValuesAreDifferent_ShouldFail(bool value)
+		public async Task WhenValuesAreDifferent_ShouldFail(bool subject)
 		{
-			bool expected = !value;
+			bool expected = !subject;
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is {expected},
-				                   but found {value}
-				                   at Expect.That(value).Is(expected)
+				                   but found {subject}
+				                   at Expect.That(subject).Is(expected)
 				                   """);
 		}
 
 		[Theory]
 		[InlineData(true)]
 		[InlineData(false)]
-		public async Task WhenValuesAreTheSame_ShouldSucceed(bool value)
+		public async Task WhenValuesAreTheSame_ShouldSucceed(bool subject)
 		{
-			bool expected = value;
+			bool expected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsTrueTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatBool.IsTrueTests.cs
@@ -5,29 +5,29 @@ public sealed partial class ThatBool
 	public sealed class IsTrueTests
 	{
 		[Fact]
-		public async Task Fails_For_False_Value()
+		public async Task WhenFalse_ShouldFail()
 		{
-			bool value = false;
+			bool subject = false;
 
 			async Task Act()
-				=> await Expect.That(value).IsTrue();
+				=> await Expect.That(subject).IsTrue();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that value
+				                  Expected that subject
 				                  is True,
 				                  but found False
-				                  at Expect.That(value).IsTrue()
+				                  at Expect.That(subject).IsTrue()
 				                  """);
 		}
 
 		[Fact]
-		public async Task Succeeds_For_True_Value()
+		public async Task WhenTrue_ShouldSucceed()
 		{
-			bool value = true;
+			bool subject = true;
 
 			async Task Act()
-				=> await Expect.That(value).IsTrue();
+				=> await Expect.That(subject).IsTrue();
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsFalseTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsFalseTests.cs
@@ -5,46 +5,46 @@ public sealed partial class ThatNullableBool
 	public sealed class IsFalseTests
 	{
 		[Fact]
-		public async Task Fails_For_Null_Value()
+		public async Task WhenNull_ShouldFail()
 		{
-			bool? value = null;
+			bool? subject = null;
 
 			async Task Act()
-				=> await Expect.That(value).IsFalse();
+				=> await Expect.That(subject).IsFalse();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that value
+				                  Expected that subject
 				                  is False,
 				                  but found <null>
-				                  at Expect.That(value).IsFalse()
+				                  at Expect.That(subject).IsFalse()
 				                  """);
 		}
 
 		[Fact]
-		public async Task Fails_For_True_Value()
+		public async Task WhenTrue_ShouldFail()
 		{
-			bool? value = true;
+			bool? subject = true;
 
 			async Task Act()
-				=> await Expect.That(value).IsFalse();
+				=> await Expect.That(subject).IsFalse();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that value
+				                  Expected that subject
 				                  is False,
 				                  but found True
-				                  at Expect.That(value).IsFalse()
+				                  at Expect.That(subject).IsFalse()
 				                  """);
 		}
 
 		[Fact]
-		public async Task Succeeds_For_False_Value()
+		public async Task WhenFalse_ShouldSucceed()
 		{
-			bool? value = false;
+			bool? subject = false;
 
 			async Task Act()
-				=> await Expect.That(value).IsFalse();
+				=> await Expect.That(subject).IsFalse();
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotFalseTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotFalseTests.cs
@@ -5,29 +5,40 @@ public sealed partial class ThatNullableBool
 	public sealed class IsNotFalseTests
 	{
 		[Fact]
-		public async Task Fails_For_False_Value()
+		public async Task WhenFalse_ShouldFail()
 		{
-			bool? value = false;
+			bool? subject = false;
 
 			async Task Act()
-				=> await Expect.That(value).IsNotFalse();
+				=> await Expect.That(subject).IsNotFalse();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that value
+				                  Expected that subject
 				                  is not False,
 				                  but found False
-				                  at Expect.That(value).IsNotFalse()
+				                  at Expect.That(subject).IsNotFalse()
 				                  """);
 		}
 
-		[Theory]
-		[InlineData(true)]
-		[InlineData(null)]
-		public async Task Succeeds_For_True_Or_Null_Value(bool? value)
+		[Fact]
+		public async Task WhenNull_ShouldSucceed()
 		{
+			bool? subject = null;
+
 			async Task Act()
-				=> await Expect.That(value).IsNotFalse();
+				=> await Expect.That(subject).IsNotFalse();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenTrue_ShouldSucceed()
+		{
+			bool? subject = true;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNotFalse();
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotNullTests.cs
@@ -5,29 +5,40 @@ public sealed partial class ThatNullableBool
 	public sealed class IsNotNullTests
 	{
 		[Fact]
-		public async Task Fails_For_Null_Value()
+		public async Task WhenFalse_ShouldSucceed()
 		{
-			bool? value = null;
+			bool? subject = false;
 
 			async Task Act()
-				=> await Expect.That(value).IsNotNull();
+				=> await Expect.That(subject).IsNotNull();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenNull_ShouldFail()
+		{
+			bool? subject = null;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNotNull();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that value
+				                  Expected that subject
 				                  is not <null>,
 				                  but found <null>
-				                  at Expect.That(value).IsNotNull()
+				                  at Expect.That(subject).IsNotNull()
 				                  """);
 		}
 
-		[Theory]
-		[InlineData(true)]
-		[InlineData(false)]
-		public async Task Succeeds_For_True_Or_False_Value(bool? value)
+		[Fact]
+		public async Task WhenTrue_ShouldSucceed()
 		{
+			bool? subject = true;
+
 			async Task Act()
-				=> await Expect.That(value).IsNotNull();
+				=> await Expect.That(subject).IsNotNull();
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotTests.cs
@@ -8,19 +8,19 @@ public sealed partial class ThatNullableBool
 		[InlineData(true)]
 		[InlineData(false)]
 		[InlineData(null)]
-		public async Task WhenValuesAreTheSame_ShouldFail(bool? value)
+		public async Task WhenValuesAreTheSame_ShouldFail(bool? subject)
 		{
-			bool? unexpected = value;
+			bool? unexpected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not {unexpected?.ToString() ?? "<null>"},
-				                   but found {value?.ToString() ?? "<null>"}
-				                   at Expect.That(value).IsNot(unexpected)
+				                   but found {subject?.ToString() ?? "<null>"}
+				                   at Expect.That(subject).IsNot(unexpected)
 				                   """);
 		}
 
@@ -31,10 +31,10 @@ public sealed partial class ThatNullableBool
 		[InlineData(false, null)]
 		[InlineData(null, true)]
 		[InlineData(null, false)]
-		public async Task WhenValuesAreDifferent_ShouldSucceed(bool? value, bool? unexpected)
+		public async Task WhenValuesAreDifferent_ShouldSucceed(bool? subject, bool? unexpected)
 		{
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotTrueTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNotTrueTests.cs
@@ -5,31 +5,42 @@ public sealed partial class ThatNullableBool
 	public sealed class IsNotTrueTests
 	{
 		[Fact]
-		public async Task Fails_For_True_Value()
+		public async Task WhenFalse_ShouldFail()
 		{
-			bool? value = true;
+			bool? subject = false;
 
 			async Task Act()
-				=> await Expect.That(value).IsNotTrue();
+				=> await Expect.That(subject).IsNotTrue();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenNull_ShouldFail()
+		{
+			bool? subject = null;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNotTrue();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenTrue_ShouldFail()
+		{
+			bool? subject = true;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNotTrue();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that value
+				                  Expected that subject
 				                  is not True,
 				                  but found True
-				                  at Expect.That(value).IsNotTrue()
+				                  at Expect.That(subject).IsNotTrue()
 				                  """);
-		}
-
-		[Theory]
-		[InlineData(false)]
-		[InlineData(null)]
-		public async Task Succeeds_For_False_Or_Null_Value(bool? value)
-		{
-			async Task Act()
-				=> await Expect.That(value).IsNotTrue();
-
-			await Expect.That(Act).DoesNotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNullTests.cs
@@ -41,10 +41,10 @@ public sealed partial class ThatNullableBool
 		[Fact]
 		public async Task WhenNull_ShouldSucceed()
 		{
-			bool? value = null;
+			bool? subject = null;
 
 			async Task Act()
-				=> await Expect.That(value).IsNull();
+				=> await Expect.That(subject).IsNull();
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsNullTests.cs
@@ -5,41 +5,41 @@ public sealed partial class ThatNullableBool
 	public sealed class IsNullTests
 	{
 		[Fact]
-		public async Task Fails_For_False_Value()
+		public async Task WhenFalse_ShouldFail()
 		{
-			bool? value = false;
+			bool? subject = false;
 
 			async Task Act()
-				=> await Expect.That(value).IsNull();
+				=> await Expect.That(subject).IsNull();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that value
+				                  Expected that subject
 				                  is <null>,
 				                  but found False
-				                  at Expect.That(value).IsNull()
+				                  at Expect.That(subject).IsNull()
 				                  """);
 		}
 
 		[Fact]
-		public async Task Fails_For_True_Value()
+		public async Task WhenTrue_ShouldFail()
 		{
-			bool? value = true;
+			bool? subject = true;
 
 			async Task Act()
-				=> await Expect.That(value).IsNull();
+				=> await Expect.That(subject).IsNull();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that value
+				                  Expected that subject
 				                  is <null>,
 				                  but found True
-				                  at Expect.That(value).IsNull()
+				                  at Expect.That(subject).IsNull()
 				                  """);
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Null_Value()
+		public async Task WhenNull_ShouldSucceed()
 		{
 			bool? value = null;
 

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsTests.cs
@@ -11,17 +11,17 @@ public sealed partial class ThatNullableBool
 		[InlineData(false, null)]
 		[InlineData(null, true)]
 		[InlineData(null, false)]
-		public async Task WhenValuesAreDifferent_ShouldFail(bool? value, bool? expected)
+		public async Task WhenValuesAreDifferent_ShouldFail(bool? subject, bool? expected)
 		{
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is {expected?.ToString() ?? "<null>"},
-				                   but found {value?.ToString() ?? "<null>"}
-				                   at Expect.That(value).Is(expected)
+				                   but found {subject?.ToString() ?? "<null>"}
+				                   at Expect.That(subject).Is(expected)
 				                   """);
 		}
 
@@ -29,12 +29,12 @@ public sealed partial class ThatNullableBool
 		[InlineData(true)]
 		[InlineData(false)]
 		[InlineData(null)]
-		public async Task WhenValuesAreTheSame_ShouldSucceed(bool? value)
+		public async Task WhenValuesAreTheSame_ShouldSucceed(bool? subject)
 		{
-			bool? expected = value;
+			bool? expected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsTrueTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsTrueTests.cs
@@ -41,10 +41,10 @@ public sealed partial class ThatNullableBool
 		[Fact]
 		public async Task WhenTrue_ShouldSucceed()
 		{
-			bool? value = true;
+			bool? subject = true;
 
 			async Task Act()
-				=> await Expect.That(value).IsTrue();
+				=> await Expect.That(subject).IsTrue();
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsTrueTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Booleans/ThatNullableBool.IsTrueTests.cs
@@ -5,41 +5,41 @@ public sealed partial class ThatNullableBool
 	public sealed class IsTrueTests
 	{
 		[Fact]
-		public async Task Fails_For_False_Value()
+		public async Task WhenFalse_ShouldFail()
 		{
-			bool? value = false;
+			bool? subject = false;
 
 			async Task Act()
-				=> await Expect.That(value).IsTrue();
+				=> await Expect.That(subject).IsTrue();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that value
+				                  Expected that subject
 				                  is True,
 				                  but found False
-				                  at Expect.That(value).IsTrue()
+				                  at Expect.That(subject).IsTrue()
 				                  """);
 		}
 
 		[Fact]
-		public async Task Fails_For_Null_Value()
+		public async Task WhenNull_ShouldFail()
 		{
-			bool? value = null;
+			bool? subject = null;
 
 			async Task Act()
-				=> await Expect.That(value).IsTrue();
+				=> await Expect.That(subject).IsTrue();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that value
+				                  Expected that subject
 				                  is True,
 				                  but found <null>
-				                  at Expect.That(value).IsTrue()
+				                  at Expect.That(subject).IsTrue()
 				                  """);
 		}
 
 		[Fact]
-		public async Task Succeeds_For_True_Value()
+		public async Task WhenTrue_ShouldSucceed()
 		{
 			bool? value = true;
 

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsNotTests.cs
@@ -8,29 +8,29 @@ public sealed partial class ThatDateOnly
 		[Fact]
 		public async Task WhenValuesAreTheSame_ShouldFail()
 		{
-			DateOnly value = CurrentTime();
-			DateOnly unexpected = value;
+			DateOnly subject = CurrentTime();
+			DateOnly unexpected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not {unexpected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsNot(unexpected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNot(unexpected)
 				                   """);
 		}
 
 		[Fact]
 		public async Task WhenValuesAreDifferent_ShouldSucceed()
 		{
-			DateOnly value = CurrentTime();
+			DateOnly subject = CurrentTime();
 			DateOnly unexpected = LaterTime();
 			
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateOnly.IsTests.cs
@@ -8,29 +8,29 @@ public sealed partial class ThatDateOnly
 		[Fact]
 		public async Task WhenValuesAreDifferent_ShouldFail()
 		{
-			DateOnly value = CurrentTime();
+			DateOnly subject = CurrentTime();
 			DateOnly expected = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).Is(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).Is(expected)
 				                   """);
 		}
 
 		[Fact]
 		public async Task WhenValuesAreTheSame_ShouldSucceed()
 		{
-			DateOnly value = CurrentTime();
-			DateOnly expected = value;
+			DateOnly subject = CurrentTime();
+			DateOnly expected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsAfterTests.cs
@@ -8,17 +8,17 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsEarlier_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime();
+			DateTime subject = EarlierTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsAfter(expected);
+				=> await Expect.That(subject).IsAfter(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is after {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsAfter(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsAfter(expected)
 				                   """);
 		}
 
@@ -26,17 +26,17 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsSame_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = expected;
+			DateTime subject = expected;
 
 			async Task Act()
-				=> await Expect.That(value).IsAfter(expected);
+				=> await Expect.That(subject).IsAfter(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is after {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsAfter(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsAfter(expected)
 				                   """);
 		}
 
@@ -44,10 +44,10 @@ public sealed partial class ThatDateTime
 		public async Task WhenValuesIsLater_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime();
+			DateTime subject = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsAfter(expected);
+				=> await Expect.That(subject).IsAfter(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -56,17 +56,17 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime(3);
+			DateTime subject = EarlierTime(3);
 
 			async Task Act()
-				=> await Expect.That(value).IsAfter(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsAfter(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is after {expected:O} ± 0:03,
-				                   but found {value:O}
-				                   at Expect.That(value).IsAfter(expected).Within(TimeSpan.FromSeconds(3))
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsAfter(expected).Within(TimeSpan.FromSeconds(3))
 				                   """);
 		}
 
@@ -74,10 +74,10 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime(2);
+			DateTime subject = EarlierTime(2);
 
 			async Task Act()
-				=> await Expect.That(value).IsAfter(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsAfter(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsBeforeTests.cs
@@ -8,17 +8,17 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsLater_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime();
+			DateTime subject = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsBefore(expected);
+				=> await Expect.That(subject).IsBefore(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is before {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsBefore(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsBefore(expected)
 				                   """);
 		}
 
@@ -26,17 +26,17 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsSame_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = expected;
+			DateTime subject = expected;
 
 			async Task Act()
-				=> await Expect.That(value).IsBefore(expected);
+				=> await Expect.That(subject).IsBefore(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is before {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsBefore(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsBefore(expected)
 				                   """);
 		}
 
@@ -44,10 +44,10 @@ public sealed partial class ThatDateTime
 		public async Task WhenValuesIsEarlier_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime();
+			DateTime subject = EarlierTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsBefore(expected);
+				=> await Expect.That(subject).IsBefore(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -56,17 +56,17 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime(3);
+			DateTime subject = LaterTime(3);
 
 			async Task Act()
-				=> await Expect.That(value).IsBefore(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsBefore(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is before {expected:O} ± 0:03,
-				                   but found {value:O}
-				                   at Expect.That(value).IsBefore(expected).Within(TimeSpan.FromSeconds(3))
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsBefore(expected).Within(TimeSpan.FromSeconds(3))
 				                   """);
 		}
 
@@ -74,10 +74,10 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime(2);
+			DateTime subject = LaterTime(2);
 
 			async Task Act()
-				=> await Expect.That(value).IsBefore(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsBefore(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotAfterTests.cs
@@ -8,17 +8,17 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsLater_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime();
+			DateTime subject = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsNotAfter(expected);
+				=> await Expect.That(subject).IsNotAfter(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not after {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsNotAfter(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNotAfter(expected)
 				                   """);
 		}
 
@@ -26,10 +26,10 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsSame_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = expected;
+			DateTime subject = expected;
 
 			async Task Act()
-				=> await Expect.That(value).IsNotAfter(expected);
+				=> await Expect.That(subject).IsNotAfter(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -38,10 +38,10 @@ public sealed partial class ThatDateTime
 		public async Task WhenValuesIsEarlier_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime();
+			DateTime subject = EarlierTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsNotAfter(expected);
+				=> await Expect.That(subject).IsNotAfter(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -50,17 +50,17 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime(4);
+			DateTime subject = LaterTime(4);
 
 			async Task Act()
-				=> await Expect.That(value).IsNotAfter(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsNotAfter(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not after {expected:O} ± 0:03,
-				                   but found {value:O}
-				                   at Expect.That(value).IsNotAfter(expected).Within(TimeSpan.FromSeconds(3))
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNotAfter(expected).Within(TimeSpan.FromSeconds(3))
 				                   """);
 		}
 
@@ -68,10 +68,10 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime(3);
+			DateTime subject = LaterTime(3);
 
 			async Task Act()
-				=> await Expect.That(value).IsNotAfter(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsNotAfter(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotBeforeTests.cs
@@ -8,17 +8,17 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsEarlier_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime();
+			DateTime subject = EarlierTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsNotBefore(expected);
+				=> await Expect.That(subject).IsNotBefore(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not before {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsNotBefore(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNotBefore(expected)
 				                   """);
 		}
 
@@ -26,10 +26,10 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsSame_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = expected;
+			DateTime subject = expected;
 
 			async Task Act()
-				=> await Expect.That(value).IsNotBefore(expected);
+				=> await Expect.That(subject).IsNotBefore(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -38,10 +38,10 @@ public sealed partial class ThatDateTime
 		public async Task WhenValuesIsLater_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime();
+			DateTime subject = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsNotBefore(expected);
+				=> await Expect.That(subject).IsNotBefore(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -50,17 +50,17 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime(4);
+			DateTime subject = EarlierTime(4);
 
 			async Task Act()
-				=> await Expect.That(value).IsNotBefore(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsNotBefore(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not before {expected:O} ± 0:03,
-				                   but found {value:O}
-				                   at Expect.That(value).IsNotBefore(expected).Within(TimeSpan.FromSeconds(3))
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNotBefore(expected).Within(TimeSpan.FromSeconds(3))
 				                   """);
 		}
 
@@ -68,10 +68,10 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime(3);
+			DateTime subject = EarlierTime(3);
 
 			async Task Act()
-				=> await Expect.That(value).IsNotBefore(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsNotBefore(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrAfterTests.cs
@@ -8,17 +8,17 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsLater_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime();
+			DateTime subject = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsNotOnOrAfter(expected);
+				=> await Expect.That(subject).IsNotOnOrAfter(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not on or after {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsNotOnOrAfter(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNotOnOrAfter(expected)
 				                   """);
 		}
 
@@ -26,17 +26,17 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsSame_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = expected;
+			DateTime subject = expected;
 
 			async Task Act()
-				=> await Expect.That(value).IsNotOnOrAfter(expected);
+				=> await Expect.That(subject).IsNotOnOrAfter(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not on or after {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsNotOnOrAfter(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNotOnOrAfter(expected)
 				                   """);
 		}
 
@@ -44,10 +44,10 @@ public sealed partial class ThatDateTime
 		public async Task WhenValuesIsEarlier_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime();
+			DateTime subject = EarlierTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsNotOnOrAfter(expected);
+				=> await Expect.That(subject).IsNotOnOrAfter(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -56,18 +56,18 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime(3);
+			DateTime subject = LaterTime(3);
 
 			async Task Act()
-				=> await Expect.That(value).IsNotOnOrAfter(expected)
+				=> await Expect.That(subject).IsNotOnOrAfter(expected)
 					.Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not on or after {expected:O} ± 0:03,
-				                   but found {value:O}
-				                   at Expect.That(value).IsNotOnOrAfter(expected).Within(TimeSpan.FromSeconds(3))
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNotOnOrAfter(expected).Within(TimeSpan.FromSeconds(3))
 				                   """);
 		}
 
@@ -75,10 +75,10 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime(2);
+			DateTime subject = LaterTime(2);
 
 			async Task Act()
-				=> await Expect.That(value).IsNotOnOrAfter(expected)
+				=> await Expect.That(subject).IsNotOnOrAfter(expected)
 					.Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).DoesNotThrow();

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotOnOrBeforeTests.cs
@@ -8,17 +8,17 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsEarlier_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime();
+			DateTime subject = EarlierTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsNotOnOrBefore(expected);
+				=> await Expect.That(subject).IsNotOnOrBefore(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not on or before {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsNotOnOrBefore(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNotOnOrBefore(expected)
 				                   """);
 		}
 
@@ -26,17 +26,17 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsSame_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = expected;
+			DateTime subject = expected;
 
 			async Task Act()
-				=> await Expect.That(value).IsNotOnOrBefore(expected);
+				=> await Expect.That(subject).IsNotOnOrBefore(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not on or before {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsNotOnOrBefore(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNotOnOrBefore(expected)
 				                   """);
 		}
 
@@ -44,10 +44,10 @@ public sealed partial class ThatDateTime
 		public async Task WhenValuesIsLater_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime();
+			DateTime subject = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsNotOnOrBefore(expected);
+				=> await Expect.That(subject).IsNotOnOrBefore(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -56,18 +56,18 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime(3);
+			DateTime subject = EarlierTime(3);
 
 			async Task Act()
-				=> await Expect.That(value).IsNotOnOrBefore(expected)
+				=> await Expect.That(subject).IsNotOnOrBefore(expected)
 					.Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not on or before {expected:O} ± 0:03,
-				                   but found {value:O}
-				                   at Expect.That(value).IsNotOnOrBefore(expected).Within(TimeSpan.FromSeconds(3))
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNotOnOrBefore(expected).Within(TimeSpan.FromSeconds(3))
 				                   """);
 		}
 
@@ -75,10 +75,10 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime(2);
+			DateTime subject = EarlierTime(2);
 
 			async Task Act()
-				=> await Expect.That(value).IsNotOnOrBefore(expected)
+				=> await Expect.That(subject).IsNotOnOrBefore(expected)
 					.Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).DoesNotThrow();

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsNotTests.cs
@@ -7,11 +7,11 @@ public sealed partial class ThatDateTime
 		[Fact]
 		public async Task WhenValuesAreDifferent_ShouldSucceed()
 		{
-			DateTime value = CurrentTime();
+			DateTime subject = CurrentTime();
 			DateTime unexpected = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -19,29 +19,29 @@ public sealed partial class ThatDateTime
 		[Fact]
 		public async Task WhenValuesAreTheSame_ShouldFail()
 		{
-			DateTime value = CurrentTime();
-			DateTime unexpected = value;
+			DateTime subject = CurrentTime();
+			DateTime unexpected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not {unexpected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsNot(unexpected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNot(unexpected)
 				                   """);
 		}
 
 		[Fact]
 		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
 		{
-			DateTime value = CurrentTime();
+			DateTime subject = CurrentTime();
 			DateTime expected = LaterTime(4);
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsNot(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -49,18 +49,18 @@ public sealed partial class ThatDateTime
 		[Fact]
 		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
 		{
-			DateTime value = CurrentTime();
+			DateTime subject = CurrentTime();
 			DateTime expected = LaterTime(3);
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsNot(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not {expected:O} ± 0:03,
-				                   but found {value:O}
-				                   at Expect.That(value).IsNot(expected).Within(TimeSpan.FromSeconds(3))
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNot(expected).Within(TimeSpan.FromSeconds(3))
 				                   """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrAfterTests.cs
@@ -8,17 +8,17 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsEarlier_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime();
+			DateTime subject = EarlierTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsOnOrAfter(expected);
+				=> await Expect.That(subject).IsOnOrAfter(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is on or after {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsOnOrAfter(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsOnOrAfter(expected)
 				                   """);
 		}
 
@@ -26,10 +26,10 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsSame_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = expected;
+			DateTime subject = expected;
 
 			async Task Act()
-				=> await Expect.That(value).IsOnOrAfter(expected);
+				=> await Expect.That(subject).IsOnOrAfter(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -38,10 +38,10 @@ public sealed partial class ThatDateTime
 		public async Task WhenValuesIsLater_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime();
+			DateTime subject = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsOnOrAfter(expected);
+				=> await Expect.That(subject).IsOnOrAfter(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -50,17 +50,17 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime(4);
+			DateTime subject = EarlierTime(4);
 
 			async Task Act()
-				=> await Expect.That(value).IsOnOrAfter(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsOnOrAfter(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is on or after {expected:O} ± 0:03,
-				                   but found {value:O}
-				                   at Expect.That(value).IsOnOrAfter(expected).Within(TimeSpan.FromSeconds(3))
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsOnOrAfter(expected).Within(TimeSpan.FromSeconds(3))
 				                   """);
 		}
 
@@ -68,10 +68,10 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime(3);
+			DateTime subject = EarlierTime(3);
 
 			async Task Act()
-				=> await Expect.That(value).IsOnOrAfter(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsOnOrAfter(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsOnOrBeforeTests.cs
@@ -8,17 +8,17 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsLater_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime();
+			DateTime subject = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsOnOrBefore(expected);
+				=> await Expect.That(subject).IsOnOrBefore(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is on or before {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsOnOrBefore(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsOnOrBefore(expected)
 				                   """);
 		}
 
@@ -26,10 +26,10 @@ public sealed partial class ThatDateTime
 		public async Task WhenValueIsSame_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = expected;
+			DateTime subject = expected;
 
 			async Task Act()
-				=> await Expect.That(value).IsOnOrBefore(expected);
+				=> await Expect.That(subject).IsOnOrBefore(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -38,10 +38,10 @@ public sealed partial class ThatDateTime
 		public async Task WhenValuesIsEarlier_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = EarlierTime();
+			DateTime subject = EarlierTime();
 
 			async Task Act()
-				=> await Expect.That(value).IsOnOrBefore(expected);
+				=> await Expect.That(subject).IsOnOrBefore(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -50,17 +50,17 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime(4);
+			DateTime subject = LaterTime(4);
 
 			async Task Act()
-				=> await Expect.That(value).IsOnOrBefore(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsOnOrBefore(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is on or before {expected:O} ± 0:03,
-				                   but found {value:O}
-				                   at Expect.That(value).IsOnOrBefore(expected).Within(TimeSpan.FromSeconds(3))
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsOnOrBefore(expected).Within(TimeSpan.FromSeconds(3))
 				                   """);
 		}
 
@@ -68,10 +68,10 @@ public sealed partial class ThatDateTime
 		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
 		{
 			DateTime expected = CurrentTime();
-			DateTime value = LaterTime(3);
+			DateTime subject = LaterTime(3);
 
 			async Task Act()
-				=> await Expect.That(value).IsOnOrBefore(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).IsOnOrBefore(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTime.IsTests.cs
@@ -7,29 +7,29 @@ public sealed partial class ThatDateTime
 		[Fact]
 		public async Task WhenValuesAreDifferent_ShouldFail()
 		{
-			DateTime value = CurrentTime();
+			DateTime subject = CurrentTime();
 			DateTime expected = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).Is(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).Is(expected)
 				                   """);
 		}
 
 		[Fact]
 		public async Task WhenValuesAreTheSame_ShouldSucceed()
 		{
-			DateTime value = CurrentTime();
-			DateTime expected = value;
+			DateTime subject = CurrentTime();
+			DateTime expected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -37,29 +37,29 @@ public sealed partial class ThatDateTime
 		[Fact]
 		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			DateTime value = CurrentTime();
+			DateTime subject = CurrentTime();
 			DateTime expected = LaterTime(4);
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).Is(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is {expected:O} ± 0:03,
-				                   but found {value:O}
-				                   at Expect.That(value).Is(expected).Within(TimeSpan.FromSeconds(3))
+				                   but found {subject:O}
+				                   at Expect.That(subject).Is(expected).Within(TimeSpan.FromSeconds(3))
 				                   """);
 		}
 
 		[Fact]
 		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
 		{
-			DateTime value = CurrentTime();
+			DateTime subject = CurrentTime();
 			DateTime expected = LaterTime(3);
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected).Within(TimeSpan.FromSeconds(3));
+				=> await Expect.That(subject).Is(expected).Within(TimeSpan.FromSeconds(3));
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsNotTests.cs
@@ -7,29 +7,29 @@ public sealed partial class ThatDateTimeOffset
 		[Fact]
 		public async Task WhenValuesAreTheSame_ShouldFail()
 		{
-			DateTimeOffset value = CurrentTime();
-			DateTimeOffset unexpected = value;
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset unexpected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not {unexpected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsNot(unexpected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNot(unexpected)
 				                   """);
 		}
 
 		[Fact]
 		public async Task WhenValuesAreDifferent_ShouldSucceed()
 		{
-			DateTimeOffset value = CurrentTime();
+			DateTimeOffset subject = CurrentTime();
 			DateTimeOffset unexpected = LaterTime();
 			
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatDateTimeOffset.IsTests.cs
@@ -7,29 +7,29 @@ public sealed partial class ThatDateTimeOffset
 		[Fact]
 		public async Task WhenValuesAreDifferent_ShouldFail()
 		{
-			DateTimeOffset value = CurrentTime();
+			DateTimeOffset subject = CurrentTime();
 			DateTimeOffset expected = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).Is(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).Is(expected)
 				                   """);
 		}
 
 		[Fact]
 		public async Task WhenValuesAreTheSame_ShouldSucceed()
 		{
-			DateTimeOffset value = CurrentTime();
-			DateTimeOffset expected = value;
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset expected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsNotTests.cs
@@ -8,29 +8,29 @@ public sealed partial class ThatTimeOnly
 		[Fact]
 		public async Task WhenValuesAreTheSame_ShouldFail()
 		{
-			TimeOnly value = CurrentTime();
-			TimeOnly unexpected = value;
+			TimeOnly subject = CurrentTime();
+			TimeOnly unexpected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not {unexpected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).IsNot(unexpected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).IsNot(unexpected)
 				                   """);
 		}
 
 		[Fact]
 		public async Task WhenValuesAreDifferent_ShouldSucceed()
 		{
-			TimeOnly value = CurrentTime();
+			TimeOnly subject = CurrentTime();
 			TimeOnly unexpected = LaterTime();
 			
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeOnly.IsTests.cs
@@ -8,29 +8,29 @@ public sealed partial class ThatTimeOnly
 		[Fact]
 		public async Task WhenValuesAreDifferent_ShouldFail()
 		{
-			TimeOnly value = CurrentTime();
+			TimeOnly subject = CurrentTime();
 			TimeOnly expected = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is {expected:O},
-				                   but found {value:O}
-				                   at Expect.That(value).Is(expected)
+				                   but found {subject:O}
+				                   at Expect.That(subject).Is(expected)
 				                   """);
 		}
 
 		[Fact]
 		public async Task WhenValuesAreTheSame_ShouldSucceed()
 		{
-			TimeOnly value = CurrentTime();
-			TimeOnly expected = value;
+			TimeOnly subject = CurrentTime();
+			TimeOnly expected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsNotTests.cs
@@ -9,29 +9,29 @@ public sealed partial class ThatTimeSpan
 		[Fact]
 		public async Task WhenValuesAreTheSame_ShouldFail()
 		{
-			TimeSpan value = CurrentTime();
-			TimeSpan unexpected = value;
+			TimeSpan subject = CurrentTime();
+			TimeSpan unexpected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not {Formatter.Format(unexpected)},
-				                   but found {Formatter.Format(value)}
-				                   at Expect.That(value).IsNot(unexpected)
+				                   but found {Formatter.Format(subject)}
+				                   at Expect.That(subject).IsNot(unexpected)
 				                   """);
 		}
 
 		[Fact]
 		public async Task WhenValuesAreDifferent_ShouldSucceed()
 		{
-			TimeSpan value = CurrentTime();
+			TimeSpan subject = CurrentTime();
 			TimeSpan unexpected = LaterTime();
 			
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Chronology/ThatTimeSpan.IsTests.cs
@@ -9,29 +9,29 @@ public sealed partial class ThatTimeSpan
 		[Fact]
 		public async Task WhenValuesAreDifferent_ShouldFail()
 		{
-			TimeSpan value = CurrentTime();
+			TimeSpan subject = CurrentTime();
 			TimeSpan expected = LaterTime();
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is {Formatter.Format(expected)},
-				                   but found {Formatter.Format(value)}
-				                   at Expect.That(value).Is(expected)
+				                   but found {Formatter.Format(subject)}
+				                   at Expect.That(subject).Is(expected)
 				                   """);
 		}
 
 		[Fact]
 		public async Task WhenValuesAreTheSame_ShouldSucceed()
 		{
-			TimeSpan value = CurrentTime();
-			TimeSpan expected = value;
+			TimeSpan subject = CurrentTime();
+			TimeSpan expected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatEnum.DoesNotHaveFlagTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatEnum.DoesNotHaveFlagTests.cs
@@ -7,17 +7,17 @@ public sealed partial class ThatEnum
 		[Theory]
 		[InlineData(MyColors.Blue | MyColors.Green, MyColors.Green)]
 		[InlineData(MyColors.Blue | MyColors.Yellow, MyColors.Blue)]
-		public async Task WhenSubjectHasFlag_ShouldFail(MyColors value, MyColors unexpected)
+		public async Task WhenSubjectHasFlag_ShouldFail(MyColors subject, MyColors unexpected)
 		{
 			async Task Act()
-				=> await Expect.That(value).DoesNotHaveFlag(unexpected);
+				=> await Expect.That(subject).DoesNotHaveFlag(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   does not have flag {unexpected},
-				                   but found {value}
-				                   at Expect.That(value).DoesNotHaveFlag(unexpected)
+				                   but found {subject}
+				                   at Expect.That(subject).DoesNotHaveFlag(unexpected)
 				                   """);
 		}
 
@@ -26,10 +26,10 @@ public sealed partial class ThatEnum
 		[InlineData(MyColors.Green)]
 		public async Task WhenSubjectDoesNotHaveFlag_ShouldSucceed(MyColors unexpected)
 		{
-			MyColors value = MyColors.Yellow | MyColors.Red & ~unexpected;
+			MyColors subject = MyColors.Yellow | MyColors.Red & ~unexpected;
 
 			async Task Act()
-				=> await Expect.That(value).DoesNotHaveFlag(unexpected);
+				=> await Expect.That(subject).DoesNotHaveFlag(unexpected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -37,19 +37,19 @@ public sealed partial class ThatEnum
 		[Theory]
 		[InlineData(MyColors.Blue)]
 		[InlineData(MyColors.Green)]
-		public async Task WhenValuesAreTheSame_ShouldFail(MyColors value)
+		public async Task WhenValuesAreTheSame_ShouldFail(MyColors subject)
 		{
-			MyColors unexpected = value;
+			MyColors unexpected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).DoesNotHaveFlag(unexpected);
+				=> await Expect.That(subject).DoesNotHaveFlag(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   does not have flag {unexpected},
-				                   but found {value}
-				                   at Expect.That(value).DoesNotHaveFlag(unexpected)
+				                   but found {subject}
+				                   at Expect.That(subject).DoesNotHaveFlag(unexpected)
 				                   """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatEnum.HasFlagTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatEnum.HasFlagTests.cs
@@ -7,17 +7,17 @@ public sealed partial class ThatEnum
 		[Theory]
 		[InlineData(MyColors.Blue | MyColors.Red, MyColors.Green)]
 		[InlineData(MyColors.Green | MyColors.Yellow, MyColors.Blue)]
-		public async Task WhenSubjectDoesNotHaveFlag_ShouldFail(MyColors value, MyColors expected)
+		public async Task WhenSubjectDoesNotHaveFlag_ShouldFail(MyColors subject, MyColors expected)
 		{
 			async Task Act()
-				=> await Expect.That(value).HasFlag(expected);
+				=> await Expect.That(subject).HasFlag(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   has flag {expected},
-				                   but found {value}
-				                   at Expect.That(value).HasFlag(expected)
+				                   but found {subject}
+				                   at Expect.That(subject).HasFlag(expected)
 				                   """);
 		}
 
@@ -26,10 +26,10 @@ public sealed partial class ThatEnum
 		[InlineData(MyColors.Green)]
 		public async Task WhenSubjectHasFlag_ShouldSucceed(MyColors expected)
 		{
-			MyColors value = MyColors.Yellow | MyColors.Red | expected;
+			MyColors subject = MyColors.Yellow | MyColors.Red | expected;
 
 			async Task Act()
-				=> await Expect.That(value).HasFlag(expected);
+				=> await Expect.That(subject).HasFlag(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -37,12 +37,12 @@ public sealed partial class ThatEnum
 		[Theory]
 		[InlineData(MyColors.Blue)]
 		[InlineData(MyColors.Green)]
-		public async Task WhenValuesAreTheSame_ShouldSucceed(MyColors value)
+		public async Task WhenValuesAreTheSame_ShouldSucceed(MyColors subject)
 		{
-			MyColors expected = value;
+			MyColors expected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).HasFlag(expected);
+				=> await Expect.That(subject).HasFlag(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatEnum.IsDefinedTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatEnum.IsDefinedTests.cs
@@ -7,10 +7,10 @@ public sealed partial class ThatEnum
 		[Theory]
 		[InlineData(MyColors.Blue)]
 		[InlineData(MyColors.Green)]
-		public async Task WhenValueIsDefined_ShouldSucceed(MyColors value)
+		public async Task WhenValueIsDefined_ShouldSucceed(MyColors subject)
 		{
 			async Task Act()
-				=> await Expect.That(value).IsDefined();
+				=> await Expect.That(subject).IsDefined();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -18,17 +18,17 @@ public sealed partial class ThatEnum
 		[Fact]
 		public async Task WhenValueIsNotDefined_ShouldFail()
 		{
-			MyColors value = (MyColors)42;
+			MyColors subject = (MyColors)42;
 
 			async Task Act()
-				=> await Expect.That(value).IsDefined();
+				=> await Expect.That(subject).IsDefined();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is defined,
-				                   but found {value}
-				                   at Expect.That(value).IsDefined()
+				                   but found {subject}
+				                   at Expect.That(subject).IsDefined()
 				                   """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatEnum.IsNotDefinedTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatEnum.IsNotDefinedTests.cs
@@ -7,27 +7,27 @@ public sealed partial class ThatEnum
 		[Theory]
 		[InlineData(MyColors.Blue)]
 		[InlineData(MyColors.Green)]
-		public async Task WhenValueIsDefined_ShouldFail(MyColors value)
+		public async Task WhenValueIsDefined_ShouldFail(MyColors subject)
 		{
 			async Task Act()
-				=> await Expect.That(value).IsNotDefined();
+				=> await Expect.That(subject).IsNotDefined();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not defined,
-				                   but found {value}
-				                   at Expect.That(value).IsNotDefined()
+				                   but found {subject}
+				                   at Expect.That(subject).IsNotDefined()
 				                   """);
 		}
 
 		[Fact]
 		public async Task WhenValueIsNotDefined_ShouldSucceed()
 		{
-			MyColors value = (MyColors)42;
+			MyColors subject = (MyColors)42;
 
 			async Task Act()
-				=> await Expect.That(value).IsNotDefined();
+				=> await Expect.That(subject).IsNotDefined();
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatEnum.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatEnum.IsNotTests.cs
@@ -7,29 +7,29 @@ public sealed partial class ThatEnum
 		[Theory]
 		[InlineData(MyColors.Blue)]
 		[InlineData(MyColors.Green)]
-		public async Task WhenValuesAreTheSame_ShouldFail(MyColors value)
+		public async Task WhenValuesAreTheSame_ShouldFail(MyColors subject)
 		{
-			MyColors unexpected = value;
+			MyColors unexpected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not {unexpected},
-				                   but found {value}
-				                   at Expect.That(value).IsNot(unexpected)
+				                   but found {subject}
+				                   at Expect.That(subject).IsNot(unexpected)
 				                   """);
 		}
 
 		[Theory]
 		[InlineData(MyColors.Blue, MyColors.Green)]
 		[InlineData(MyColors.Green, MyColors.Blue)]
-		public async Task WhenValuesAreDifferent_ShouldSucceed(MyColors value, MyColors unexpected)
+		public async Task WhenValuesAreDifferent_ShouldSucceed(MyColors subject, MyColors unexpected)
 		{
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatEnum.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatEnum.IsTests.cs
@@ -7,29 +7,29 @@ public sealed partial class ThatEnum
 		[Theory]
 		[InlineData(MyColors.Blue, MyColors.Green)]
 		[InlineData(MyColors.Green, MyColors.Blue)]
-		public async Task WhenValuesAreDifferent_ShouldFail(MyColors value, MyColors expected)
+		public async Task WhenValuesAreDifferent_ShouldFail(MyColors subject, MyColors expected)
 		{
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is {expected},
-				                   but found {value}
-				                   at Expect.That(value).Is(expected)
+				                   but found {subject}
+				                   at Expect.That(subject).Is(expected)
 				                   """);
 		}
 
 		[Theory]
 		[InlineData(MyColors.Blue)]
 		[InlineData(MyColors.Green)]
-		public async Task WhenValuesAreTheSame_ShouldSucceed(MyColors value)
+		public async Task WhenValuesAreTheSame_ShouldSucceed(MyColors subject)
 		{
-			MyColors expected = value;
+			MyColors expected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatNullableEnum.DoesNotHaveFlagTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatNullableEnum.DoesNotHaveFlagTests.cs
@@ -7,17 +7,17 @@ public sealed partial class ThatNullableEnum
 		[Theory]
 		[InlineData(MyColors.Blue | MyColors.Green, MyColors.Green)]
 		[InlineData(MyColors.Blue | MyColors.Yellow, MyColors.Blue)]
-		public async Task WhenSubjectHasFlag_ShouldFail(MyColors? value, MyColors unexpected)
+		public async Task WhenSubjectHasFlag_ShouldFail(MyColors? subject, MyColors unexpected)
 		{
 			async Task Act()
-				=> await Expect.That(value).DoesNotHaveFlag(unexpected);
+				=> await Expect.That(subject).DoesNotHaveFlag(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   does not have flag {unexpected},
-				                   but found {value}
-				                   at Expect.That(value).DoesNotHaveFlag(unexpected)
+				                   but found {subject}
+				                   at Expect.That(subject).DoesNotHaveFlag(unexpected)
 				                   """);
 		}
 
@@ -26,10 +26,10 @@ public sealed partial class ThatNullableEnum
 		[InlineData(MyColors.Green)]
 		public async Task WhenSubjectDoesNotHaveFlag_ShouldSucceed(MyColors unexpected)
 		{
-			MyColors? value = MyColors.Yellow | MyColors.Red & ~unexpected;
+			MyColors? subject = MyColors.Yellow | MyColors.Red & ~unexpected;
 
 			async Task Act()
-				=> await Expect.That(value).DoesNotHaveFlag(unexpected);
+				=> await Expect.That(subject).DoesNotHaveFlag(unexpected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -39,17 +39,17 @@ public sealed partial class ThatNullableEnum
 		[InlineData(MyColors.Green)]
 		public async Task WhenValuesAreTheSame_ShouldFail(MyColors unexpected)
 		{
-			MyColors? value = unexpected;
+			MyColors? subject = unexpected;
 
 			async Task Act()
-				=> await Expect.That(value).DoesNotHaveFlag(unexpected);
+				=> await Expect.That(subject).DoesNotHaveFlag(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   does not have flag {unexpected},
-				                   but found {value}
-				                   at Expect.That(value).DoesNotHaveFlag(unexpected)
+				                   but found {subject}
+				                   at Expect.That(subject).DoesNotHaveFlag(unexpected)
 				                   """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatNullableEnum.HasFlagTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatNullableEnum.HasFlagTests.cs
@@ -7,17 +7,17 @@ public sealed partial class ThatNullableEnum
 		[Theory]
 		[InlineData(MyColors.Blue | MyColors.Red, MyColors.Green)]
 		[InlineData(MyColors.Green | MyColors.Yellow, MyColors.Blue)]
-		public async Task WhenSubjectDoesNotHaveFlag_ShouldFail(MyColors? value, MyColors expected)
+		public async Task WhenSubjectDoesNotHaveFlag_ShouldFail(MyColors? subject, MyColors expected)
 		{
 			async Task Act()
-				=> await Expect.That(value).HasFlag(expected);
+				=> await Expect.That(subject).HasFlag(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   has flag {expected},
-				                   but found {value}
-				                   at Expect.That(value).HasFlag(expected)
+				                   but found {subject}
+				                   at Expect.That(subject).HasFlag(expected)
 				                   """);
 		}
 
@@ -26,10 +26,10 @@ public sealed partial class ThatNullableEnum
 		[InlineData(MyColors.Green)]
 		public async Task WhenSubjectHasFlag_ShouldSucceed(MyColors expected)
 		{
-			MyColors? value = MyColors.Yellow | MyColors.Red | expected;
+			MyColors? subject = MyColors.Yellow | MyColors.Red | expected;
 
 			async Task Act()
-				=> await Expect.That(value).HasFlag(expected);
+				=> await Expect.That(subject).HasFlag(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -39,10 +39,10 @@ public sealed partial class ThatNullableEnum
 		[InlineData(MyColors.Green)]
 		public async Task WhenValuesAreTheSame_ShouldSucceed(MyColors expected)
 		{
-			MyColors? value = expected;
+			MyColors? subject = expected;
 
 			async Task Act()
-				=> await Expect.That(value).HasFlag(expected);
+				=> await Expect.That(subject).HasFlag(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatNullableEnum.IsDefinedTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatNullableEnum.IsDefinedTests.cs
@@ -7,10 +7,10 @@ public sealed partial class ThatNullableEnum
 		[Theory]
 		[InlineData(MyColors.Blue)]
 		[InlineData(MyColors.Green)]
-		public async Task WhenValueIsDefined_ShouldSucceed(MyColors? value)
+		public async Task WhenValueIsDefined_ShouldSucceed(MyColors? subject)
 		{
 			async Task Act()
-				=> await Expect.That(value).IsDefined();
+				=> await Expect.That(subject).IsDefined();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -18,17 +18,17 @@ public sealed partial class ThatNullableEnum
 		[Fact]
 		public async Task WhenValueIsNotDefined_ShouldFail()
 		{
-			MyColors? value = (MyColors)42;
+			MyColors? subject = (MyColors)42;
 
 			async Task Act()
-				=> await Expect.That(value).IsDefined();
+				=> await Expect.That(subject).IsDefined();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is defined,
-				                   but found {value}
-				                   at Expect.That(value).IsDefined()
+				                   but found {subject}
+				                   at Expect.That(subject).IsDefined()
 				                   """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatNullableEnum.IsNotDefinedTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatNullableEnum.IsNotDefinedTests.cs
@@ -7,27 +7,27 @@ public sealed partial class ThatNullableEnum
 		[Theory]
 		[InlineData(MyColors.Blue)]
 		[InlineData(MyColors.Green)]
-		public async Task WhenValueIsDefined_ShouldFail(MyColors? value)
+		public async Task WhenValueIsDefined_ShouldFail(MyColors? subject)
 		{
 			async Task Act()
-				=> await Expect.That(value).IsNotDefined();
+				=> await Expect.That(subject).IsNotDefined();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not defined,
-				                   but found {value}
-				                   at Expect.That(value).IsNotDefined()
+				                   but found {subject}
+				                   at Expect.That(subject).IsNotDefined()
 				                   """);
 		}
 
 		[Fact]
 		public async Task WhenValueIsNotDefined_ShouldSucceed()
 		{
-			MyColors? value = (MyColors)42;
+			MyColors? subject = (MyColors)42;
 
 			async Task Act()
-				=> await Expect.That(value).IsNotDefined();
+				=> await Expect.That(subject).IsNotDefined();
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatNullableEnum.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatNullableEnum.IsNotTests.cs
@@ -8,19 +8,19 @@ public sealed partial class ThatNullableEnum
 		[InlineData(MyColors.Blue)]
 		[InlineData(MyColors.Green)]
 		[InlineData(null)]
-		public async Task WhenValuesAreTheSame_ShouldFail(MyColors? value)
+		public async Task WhenValuesAreTheSame_ShouldFail(MyColors? subject)
 		{
-			MyColors? unexpected = value;
+			MyColors? unexpected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not {unexpected?.ToString() ?? "<null>"},
-				                   but found {value?.ToString() ?? "<null>"}
-				                   at Expect.That(value).IsNot(unexpected)
+				                   but found {subject?.ToString() ?? "<null>"}
+				                   at Expect.That(subject).IsNot(unexpected)
 				                   """);
 		}
 
@@ -31,10 +31,10 @@ public sealed partial class ThatNullableEnum
 		[InlineData(MyColors.Green, null)]
 		[InlineData(null, MyColors.Blue)]
 		[InlineData(null, MyColors.Green)]
-		public async Task WhenValuesAreDifferent_ShouldSucceed(MyColors? value, MyColors? unexpected)
+		public async Task WhenValuesAreDifferent_ShouldSucceed(MyColors? subject, MyColors? unexpected)
 		{
 			async Task Act()
-				=> await Expect.That(value).IsNot(unexpected);
+				=> await Expect.That(subject).IsNot(unexpected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatNullableEnum.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Enums/ThatNullableEnum.IsTests.cs
@@ -11,29 +11,29 @@ public sealed partial class ThatNullableEnum
 		[InlineData(MyColors.Green, null)]
 		[InlineData(null, MyColors.Blue)]
 		[InlineData(null, MyColors.Green)]
-		public async Task WhenValuesAreDifferent_ShouldFail(MyColors? value, MyColors? expected)
+		public async Task WhenValuesAreDifferent_ShouldFail(MyColors? subject, MyColors? expected)
 		{
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is {expected?.ToString() ?? "<null>"},
-				                   but found {value?.ToString() ?? "<null>"}
-				                   at Expect.That(value).Is(expected)
+				                   but found {subject?.ToString() ?? "<null>"}
+				                   at Expect.That(subject).Is(expected)
 				                   """);
 		}
 
 		[Theory]
 		[InlineData(MyColors.Blue)]
 		[InlineData(MyColors.Green)]
-		public async Task WhenValuesAreTheSame_ShouldSucceed(MyColors? value)
+		public async Task WhenValuesAreTheSame_ShouldSucceed(MyColors? subject)
 		{
-			MyColors? expected = value;
+			MyColors? expected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Exceptions/ThatException.HasInnerExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Exceptions/ThatException.HasInnerExceptionTests.cs
@@ -7,112 +7,112 @@ public sealed partial class ThatException
 		[Fact]
 		public async Task FailsWhenInnerExceptionHasCorrectMessageButUnexpectedType()
 		{
-			Exception sut = new("outer",
+			Exception subject = new("outer",
 				new Exception("inner"));
 
 			async Task Act()
-				=> await Expect.That(sut).HasInner<CustomException>(e => e.HasMessage("inner"));
+				=> await Expect.That(subject).HasInner<CustomException>(e => e.HasMessage("inner"));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that sut
+				                  Expected that subject
 				                  has an inner CustomException which has Message equal to "inner",
 				                  but found an Exception:
 				                    inner
-				                  at Expect.That(sut).HasInner<CustomException>(e => e.HasMessage("inner"))
+				                  at Expect.That(subject).HasInner<CustomException>(e => e.HasMessage("inner"))
 				                  """);
 		}
 
 		[Fact]
 		public async Task FailsWhenInnerExceptionHasCorrectTypeButUnexpectedMessage()
 		{
-			Exception sut = new("outer",
+			Exception subject = new("outer",
 				new CustomException("inner"));
 
 			async Task Act()
-				=> await Expect.That(sut)
+				=> await Expect.That(subject)
 					.HasInner<CustomException>(e => e.HasMessage("some other message"));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that sut
+				                  Expected that subject
 				                  has an inner CustomException which has Message equal to "some other message",
 				                  but found "inner" which differs at index 0:
 				                     ↓ (actual)
 				                    "inner"
 				                    "some other message"
 				                     ↑ (expected)
-				                  at Expect.That(sut).HasInner<CustomException>(e => e.HasMessage("some other message"))
+				                  at Expect.That(subject).HasInner<CustomException>(e => e.HasMessage("some other message"))
 				                  """);
 		}
 
 		[Fact]
 		public async Task FailsWhenInnerExceptionHasUnexpectedMessage()
 		{
-			Exception sut = new("outer",
+			Exception subject = new("outer",
 				new Exception("inner"));
 
 			async Task Act()
-				=> await Expect.That(sut)
+				=> await Expect.That(subject)
 					.HasInnerException(e => e.HasMessage("some other message"));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that sut
+				                  Expected that subject
 				                  has an inner exception which has Message equal to "some other message",
 				                  but found "inner" which differs at index 0:
 				                     ↓ (actual)
 				                    "inner"
 				                    "some other message"
 				                     ↑ (expected)
-				                  at Expect.That(sut).HasInnerException(e => e.HasMessage("some other message"))
+				                  at Expect.That(subject).HasInnerException(e => e.HasMessage("some other message"))
 				                  """);
 		}
 
 		[Fact]
 		public async Task FailsWhenInnerExceptionIsNotOfTheExpectedType()
 		{
-			Exception sut = new("outer",
+			Exception subject = new("outer",
 				new Exception("inner"));
 
 			async Task Act()
-				=> await Expect.That(sut).HasInner<CustomException>();
+				=> await Expect.That(subject).HasInner<CustomException>();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that sut
+				                  Expected that subject
 				                  has an inner CustomException,
 				                  but found an Exception:
 				                    inner
-				                  at Expect.That(sut).HasInner<CustomException>()
+				                  at Expect.That(subject).HasInner<CustomException>()
 				                  """);
 		}
 
 		[Fact]
 		public async Task FailsWhenInnerExceptionIsNotSet()
 		{
-			Exception sut = new("outer");
+			Exception subject = new("outer");
 
 			async Task Act()
-				=> await Expect.That(sut).HasInnerException();
+				=> await Expect.That(subject).HasInnerException();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that sut
+				                  Expected that subject
 				                  has an inner exception,
 				                  but it did not
-				                  at Expect.That(sut).HasInnerException()
+				                  at Expect.That(subject).HasInnerException()
 				                  """);
 		}
 
 		[Fact]
 		public async Task SucceedsWhenInnerExceptionHasCorrectMessage()
 		{
-			Exception sut = new("outer",
+			Exception subject = new("outer",
 				new CustomException("inner"));
 
 			async Task Act()
-				=> await Expect.That(sut).HasInnerException(e => e.HasMessage("inner"));
+				=> await Expect.That(subject).HasInnerException(e => e.HasMessage("inner"));
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -120,11 +120,11 @@ public sealed partial class ThatException
 		[Fact]
 		public async Task SucceedsWhenInnerExceptionHasCorrectTypeAndMessage()
 		{
-			Exception sut = new("outer",
+			Exception subject = new("outer",
 				new CustomException("inner"));
 
 			async Task Act()
-				=> await Expect.That(sut).HasInner<CustomException>(e => e.HasMessage("inner"));
+				=> await Expect.That(subject).HasInner<CustomException>(e => e.HasMessage("inner"));
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -132,11 +132,11 @@ public sealed partial class ThatException
 		[Fact]
 		public async Task SucceedsWhenInnerExceptionIsSet()
 		{
-			Exception sut = new("outer",
+			Exception subject = new("outer",
 				new Exception("inner"));
 
 			async Task Act()
-				=> await Expect.That(sut).HasInnerException();
+				=> await Expect.That(subject).HasInnerException();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -144,11 +144,11 @@ public sealed partial class ThatException
 		[Fact]
 		public async Task SucceedsWhenInnerExceptionMeetsType()
 		{
-			Exception sut = new("outer",
+			Exception subject = new("outer",
 				new CustomException("inner"));
 
 			async Task Act()
-				=> await Expect.That(sut).HasInner<CustomException>();
+				=> await Expect.That(subject).HasInner<CustomException>();
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Exceptions/ThatException.HasMessageTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Exceptions/ThatException.HasMessageTests.cs
@@ -9,21 +9,21 @@ public sealed partial class ThatException
 		{
 			string actual = "actual text";
 			string expected = "expected other text";
-			Exception sut = new(actual);
+			Exception subject = new(actual);
 
 			async Task Act()
-				=> await Expect.That(sut).HasMessage(expected);
+				=> await Expect.That(subject).HasMessage(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that sut
+				                  Expected that subject
 				                  has Message equal to "expected other text",
 				                  but found "actual text" which differs at index 0:
 				                     ↓ (actual)
 				                    "actual text"
 				                    "expected other text"
 				                     ↑ (expected)
-				                  at Expect.That(sut).HasMessage(expected)
+				                  at Expect.That(subject).HasMessage(expected)
 				                  """);
 		}
 
@@ -31,10 +31,10 @@ public sealed partial class ThatException
 		[AutoData]
 		public async Task SucceedsForSameStrings(string actual)
 		{
-			Exception sut = new(actual);
+			Exception subject = new(actual);
 
 			async Task Act()
-				=> await Expect.That(sut).HasMessage(actual);
+				=> await Expect.That(subject).HasMessage(actual);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Numbers/ThatNumber.IsNaNTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Numbers/ThatNumber.IsNaNTests.cs
@@ -5,45 +5,23 @@ public sealed partial class ThatNumber
 	public sealed class IsNaNTests
 	{
 		[Fact]
-		public async Task NaN_is_equal_to_NaN_when_its_a_double()
+		public async Task ForDouble_ShouldSupportChaining()
 		{
-			double value = double.NaN;
-
-			async Task Act() => await Expect.That(value).IsNaN();
-
-			await Expect.That(Act).DoesNotThrow();
-		}
-
-		[Fact]
-		public async Task NaN_is_equal_to_NaN_when_its_a_float()
-		{
-			float value = float.NaN;
+			double subject = double.NaN;
 
 			async Task Act()
-				=> await Expect.That(value).IsNaN();
+				=> await Expect.That(subject).IsNaN()
+					.And.Is(subject);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
 
 		[Fact]
-		public async Task Should_chain_when_asserting_NaN_as_double()
+		public async Task ForDouble_WhenSubjectIsNaN_ShouldSucceed()
 		{
-			double value = double.NaN;
+			double subject = double.NaN;
 
-			async Task Act()
-				=> await Expect.That(value).IsNaN()
-					.And.Is(value);
-
-			await Expect.That(Act).DoesNotThrow();
-		}
-
-		[Fact]
-		public async Task Should_chain_when_asserting_NaN_as_float()
-		{
-			float value = float.NaN;
-
-			async Task Act() => await Expect.That(value).IsNaN()
-				.And.Is(value);
+			async Task Act() => await Expect.That(subject).IsNaN();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -57,18 +35,40 @@ public sealed partial class ThatNumber
 		[InlineData(double.Epsilon)]
 		[InlineData(double.NegativeInfinity)]
 		[InlineData(double.PositiveInfinity)]
-		public async Task Should_fail_when_asserting_normal_double_value_to_be_NaN(double value)
+		public async Task ForDouble_WhenSubjectIsNormalValue_ShouldFail(double subject)
 		{
 			async Task Act()
-				=> await Expect.That(value).IsNaN();
+				=> await Expect.That(subject).IsNaN();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is NaN,
-				                   but found {value}
-				                   at Expect.That(value).IsNaN()
+				                   but found {subject}
+				                   at Expect.That(subject).IsNaN()
 				                   """);
+		}
+
+		[Fact]
+		public async Task ForFloat_ShouldSupportChaining()
+		{
+			float subject = float.NaN;
+
+			async Task Act() => await Expect.That(subject).IsNaN()
+				.And.Is(subject);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task ForFloat_WhenSubjectIsNaN_ShouldSucceed()
+		{
+			float subject = float.NaN;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNaN();
+
+			await Expect.That(Act).DoesNotThrow();
 		}
 
 		[Theory]
@@ -80,17 +80,17 @@ public sealed partial class ThatNumber
 		[InlineData(float.Epsilon)]
 		[InlineData(float.NegativeInfinity)]
 		[InlineData(float.PositiveInfinity)]
-		public async Task Should_fail_when_asserting_normal_float_value_to_be_NaN(float value)
+		public async Task ForFloat_WhenSubjectIsNormalValue_ShouldFail(float subject)
 		{
 			async Task Act()
-				=> await Expect.That(value).IsNaN();
+				=> await Expect.That(subject).IsNaN();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is NaN,
-				                   but found {value}
-				                   at Expect.That(value).IsNaN()
+				                   but found {subject}
+				                   at Expect.That(subject).IsNaN()
 				                   """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Primitives/Numbers/ThatNumber.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Numbers/ThatNumber.IsNotTests.cs
@@ -6,29 +6,29 @@ public sealed partial class ThatNumber
 	{
 		[Theory]
 		[AutoData]
-		public async Task WhenValuesAreTheSame_ShouldFail(int value)
+		public async Task WhenValuesAreTheSame_ShouldFail(int subject)
 		{
-			int expected = value;
+			int expected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).IsNot(expected);
+				=> await Expect.That(subject).IsNot(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is not {expected},
-				                   but found {value}
-				                   at Expect.That(value).IsNot(expected)
+				                   but found {subject}
+				                   at Expect.That(subject).IsNot(expected)
 				                   """);
 		}
 
 		[Theory]
 		[InlineData(1, 2)]
 		[InlineData(5, -3)]
-		public async Task WhenValuesAreDifferent_ShouldSucceed(int value, int expected)
+		public async Task WhenValuesAreDifferent_ShouldSucceed(int subject, int expected)
 		{
 			async Task Act()
-				=> await Expect.That(value).IsNot(expected);
+				=> await Expect.That(subject).IsNot(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Numbers/ThatNumber.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Numbers/ThatNumber.IsTests.cs
@@ -5,147 +5,147 @@ public sealed partial class ThatNumber
 	public sealed class IsTests
 	{
 		[Theory]
-		[AutoData]
-		public async Task A_double_number_is_equal_to_the_same_floating_number(float expected)
-		{
-			double value = expected;
-
-			async Task Act()
-				=> await Expect.That(value).Is(expected);
-
-			await Expect.That(Act).DoesNotThrow();
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task A_floating_number_is_equal_to_the_same_nullable_value(float value)
-		{
-			float? expected = value;
-
-			async Task Act()
-				=> await Expect.That(value).Is(expected);
-
-			await Expect.That(Act).DoesNotThrow();
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task A_floating_number_is_equal_to_the_same_value(float value)
-		{
-			float expected = value;
-
-			async Task Act()
-				=> await Expect.That(value).Is(expected);
-
-			await Expect.That(Act).DoesNotThrow();
-		}
-
-		[Theory]
 		[InlineData(1.0, 2.1)]
 		[InlineData(5.8, -3.03)]
-		public async Task A_floating_number_is_not_equal_to_a_different_value(float value,
+		public async Task ShouldFailForDifferentFloatValues(float subject,
 			float expected)
 		{
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is {expected},
-				                   but found {value}
-				                   at Expect.That(value).Is(expected)
+				                   but found {subject}
+				                   at Expect.That(subject).Is(expected)
 				                   """);
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task A_floating_number_is_not_equal_to_null(float value)
-		{
-			float? expected = null;
-
-			async Task Act()
-				=> await Expect.That(value).Is(expected);
-
-			await Expect.That(Act).Throws<XunitException>()
-				.Which.HasMessage($"""
-				                   Expected that value
-				                   is <null>,
-				                   but found {value}
-				                   at Expect.That(value).Is(expected)
-				                   """);
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task A_long_number_is_equal_to_the_same_integer_number(int expected)
-		{
-			long value = expected;
-
-			async Task Act()
-				=> await Expect.That(value).Is(expected);
-
-			await Expect.That(Act).DoesNotThrow();
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task An_integer_number_is_equal_to_the_same_nullable_value(int value)
-		{
-			int? expected = value;
-
-			async Task Act()
-				=> await Expect.That(value).Is(expected);
-
-			await Expect.That(Act).DoesNotThrow();
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task An_integer_number_is_equal_to_the_same_value(int value)
-		{
-			int expected = value;
-
-			async Task Act()
-				=> await Expect.That(value).Is(expected);
-
-			await Expect.That(Act).DoesNotThrow();
 		}
 
 		[Theory]
 		[InlineData(1, 2)]
 		[InlineData(5, -3)]
-		public async Task An_integer_number_is_not_equal_to_a_different_value(int value,
+		public async Task ShouldFailForDifferentIntegerValues(int subject,
 			int expected)
 		{
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is {expected},
-				                   but found {value}
-				                   at Expect.That(value).Is(expected)
+				                   but found {subject}
+				                   at Expect.That(subject).Is(expected)
 				                   """);
 		}
 
 		[Theory]
 		[AutoData]
-		public async Task An_integer_number_is_not_equal_to_null(int value)
+		public async Task ShouldFailForFloatComparisonWithNull(float subject)
+		{
+			float? expected = null;
+
+			async Task Act()
+				=> await Expect.That(subject).Is(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   is <null>,
+				                   but found {subject}
+				                   at Expect.That(subject).Is(expected)
+				                   """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldFailForIntegerComparisonWithNull(int subject)
 		{
 			int? expected = null;
 
 			async Task Act()
-				=> await Expect.That(value).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that value
+				                   Expected that subject
 				                   is <null>,
-				                   but found {value}
-				                   at Expect.That(value).Is(expected)
+				                   but found {subject}
+				                   at Expect.That(subject).Is(expected)
 				                   """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSucceedForEqualDoubleAndFloatValues(float expected)
+		{
+			double subject = expected;
+
+			async Task Act()
+				=> await Expect.That(subject).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSucceedForEqualFloatValueAndNullableValue(float subject)
+		{
+			float? expected = subject;
+
+			async Task Act()
+				=> await Expect.That(subject).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSucceedForEqualFloatValues(float subject)
+		{
+			float expected = subject;
+
+			async Task Act()
+				=> await Expect.That(subject).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSucceedForEqualIntegerValueAndNullableValue(int subject)
+		{
+			int? expected = subject;
+
+			async Task Act()
+				=> await Expect.That(subject).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSucceedForEqualIntegerValues(int subject)
+		{
+			int expected = subject;
+
+			async Task Act()
+				=> await Expect.That(subject).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSucceedForEqualLongAndIntegerValues(int expected)
+		{
+			long subject = expected;
+
+			async Task Act()
+				=> await Expect.That(subject).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/Objects/ThatObject.IsEquivalentToTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Objects/ThatObject.IsEquivalentToTests.cs
@@ -10,42 +10,42 @@ public sealed partial class ThatObject
 		[Fact]
 		public async Task BasicObjects_ShouldBeEquivalent()
 		{
-			var object1 = new MyClass
+			var subject = new MyClass
 			{
 				Value = "Foo"
 			};
-			var object2 = new MyClass
+			var expected = new MyClass
 			{
 				Value = "Foo"
 			};
 
-			await Expect.That(object1).IsEquivalentTo(object2);
+			await Expect.That(subject).IsEquivalentTo(expected);
 		}
 
 		[Fact]
 		public async Task MismatchedObjects_ShouldNotBeEquivalent()
 		{
-			var object1 = new MyClass();
-			var object2 = new MyClass
+			var subject = new MyClass();
+			var expected = new MyClass
 			{
 				Value = "Foo"
 			};
 
-			await Expect.That(async () => await Expect.That(object1).IsEquivalentTo(object2))
+			await Expect.That(async () => await Expect.That(subject).IsEquivalentTo(expected))
 				.ThrowsWithMessage("""
-				                   Expected that object1
-				                   is equivalent to object2,
+				                   Expected that subject
+				                   is equivalent to expected,
 				                   but Property Value did not match:
 				                     Expected: "Foo"
 				                     Received: <null>
-				                   at Expect.That(object1).IsEquivalentTo(object2)
+				                   at Expect.That(subject).IsEquivalentTo(expected)
 				                   """);
 		}
 
 		[Fact]
 		public async Task ObjectsWithNestedMismatch_ShouldNotBeEquivalent()
 		{
-			var object1 = new MyClass
+			var subject = new MyClass
 			{
 				Value = "Foo",
 				Inner = new InnerClass
@@ -54,7 +54,7 @@ public sealed partial class ThatObject
 					Inner = new InnerClass()
 				}
 			};
-			var object2 = new MyClass
+			var expected = new MyClass
 			{
 				Value = "Foo",
 				Inner = new InnerClass
@@ -67,21 +67,21 @@ public sealed partial class ThatObject
 				}
 			};
 
-			await Expect.That(async () => await Expect.That(object1).IsEquivalentTo(object2))
+			await Expect.That(async () => await Expect.That(subject).IsEquivalentTo(expected))
 				.ThrowsWithMessage("""
-				                   Expected that object1
-				                   is equivalent to object2,
+				                   Expected that subject
+				                   is equivalent to expected,
 				                   but Property Inner.Inner.Value did not match:
 				                     Expected: "Baz"
 				                     Received: <null>
-				                   at Expect.That(object1).IsEquivalentTo(object2)
+				                   at Expect.That(subject).IsEquivalentTo(expected)
 				                   """).Exactly();
 		}
 
 		[Fact]
 		public async Task ObjectsWithNestedMatches_ShouldBeEquivalent()
 		{
-			var object1 = new MyClass
+			var subject = new MyClass
 			{
 				Value = "Foo",
 				Inner = new InnerClass
@@ -93,7 +93,7 @@ public sealed partial class ThatObject
 					}
 				}
 			};
-			var object2 = new MyClass
+			var expected = new MyClass
 			{
 				Value = "Foo",
 				Inner = new InnerClass
@@ -106,13 +106,13 @@ public sealed partial class ThatObject
 				}
 			};
 
-			await Expect.That(object1).IsEquivalentTo(object2);
+			await Expect.That(subject).IsEquivalentTo(expected);
 		}
 
 		[Fact]
 		public void ObjectsWithNestedEnumerableMismatch_ShouldNotBeEquivalent()
 		{
-			var object1 = new MyClass
+			var subject = new MyClass
 			{
 				Value = "Foo",
 				Inner = new InnerClass
@@ -126,7 +126,7 @@ public sealed partial class ThatObject
 				}
 			};
 
-			var object2 = new MyClass
+			var expected = new MyClass
 			{
 				Value = "Foo",
 				Inner = new InnerClass
@@ -140,21 +140,21 @@ public sealed partial class ThatObject
 				}
 			};
 
-			Expect.That(async () => await Expect.That(object1).IsEquivalentTo(object2))
+			Expect.That(async () => await Expect.That(subject).IsEquivalentTo(expected))
 				.ThrowsWithMessage("""
-				                   Expected that object1
-				                   is equivalent to object2,
+				                   Expected that subject
+				                   is equivalent to expected,
 				                   but EnumerableItem Inner.Inner.Collection.[3] did not match
 				                     Expected: "4"
 				                     Received: null
-				                   at Expect.That(object1).IsEquivalentTo(object2)
+				                   at Expect.That(subject).IsEquivalentTo(expected)
 				                   """);
 		}
 
 		[Fact]
 		public async Task ObjectsWithNestedEnumerableMismatch_WithIgnoreRule_ShouldBeEquivalent()
 		{
-			var object1 = new MyClass
+			var subject = new MyClass
 			{
 				Value = "Foo",
 				Inner = new InnerClass
@@ -168,7 +168,7 @@ public sealed partial class ThatObject
 				}
 			};
 
-			var object2 = new MyClass
+			var expected = new MyClass
 			{
 				Value = "Foo",
 				Inner = new InnerClass
@@ -182,13 +182,13 @@ public sealed partial class ThatObject
 				}
 			};
 
-			await Expect.That(object1).IsEquivalentTo(object2).IgnoringMember("Inner.Inner.Collection.[3]");
+			await Expect.That(subject).IsEquivalentTo(expected).IgnoringMember("Inner.Inner.Collection.[3]");
 		}
 
 		[Fact]
 		public async Task ObjectsWithNestedEnumerableMatches_ShouldBeEquivalent()
 		{
-			var object1 = new MyClass
+			var subject = new MyClass
 			{
 				Value = "Foo",
 				Inner = new InnerClass
@@ -201,7 +201,7 @@ public sealed partial class ThatObject
 					}
 				}
 			};
-			var object2 = new MyClass
+			var expected = new MyClass
 			{
 				Value = "Foo",
 				Inner = new InnerClass
@@ -215,7 +215,7 @@ public sealed partial class ThatObject
 				}
 			};
 
-			await Expect.That(object1).IsEquivalentTo(object2);
+			await Expect.That(subject).IsEquivalentTo(expected);
 		}
 
 		public class MyClass

--- a/Tests/Testably.Expectations.Tests/Primitives/Objects/ThatObject.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Objects/ThatObject.IsTests.cs
@@ -8,12 +8,12 @@ public sealed partial class ThatObject
 		[AutoData]
 		public async Task S(int value)
 		{
-			object sut = new Other
+			object subject = new Other
 			{
 				Value = value
 			};
 
-			Other result = await Expect.That(sut).Is<Other>();
+			Other result = await Expect.That(subject).Is<Other>();
 			await Expect.That(result.Value).Is(value);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Primitives/Objects/ThatObject.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Objects/ThatObject.IsTests.cs
@@ -6,7 +6,7 @@ public sealed partial class ThatObject
 	{
 		[Theory]
 		[AutoData]
-		public async Task S(int value)
+		public async Task WhenTypeMatches_ShouldSucceed(int value)
 		{
 			object subject = new Other
 			{

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.ContainsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.ContainsTests.cs
@@ -7,12 +7,12 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task AtLeast_WhenExpectedStringOccursEnoughTimes_ShouldSucceed()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).AtLeast(3);
+				=> await Expect.That(subject).Contains(expected).AtLeast(3);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -20,50 +20,50 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task AtLeast_WhenExpectedStringOccursFewerTimes_ShouldFail()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).AtLeast(5);
+				=> await Expect.That(subject).Contains(expected).AtLeast(5);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  contains "in" at least 5 times,
 				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Contains(expected).AtLeast(5)
+				                  at Expect.That(subject).Contains(expected).AtLeast(5)
 				                  """);
 		}
 
 		[Fact]
 		public async Task AtLeast_WhenExpectedStringOccursNever_ShouldFail()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "text that does not occur";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).AtLeast(1);
+				=> await Expect.That(subject).Contains(expected).AtLeast(1);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  contains "text that does not occur" at least once,
 				                  but found it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Contains(expected).AtLeast(1)
+				                  at Expect.That(subject).Contains(expected).AtLeast(1)
 				                  """);
 		}
 
 		[Fact]
 		public async Task AtLeast_WhenMinimumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).AtLeast(-1);
+				=> await Expect.That(subject).Contains(expected).AtLeast(-1);
 
 			await Expect.That(Act).ThrowsExactly<ArgumentOutOfRangeException>().Which
 				.HasMessage("*'minimum'*").AsWildcard().And
@@ -73,31 +73,31 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task AtMost_WhenExpectedStringOccursMoreTimes_ShouldFail()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).AtMost(2);
+				=> await Expect.That(subject).Contains(expected).AtMost(2);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  contains "in" at most 2 times,
 				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Contains(expected).AtMost(2)
+				                  at Expect.That(subject).Contains(expected).AtMost(2)
 				                  """);
 		}
 
 		[Fact]
 		public async Task AtMost_WhenExpectedStringOccursNever_ShouldSucceed()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "text that does not occur";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).AtMost(1);
+				=> await Expect.That(subject).Contains(expected).AtMost(1);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -105,12 +105,12 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task AtMost_WhenExpectedStringSufficientlyFewTimes_ShouldSucceed()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).AtMost(3);
+				=> await Expect.That(subject).Contains(expected).AtMost(3);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -118,12 +118,12 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task AtMost_WhenMaximumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).AtMost(-1);
+				=> await Expect.That(subject).Contains(expected).AtMost(-1);
 
 			await Expect.That(Act).ThrowsExactly<ArgumentOutOfRangeException>().Which
 				.HasMessage("*'maximum'*").AsWildcard().And
@@ -133,50 +133,50 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task Between_WhenExpectedStringOccursFewerTimes_ShouldFail()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Between(4).And(9);
+				=> await Expect.That(subject).Contains(expected).Between(4).And(9);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  contains "in" between 4 and 9 times,
 				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Contains(expected).Between(4).And(9)
+				                  at Expect.That(subject).Contains(expected).Between(4).And(9)
 				                  """);
 		}
 
 		[Fact]
 		public async Task Between_WhenExpectedStringOccursMoreTimes_ShouldFail()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Between(1).And(2);
+				=> await Expect.That(subject).Contains(expected).Between(1).And(2);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  contains "in" between 1 and 2 times,
 				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Contains(expected).Between(1).And(2)
+				                  at Expect.That(subject).Contains(expected).Between(1).And(2)
 				                  """);
 		}
 
 		[Fact]
 		public async Task Between_WhenExpectedStringOccursSufficientTimes_ShouldSucceed()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Between(1).And(4);
+				=> await Expect.That(subject).Contains(expected).Between(1).And(4);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -184,12 +184,12 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task Between_WhenMaximumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Between(1).And(-3);
+				=> await Expect.That(subject).Contains(expected).Between(1).And(-3);
 
 			await Expect.That(Act).ThrowsExactly<ArgumentOutOfRangeException>().Which
 				.HasMessage("*'maximum'*").AsWildcard().And
@@ -199,12 +199,12 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task Between_WhenMinimumEqualsMaximum_ShouldBehaveLikeExactly()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Between(3).And(3);
+				=> await Expect.That(subject).Contains(expected).Between(3).And(3);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -212,12 +212,12 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task Between_WhenMinimumIsGreaterThanMaximum_ShouldThrowArgumentException()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Between(4).And(3);
+				=> await Expect.That(subject).Contains(expected).Between(4).And(3);
 
 			await Expect.That(Act).ThrowsExactly<ArgumentException>().Which
 				.HasMessage("*'maximum'*greater*'minimum'*").AsWildcard();
@@ -226,12 +226,12 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task Between_WhenMinimumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Between(-1).And(3);
+				=> await Expect.That(subject).Contains(expected).Between(-1).And(3);
 
 			await Expect.That(Act).ThrowsExactly<ArgumentOutOfRangeException>().Which
 				.HasMessage("*'minimum'*").AsWildcard().And
@@ -242,12 +242,12 @@ public sealed partial class ThatString
 		public async Task
 			Exactly_WhenExpectedIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Exactly(-1);
+				=> await Expect.That(subject).Contains(expected).Exactly(-1);
 
 			await Expect.That(Act).ThrowsExactly<ArgumentOutOfRangeException>().Which
 				.HasMessage("*'expected'*").AsWildcard().And
@@ -257,12 +257,12 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task Exactly_WhenExpectedStringOccursCorrectlyOften_ShouldSucceed()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Exactly(3);
+				=> await Expect.That(subject).Contains(expected).Exactly(3);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -270,57 +270,57 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task Exactly_WhenExpectedStringOccursFewerTimes_ShouldFail()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Exactly(4);
+				=> await Expect.That(subject).Contains(expected).Exactly(4);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  contains "in" exactly 4 times,
 				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Contains(expected).Exactly(4)
+				                  at Expect.That(subject).Contains(expected).Exactly(4)
 				                  """);
 		}
 
 		[Fact]
 		public async Task Exactly_WhenExpectedStringOccursMoreTimes_ShouldFail()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Exactly(2);
+				=> await Expect.That(subject).Contains(expected).Exactly(2);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  contains "in" exactly 2 times,
 				                  but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Contains(expected).Exactly(2)
+				                  at Expect.That(subject).Contains(expected).Exactly(2)
 				                  """);
 		}
 
 		[Fact]
 		public async Task IgnoringCase_ShouldIncludeSettingInExpectationText()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).AtLeast(7).IgnoringCase();
+				=> await Expect.That(subject).Contains(expected).AtLeast(7).IgnoringCase();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  contains "in" at least 7 times ignoring case,
 				                  but found it 5 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Contains(expected).AtLeast(7).IgnoringCase()
+				                  at Expect.That(subject).Contains(expected).AtLeast(7).IgnoringCase()
 				                  """);
 		}
 
@@ -328,12 +328,12 @@ public sealed partial class ThatString
 		public async Task
 			IgnoringCase_WhenExpectedStringOccursEnoughTimesCaseInsensitive_ShouldSucceed()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).AtLeast(5).IgnoringCase();
+				=> await Expect.That(subject).Contains(expected).AtLeast(5).IgnoringCase();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -341,12 +341,12 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task Never_WhenExpectedStringDoesNotOccur_ShouldSucceed()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "detective";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Never();
+				=> await Expect.That(subject).Contains(expected).Never();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -354,31 +354,31 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task Never_WhenExpectedStringOccursMoreTimes_ShouldFail()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "investigator";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Never();
+				=> await Expect.That(subject).Contains(expected).Never();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  does not contain "investigator",
 				                  but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Contains(expected).Never()
+				                  at Expect.That(subject).Contains(expected).Never()
 				                  """);
 		}
 
 		[Fact]
 		public async Task Once_WhenExpectedStringOccursExactly1Times_ShouldSucceed()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "investigator";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Once();
+				=> await Expect.That(subject).Contains(expected).Once();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -386,38 +386,38 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task Once_WhenExpectedStringOccursFewerTimes_ShouldFail()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "detective";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Once();
+				=> await Expect.That(subject).Contains(expected).Once();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  contains "detective" exactly once,
 				                  but found it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Contains(expected).Once()
+				                  at Expect.That(subject).Contains(expected).Once()
 				                  """);
 		}
 
 		[Fact]
 		public async Task Once_WhenExpectedStringOccursMoreTimes_ShouldFail()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "word";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Once();
+				=> await Expect.That(subject).Contains(expected).Once();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  contains "word" exactly once,
 				                  but found it 2 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Contains(expected).Once()
+				                  at Expect.That(subject).Contains(expected).Once()
 				                  """);
 		}
 
@@ -425,12 +425,12 @@ public sealed partial class ThatString
 		public async Task
 			Using_WhenExpectedStringOccursEnoughTimesForTheComparer_ShouldSucceed()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Exactly(4)
+				=> await Expect.That(subject).Contains(expected).Exactly(4)
 					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).DoesNotThrow();
@@ -440,31 +440,31 @@ public sealed partial class ThatString
 		public async Task
 			Using_WhenExpectedStringOccursIncorrectTimesForTheComparer_ShouldIncludeComparerInMessage()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "in";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected).Exactly(5)
+				=> await Expect.That(subject).Contains(expected).Exactly(5)
 					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  contains "in" exactly 5 times using IgnoreCaseForVocalsComparer,
 				                  but found it 4 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).Contains(expected).Exactly(5).Using(new IgnoreCaseForVocalsComparer())
+				                  at Expect.That(subject).Contains(expected).Exactly(5).Using(new IgnoreCaseForVocalsComparer())
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenExpectedStringIsContained_ShouldSucceed()
 		{
-			string actual = "some text";
+			string subject = "some text";
 			string expected = "me";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected);
+				=> await Expect.That(subject).Contains(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -472,18 +472,18 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenExpectedStringIsNotContained_ShouldFail()
 		{
-			string actual = "some text";
+			string subject = "some text";
 			string expected = "not";
 
 			async Task Act()
-				=> await Expect.That(actual).Contains(expected);
+				=> await Expect.That(subject).Contains(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  contains "not" at least once,
 				                  but found it 0 times in "some text"
-				                  at Expect.That(actual).Contains(expected)
+				                  at Expect.That(subject).Contains(expected)
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotContainTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotContainTests.cs
@@ -7,37 +7,37 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task IgnoringCase_ShouldIncludeSettingInExpectationText()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "INVESTIGATOR";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotContain(expected).IgnoringCase();
+				=> await Expect.That(subject).DoesNotContain(expected).IgnoringCase();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  does not contain "INVESTIGATOR" ignoring case,
 				                  but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).DoesNotContain(expected).IgnoringCase()
+				                  at Expect.That(subject).DoesNotContain(expected).IgnoringCase()
 				                  """);
 		}
 		[Fact]
 		public async Task Using_ShouldIncludeComparerInExpectationText()
 		{
-			string actual =
+			string subject =
 				"In this text in between the word an investigator should find the word 'IN' multiple times.";
 			string expected = "InvEstIgAtOr";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotContain(expected).Using(new IgnoreCaseForVocalsComparer());
+				=> await Expect.That(subject).DoesNotContain(expected).Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  does not contain "InvEstIgAtOr" using IgnoreCaseForVocalsComparer,
 				                  but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-				                  at Expect.That(actual).DoesNotContain(expected).Using(new IgnoreCaseForVocalsComparer())
+				                  at Expect.That(subject).DoesNotContain(expected).Using(new IgnoreCaseForVocalsComparer())
 				                  """);
 		}
 
@@ -45,29 +45,29 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenExpectedStringIsContained_ShouldFail()
 		{
-			string actual = "some text";
+			string subject = "some text";
 			string expected = "me";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotContain(expected);
+				=> await Expect.That(subject).DoesNotContain(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  does not contain "me",
 				                  but found it 1 times in "some text"
-				                  at Expect.That(actual).DoesNotContain(expected)
+				                  at Expect.That(subject).DoesNotContain(expected)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenExpectedStringIsNotContained_ShouldSucceed()
 		{
-			string actual = "some text";
+			string subject = "some text";
 			string expected = "not";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotContain(expected);
+				=> await Expect.That(subject).DoesNotContain(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotEndWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotEndWithTests.cs
@@ -7,29 +7,29 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task IgnoringCase_WhenSubjectDoesEndWithExpected_ShouldFail()
 		{
-			string actual = "some text";
+			string subject = "some text";
 			string expected = "text";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotEndWith(expected);
+				=> await Expect.That(subject).DoesNotEndWith(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  does not end with "text",
 				                  but found "some text"
-				                  at Expect.That(actual).DoesNotEndWith(expected)
+				                  at Expect.That(subject).DoesNotEndWith(expected)
 				                  """);
 		}
 
 		[Fact]
 		public async Task IgnoringCase_WhenSubjectDoesNotEndWithWithExpected_ShouldSucceed()
 		{
-			string actual = "some text";
+			string subject = "some text";
 			string expected = "some";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotEndWith(expected);
+				=> await Expect.That(subject).DoesNotEndWith(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -38,19 +38,19 @@ public sealed partial class ThatString
 		public async Task
 			Using_WhenSubjectDoesEndWithExpected_ShouldFail()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "tExt";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotEndWith(expected)
+				=> await Expect.That(subject).DoesNotEndWith(expected)
 					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  does not end with "tExt" using IgnoreCaseForVocalsComparer,
 				                  but found "some arbitrary text"
-				                  at Expect.That(actual).DoesNotEndWith(expected).Using(new IgnoreCaseForVocalsComparer())
+				                  at Expect.That(subject).DoesNotEndWith(expected).Using(new IgnoreCaseForVocalsComparer())
 				                  """);
 		}
 
@@ -58,11 +58,11 @@ public sealed partial class ThatString
 		public async Task
 			Using_WhenSubjectDoesNotEndWithWithExpected_ShouldSucceed()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "TEXT";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotEndWith(expected)
+				=> await Expect.That(subject).DoesNotEndWith(expected)
 					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).DoesNotThrow();
@@ -71,29 +71,29 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenSubjectDoesEndWithExpected_ShouldFail()
 		{
-			string actual = "some text";
+			string subject = "some text";
 			string expected = "text";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotEndWith(expected);
+				=> await Expect.That(subject).DoesNotEndWith(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  does not end with "text",
 				                  but found "some text"
-				                  at Expect.That(actual).DoesNotEndWith(expected)
+				                  at Expect.That(subject).DoesNotEndWith(expected)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenSubjectDoesNotEndWithWithExpected_ShouldSucceed()
 		{
-			string actual = "some text";
+			string subject = "some text";
 			string expected = "some";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotEndWith(expected);
+				=> await Expect.That(subject).DoesNotEndWith(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotStartWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.DoesNotStartWithTests.cs
@@ -7,29 +7,29 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task IgnoringCase_WhenSubjectDoesStartWithExpected_ShouldFail()
 		{
-			string actual = "some text";
+			string subject = "some text";
 			string expected = "some";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotStartWith(expected);
+				=> await Expect.That(subject).DoesNotStartWith(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  does not start with "some",
 				                  but found "some text"
-				                  at Expect.That(actual).DoesNotStartWith(expected)
+				                  at Expect.That(subject).DoesNotStartWith(expected)
 				                  """);
 		}
 
 		[Fact]
 		public async Task IgnoringCase_WhenSubjectDoesNotStartWithWithExpected_ShouldSucceed()
 		{
-			string actual = "some text";
+			string subject = "some text";
 			string expected = "text";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotStartWith(expected);
+				=> await Expect.That(subject).DoesNotStartWith(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -38,19 +38,19 @@ public sealed partial class ThatString
 		public async Task
 			Using_WhenSubjectDoesStartWithExpected_ShouldFail()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "sOmE";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotStartWith(expected)
+				=> await Expect.That(subject).DoesNotStartWith(expected)
 					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  does not start with "sOmE" using IgnoreCaseForVocalsComparer,
 				                  but found "some arbitrary text"
-				                  at Expect.That(actual).DoesNotStartWith(expected).Using(new IgnoreCaseForVocalsComparer())
+				                  at Expect.That(subject).DoesNotStartWith(expected).Using(new IgnoreCaseForVocalsComparer())
 				                  """);
 		}
 
@@ -58,11 +58,11 @@ public sealed partial class ThatString
 		public async Task
 			Using_WhenSubjectDoesNotStartWithWithExpected_ShouldSucceed()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "SOME";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotStartWith(expected)
+				=> await Expect.That(subject).DoesNotStartWith(expected)
 					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).DoesNotThrow();
@@ -71,11 +71,11 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenSubjectDoesNotStartWithExpected_ShouldSucceed()
 		{
-			string actual = "some text";
+			string subject = "some text";
 			string expected = "text";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotStartWith(expected);
+				=> await Expect.That(subject).DoesNotStartWith(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -83,18 +83,18 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenSubjectDoesStartWithExpected_ShouldFail()
 		{
-			string actual = "some text";
+			string subject = "some text";
 			string expected = "some";
 
 			async Task Act()
-				=> await Expect.That(actual).DoesNotStartWith(expected);
+				=> await Expect.That(subject).DoesNotStartWith(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  does not start with "some",
 				                  but found "some text"
-				                  at Expect.That(actual).DoesNotStartWith(expected)
+				                  at Expect.That(subject).DoesNotStartWith(expected)
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.EndsWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.EndsWithTests.cs
@@ -11,19 +11,19 @@ public sealed partial class ThatString
 			IgnoringCase_WhenSubjectEndsWithDifferentCase_ShouldFailUnlessCaseIsIgnored(
 				bool ignoreCase)
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "TEXT";
 
 			async Task Act()
-				=> await Expect.That(actual).EndsWith(expected).IgnoringCase(ignoreCase);
+				=> await Expect.That(subject).EndsWith(expected).IgnoringCase(ignoreCase);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.OnlyIf(!ignoreCase)
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  ends with "TEXT",
 				                  but found "some arbitrary text"
-				                  at Expect.That(actual).EndsWith(expected).IgnoringCase(ignoreCase)
+				                  at Expect.That(subject).EndsWith(expected).IgnoringCase(ignoreCase)
 				                  """);
 		}
 
@@ -31,18 +31,18 @@ public sealed partial class ThatString
 		public async Task
 			IgnoringCase_WhenSubjectEndsWithDifferentString_ShouldIncludeIgnoringCaseInMessage()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "SOME";
 
 			async Task Act()
-				=> await Expect.That(actual).EndsWith(expected).IgnoringCase();
+				=> await Expect.That(subject).EndsWith(expected).IgnoringCase();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  ends with "SOME" ignoring case,
 				                  but found "some arbitrary text"
-				                  at Expect.That(actual).EndsWith(expected).IgnoringCase()
+				                  at Expect.That(subject).EndsWith(expected).IgnoringCase()
 				                  """);
 		}
 
@@ -50,19 +50,19 @@ public sealed partial class ThatString
 		public async Task
 			Using_WhenSubjectEndsWithIncorrectMatchAccordingToComparer_ShouldIncludeComparerInMessage()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "TEXT";
 
 			async Task Act()
-				=> await Expect.That(actual).EndsWith(expected)
+				=> await Expect.That(subject).EndsWith(expected)
 					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  ends with "TEXT" using IgnoreCaseForVocalsComparer,
 				                  but found "some arbitrary text"
-				                  at Expect.That(actual).EndsWith(expected).Using(new IgnoreCaseForVocalsComparer())
+				                  at Expect.That(subject).EndsWith(expected).Using(new IgnoreCaseForVocalsComparer())
 				                  """);
 		}
 
@@ -70,11 +70,11 @@ public sealed partial class ThatString
 		public async Task
 			Using_WhenSubjectEndsWithMatchAccordingToComparer_ShouldSucceed()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "tExt";
 
 			async Task Act()
-				=> await Expect.That(actual).EndsWith(expected)
+				=> await Expect.That(subject).EndsWith(expected)
 					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).DoesNotThrow();
@@ -83,29 +83,29 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenSubjectDoesNotEndWithExpected_ShouldFail()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "some";
 
 			async Task Act()
-				=> await Expect.That(actual).EndsWith(expected);
+				=> await Expect.That(subject).EndsWith(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  ends with "some",
 				                  but found "some arbitrary text"
-				                  at Expect.That(actual).EndsWith(expected)
+				                  at Expect.That(subject).EndsWith(expected)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenSubjectEndsWithExpected_ShouldSucceed()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "text";
 
 			async Task Act()
-				=> await Expect.That(actual).EndsWith(expected);
+				=> await Expect.That(subject).EndsWith(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsNotNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsNotNullTests.cs
@@ -7,20 +7,20 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenActualIsEmpty_ShouldSucceed()
 		{
-			string actual = "";
+			string subject = "";
 
 			async Task Act()
-				=> await Expect.That(actual).IsNotNull();
+				=> await Expect.That(subject).IsNotNull();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
 
 		[Theory]
 		[AutoData]
-		public async Task WhenActualIsNotNull_ShouldSucceed(string? actual)
+		public async Task WhenActualIsNotNull_ShouldSucceed(string? subject)
 		{
 			async Task Act()
-				=> await Expect.That(actual).IsNotNull();
+				=> await Expect.That(subject).IsNotNull();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -28,17 +28,17 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenActualIsNull_ShouldFail()
 		{
-			string? actual = null;
+			string? subject = null;
 
 			async Task Act()
-				=> await Expect.That(actual).IsNotNull();
+				=> await Expect.That(subject).IsNotNull();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  is not null,
 				                  but it was
-				                  at Expect.That(actual).IsNotNull()
+				                  at Expect.That(subject).IsNotNull()
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsNullTests.cs
@@ -7,43 +7,43 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenActualIsEmpty_ShouldFail()
 		{
-			string actual = "";
+			string subject = "";
 
 			async Task Act()
-				=> await Expect.That(actual).IsNull();
+				=> await Expect.That(subject).IsNull();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  is null,
 				                  but found ""
-				                  at Expect.That(actual).IsNull()
+				                  at Expect.That(subject).IsNull()
 				                  """);
 		}
 
 		[Theory]
 		[AutoData]
-		public async Task WhenActualIsNotNull_ShouldFail(string? actual)
+		public async Task WhenActualIsNotNull_ShouldFail(string? subject)
 		{
 			async Task Act()
-				=> await Expect.That(actual).IsNull();
+				=> await Expect.That(subject).IsNull();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage($"""
-				                   Expected that actual
+				                   Expected that subject
 				                   is null,
-				                   but found "{actual}"
-				                   at Expect.That(actual).IsNull()
+				                   but found "{subject}"
+				                   at Expect.That(subject).IsNull()
 				                   """);
 		}
 
 		[Fact]
 		public async Task WhenActualIsNull_ShouldSucceed()
 		{
-			string? actual = null;
+			string? subject = null;
 
 			async Task Act()
-				=> await Expect.That(actual).IsNull();
+				=> await Expect.That(subject).IsNull();
 
 			await Act();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.IsTests.cs
@@ -12,20 +12,22 @@ public sealed partial class ThatString
 		[InlineData("some message", "some me?age", false)]
 		[InlineData("some message", "some me??age", true)]
 		public async Task AsWildcard_ShouldDefaultToCaseSensitiveMatch(
-			string actual, string pattern, bool expectMatch)
+			string subject, string pattern, bool expectMatch)
 		{
 			async Task Act()
-				=> await Expect.That(actual).Is(pattern).AsWildcard();
+				=> await Expect.That(subject).Is(pattern).AsWildcard();
 
 			await Expect.That(Act).ThrowsException().OnlyIf(!expectMatch);
 		}
 
 		[Theory]
 		[AutoData]
-		public async Task WhenStringsAreTheSame_ShouldSucceed(string actual)
+		public async Task WhenStringsAreTheSame_ShouldSucceed(string subject)
 		{
+			string expected = subject;
+
 			async Task Act()
-				=> await Expect.That(actual).Is(actual);
+				=> await Expect.That(subject).Is(expected);
 
 			await Act();
 		}
@@ -33,22 +35,22 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenStringsDiffer_ShouldFail()
 		{
-			string actual = "actual text";
+			string subject = "actual text";
 			string expected = "expected other text";
 
 			async Task Act()
-				=> await Expect.That(actual).Is(expected);
+				=> await Expect.That(subject).Is(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  is equal to "expected other text",
 				                  but found "actual text" which differs at index 0:
 				                     ↓ (actual)
 				                    "actual text"
 				                    "expected other text"
 				                     ↑ (expected)
-				                  at Expect.That(actual).Is(expected)
+				                  at Expect.That(subject).Is(expected)
 				                  """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.StartsWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Strings/ThatString.StartsWithTests.cs
@@ -11,19 +11,19 @@ public sealed partial class ThatString
 			IgnoringCase_WhenSubjectStartsWithDifferentCase_ShouldFailUnlessCaseIsIgnored(
 				bool ignoreCase)
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "SOME";
 
 			async Task Act()
-				=> await Expect.That(actual).StartsWith(expected).IgnoringCase(ignoreCase);
+				=> await Expect.That(subject).StartsWith(expected).IgnoringCase(ignoreCase);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.OnlyIf(!ignoreCase)
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  starts with "SOME",
 				                  but found "some arbitrary text"
-				                  at Expect.That(actual).StartsWith(expected).IgnoringCase(ignoreCase)
+				                  at Expect.That(subject).StartsWith(expected).IgnoringCase(ignoreCase)
 				                  """);
 		}
 
@@ -31,18 +31,18 @@ public sealed partial class ThatString
 		public async Task
 			IgnoringCase_WhenSubjectStartsWithDifferentString_ShouldIncludeIgnoringCaseInMessage()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "TEXT";
 
 			async Task Act()
-				=> await Expect.That(actual).StartsWith(expected).IgnoringCase();
+				=> await Expect.That(subject).StartsWith(expected).IgnoringCase();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  starts with "TEXT" ignoring case,
 				                  but found "some arbitrary text"
-				                  at Expect.That(actual).StartsWith(expected).IgnoringCase()
+				                  at Expect.That(subject).StartsWith(expected).IgnoringCase()
 				                  """);
 		}
 
@@ -50,19 +50,19 @@ public sealed partial class ThatString
 		public async Task
 			Using_WhenSubjectStartsWithIncorrectMatchAccordingToComparer_ShouldIncludeComparerInMessage()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "SOME";
 
 			async Task Act()
-				=> await Expect.That(actual).StartsWith(expected)
+				=> await Expect.That(subject).StartsWith(expected)
 					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  starts with "SOME" using IgnoreCaseForVocalsComparer,
 				                  but found "some arbitrary text"
-				                  at Expect.That(actual).StartsWith(expected).Using(new IgnoreCaseForVocalsComparer())
+				                  at Expect.That(subject).StartsWith(expected).Using(new IgnoreCaseForVocalsComparer())
 				                  """);
 		}
 
@@ -70,11 +70,11 @@ public sealed partial class ThatString
 		public async Task
 			Using_WhenSubjectStartsWithMatchAccordingToComparer_ShouldSucceed()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "sOmE";
 
 			async Task Act()
-				=> await Expect.That(actual).StartsWith(expected)
+				=> await Expect.That(subject).StartsWith(expected)
 					.Using(new IgnoreCaseForVocalsComparer());
 
 			await Expect.That(Act).DoesNotThrow();
@@ -83,29 +83,29 @@ public sealed partial class ThatString
 		[Fact]
 		public async Task WhenSubjectDoesNotStartWithExpected_ShouldFail()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "text";
 
 			async Task Act()
-				=> await Expect.That(actual).StartsWith(expected);
+				=> await Expect.That(subject).StartsWith(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that actual
+				                  Expected that subject
 				                  starts with "text",
 				                  but found "some arbitrary text"
-				                  at Expect.That(actual).StartsWith(expected)
+				                  at Expect.That(subject).StartsWith(expected)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenSubjectStartsWithExpected_ShouldSucceed()
 		{
-			string actual = "some arbitrary text";
+			string subject = "some arbitrary text";
 			string expected = "some";
 
 			async Task Act()
-				=> await Expect.That(actual).StartsWith(expected);
+				=> await Expect.That(subject).StartsWith(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Primitives/ThatGeneric.IsSameAsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/ThatGeneric.IsSameAsTests.cs
@@ -1,50 +1,41 @@
-﻿namespace Testably.Expectations.Tests.Primitives.Generics;
+﻿namespace Testably.Expectations.Tests.Primitives;
 
 public sealed partial class ThatGeneric
 {
 	public sealed class IsSameAsTests
 	{
 		[Fact]
-		public async Task Fails_For_True_Value()
+		public async Task WhenComparingTheSameObjectReference_ShouldSucceed()
 		{
-			Other value = new Other
-			{
-				Value = 1
-			};
-			Other other = new Other
-			{
-				Value = 1
-			};
+			Other subject = new() { Value = 1 };
+			Other expected = subject;
 
 			async Task Act()
-				=> await Expect.That(value).IsSameAs(other);
+				=> await Expect.That(subject).IsSameAs(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenComparingTwoIndividualObjectsWithSameValues_ShouldFail()
+		{
+			Other subject = new() { Value = 1 };
+			Other expected = new() { Value = 1 };
+
+			async Task Act()
+				=> await Expect.That(subject).IsSameAs(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that value
-				                  refers to other Other{
+				                  Expected that subject
+				                  refers to expected Other{
 				                    Value = 1
 				                  },
 				                  but found Other{
 				                    Value = 1
 				                  }
-				                  at Expect.That(value).IsSameAs(other)
+				                  at Expect.That(subject).IsSameAs(expected)
 				                  """);
-		}
-
-		[Fact]
-		public async Task Succeeds_For_Same_Object_References()
-		{
-			Other value = new Other
-			{
-				Value = 1
-			};
-			Other other = value;
-
-			async Task Act()
-				=> await Expect.That(value).IsSameAs(other);
-
-			await Expect.That(Act).DoesNotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/ThatGeneric.SatisfiesTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/ThatGeneric.SatisfiesTests.cs
@@ -1,42 +1,24 @@
-﻿namespace Testably.Expectations.Tests.Primitives.Generics;
+﻿namespace Testably.Expectations.Tests.Primitives;
 
 public sealed partial class ThatGeneric
 {
 	public sealed class SatisfiesTests
 	{
 		[Fact]
-		public async Task Fails_For_True_Value()
+		public async Task WhenSatisfyConditionFails_ShouldIncludeTextInMessage()
 		{
-			Other value = new Other
-			{
-				Value = 1
-			};
+			Other subject = new() { Value = 1 };
 
 			async Task Act()
-				=> await Expect.That(value).Satisfies<Other, int>(o => o.Value, v => v.Is(2));
+				=> await Expect.That(subject).Satisfies<Other, int>(o => o.Value, v => v.Is(2));
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that value
+				                  Expected that subject
 				                  satisfies Value is 2,
 				                  but found 1
-				                  at Expect.That(value).Satisfies<Other, int>(o => o.Value, v => v.Is(2))
+				                  at Expect.That(subject).Satisfies<Other, int>(o => o.Value, v => v.Is(2))
 				                  """);
-		}
-
-		[Fact]
-		public async Task Succeeds_For_Same_Object_References()
-		{
-			Other value = new Other
-			{
-				Value = 1
-			};
-			Other other = value;
-
-			async Task Act()
-				=> await Expect.That(value).IsSameAs(other);
-
-			await Expect.That(Act).DoesNotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/Primitives/ThatGeneric.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/ThatGeneric.cs
@@ -1,4 +1,4 @@
-﻿namespace Testably.Expectations.Tests.Primitives.Generics;
+﻿namespace Testably.Expectations.Tests.Primitives;
 
 public sealed partial class ThatGeneric
 {

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.DoesNotHaveStatusCodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.DoesNotHaveStatusCodeTests.cs
@@ -16,15 +16,15 @@ public sealed partial class ThatHttpResponseMessage
 		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
 		{
 			HttpStatusCode unexpected = statusCode;
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(statusCode);
 
 			async Task Act()
-				=> await Expect.That(sut).DoesNotHaveStatusCode(unexpected);
+				=> await Expect.That(subject).DoesNotHaveStatusCode(unexpected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage(
-					"*StatusCode different to*Expect.That(sut).DoesNotHaveStatusCode(unexpected)")
+					"*StatusCode different to*Expect.That(subject).DoesNotHaveStatusCode(unexpected)")
 				.AsWildcard();
 		}
 
@@ -32,11 +32,11 @@ public sealed partial class ThatHttpResponseMessage
 		public async Task WhenStatusCodeDiffersFromExpected_ShouldSucceed()
 		{
 			HttpStatusCode unexpected = HttpStatusCode.OK;
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(HttpStatusCode.BadRequest);
 
 			async Task Act()
-				=> await Expect.That(sut).DoesNotHaveStatusCode(unexpected);
+				=> await Expect.That(subject).DoesNotHaveStatusCode(unexpected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasClientErrorTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasClientErrorTests.cs
@@ -12,11 +12,11 @@ public sealed partial class ThatHttpResponseMessage
 		[MemberData(nameof(ClientErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(statusCode);
 
 			async Task Act()
-				=> await Expect.That(sut).HasClientError();
+				=> await Expect.That(subject).HasClientError();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -27,15 +27,15 @@ public sealed partial class ThatHttpResponseMessage
 		[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(statusCode);
 
 			async Task Act()
-				=> await Expect.That(sut).HasClientError();
+				=> await Expect.That(subject).HasClientError();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage(
-					"*client error (status code 4xx)*Expect.That(sut).HasClientError()")
+					"*client error (status code 4xx)*Expect.That(subject).HasClientError()")
 				.AsWildcard();
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasContentTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasContentTests.cs
@@ -11,22 +11,22 @@ public sealed partial class ThatHttpResponseMessage
 		public async Task WhenContentDiffersFromExpected_ShouldFail()
 		{
 			string expected = "other content";
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithContent("some content");
 
 			async Task Act()
-				=> await Expect.That(sut).HasContent(expected);
+				=> await Expect.That(subject).HasContent(expected);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that sut
+				                  Expected that subject
 				                  has a string content equal to "other content",
 				                  but found "some content" which differs at index 0:
 				                     ↓ (actual)
 				                    "some content"
 				                    "other content"
 				                     ↑ (expected)
-				                  at Expect.That(sut).HasContent(expected)
+				                  at Expect.That(subject).HasContent(expected)
 				                  """);
 		}
 
@@ -34,11 +34,11 @@ public sealed partial class ThatHttpResponseMessage
 		public async Task WhenContentEqualsExpected_ShouldSucceed()
 		{
 			string expected = "some content";
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithContent(expected);
 
 			async Task Act()
-				=> await Expect.That(sut).HasContent(expected);
+				=> await Expect.That(subject).HasContent(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasErrorTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasErrorTests.cs
@@ -13,11 +13,11 @@ public sealed partial class ThatHttpResponseMessage
 		[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(statusCode);
 
 			async Task Act()
-				=> await Expect.That(sut).HasError();
+				=> await Expect.That(subject).HasError();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -27,15 +27,15 @@ public sealed partial class ThatHttpResponseMessage
 		[MemberData(nameof(RedirectStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(statusCode);
 
 			async Task Act()
-				=> await Expect.That(sut).HasError();
+				=> await Expect.That(subject).HasError();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage(
-					"*an error (status code 4xx or 5xx)*Expect.That(sut).HasError()")
+					"*an error (status code 4xx or 5xx)*Expect.That(subject).HasError()")
 				.AsWildcard();
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasServerErrorTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasServerErrorTests.cs
@@ -12,11 +12,11 @@ public sealed partial class ThatHttpResponseMessage
 		[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(statusCode);
 
 			async Task Act()
-				=> await Expect.That(sut).HasServerError();
+				=> await Expect.That(subject).HasServerError();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -27,15 +27,15 @@ public sealed partial class ThatHttpResponseMessage
 		[MemberData(nameof(ClientErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(statusCode);
 
 			async Task Act()
-				=> await Expect.That(sut).HasServerError();
+				=> await Expect.That(subject).HasServerError();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage(
-					"*server error (status code 5xx)*Expect.That(sut).HasServerError()")
+					"*server error (status code 5xx)*Expect.That(subject).HasServerError()")
 				.AsWildcard();
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasStatusCodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.HasStatusCodeTests.cs
@@ -11,18 +11,18 @@ public sealed partial class ThatHttpResponseMessage
 		[Fact]
 		public async Task WhenFailing_ShouldIncludeRequestInMessage()
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(HttpStatusCode.BadRequest)
 				.WithContent("some content")
 				.WithRequest(HttpMethod.Get, "https://example.com")
 				.WithRequestContent("request content");
 
 			async Task Act()
-				=> await Expect.That(sut).HasStatusCode(HttpStatusCode.OK);
+				=> await Expect.That(subject).HasStatusCode(HttpStatusCode.OK);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that sut
+				                  Expected that subject
 				                  has StatusCode 200 OK,
 				                  but found 400 BadRequest:
 				                    HTTP/1.1 400 BadRequest
@@ -30,40 +30,40 @@ public sealed partial class ThatHttpResponseMessage
 				                    The originating request was:
 				                      GET https://example.com/ HTTP 1.1
 				                      request content
-				                  at Expect.That(sut).HasContent(HttpStatusCode.OK)
+				                  at Expect.That(subject).HasContent(HttpStatusCode.OK)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenFailing_ShouldIncludeResponseContentAndStatusCodeInMessage()
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(HttpStatusCode.BadRequest)
 				.WithContent("some content");
 
 			async Task Act()
-				=> await Expect.That(sut).HasStatusCode(HttpStatusCode.OK);
+				=> await Expect.That(subject).HasStatusCode(HttpStatusCode.OK);
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage("""
-				                  Expected that sut
+				                  Expected that subject
 				                  has StatusCode 200 OK,
 				                  but found 400 BadRequest:
 				                    HTTP/1.1 400 BadRequest
 				                    some content
 				                    The originating request was <null>
-				                  at Expect.That(sut).HasContent(HttpStatusCode.OK)
+				                  at Expect.That(subject).HasContent(HttpStatusCode.OK)
 				                  """);
 		}
 
 		[Fact]
 		public async Task WhenStatusCodeDiffersFromExpected_ShouldFail()
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(HttpStatusCode.BadRequest);
 
 			async Task Act()
-				=> await Expect.That(sut).HasStatusCode(HttpStatusCode.OK);
+				=> await Expect.That(subject).HasStatusCode(HttpStatusCode.OK);
 
 			await Expect.That(Act).Throws<XunitException>();
 		}
@@ -76,11 +76,11 @@ public sealed partial class ThatHttpResponseMessage
 		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
 		{
 			HttpStatusCode expected = statusCode;
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(statusCode);
 
 			async Task Act()
-				=> await Expect.That(sut).HasStatusCode(expected);
+				=> await Expect.That(subject).HasStatusCode(expected);
 
 			await Expect.That(Act).DoesNotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsRedirectionTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsRedirectionTests.cs
@@ -12,11 +12,11 @@ public sealed partial class ThatHttpResponseMessage
 		[MemberData(nameof(RedirectStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(statusCode);
 
 			async Task Act()
-				=> await Expect.That(sut).IsRedirection();
+				=> await Expect.That(subject).IsRedirection();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -27,15 +27,15 @@ public sealed partial class ThatHttpResponseMessage
 		[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(statusCode);
 
 			async Task Act()
-				=> await Expect.That(sut).IsRedirection();
+				=> await Expect.That(subject).IsRedirection();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage(
-					"*is redirection (status code 3xx)*Expect.That(sut).IsRedirection()")
+					"*is redirection (status code 3xx)*Expect.That(subject).IsRedirection()")
 				.AsWildcard();
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsSuccessfulTests.cs
+++ b/Tests/Testably.Expectations.Tests/Specialized/Http/ThatHttpResponseMessage.IsSuccessfulTests.cs
@@ -12,11 +12,11 @@ public sealed partial class ThatHttpResponseMessage
 		[MemberData(nameof(SuccessStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(statusCode);
 
 			async Task Act()
-				=> await Expect.That(sut).IsSuccessful();
+				=> await Expect.That(subject).IsSuccessful();
 
 			await Expect.That(Act).DoesNotThrow();
 		}
@@ -27,15 +27,15 @@ public sealed partial class ThatHttpResponseMessage
 		[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 		public async Task WhenStatusCodeIsUnexpected_ShouldFail(HttpStatusCode statusCode)
 		{
-			HttpResponseMessage sut = ResponseBuilder
+			HttpResponseMessage subject = ResponseBuilder
 				.WithStatusCode(statusCode);
 
 			async Task Act()
-				=> await Expect.That(sut).IsSuccessful();
+				=> await Expect.That(subject).IsSuccessful();
 
 			await Expect.That(Act).Throws<XunitException>()
 				.Which.HasMessage(
-					"*is successful (status code 2xx)*Expect.That(sut).IsSuccessful()")
+					"*is successful (status code 2xx)*Expect.That(subject).IsSuccessful()")
 				.AsWildcard();
 		}
 	}


### PR DESCRIPTION
Fix test names to apply to a common schema and rename `sut`, `value`, etc. to `subject` to be in line with the XML-Documentation.