### PR TITLE
feat: add support for `Guid`s

### DIFF
--- a/Source/Testably.Expectations/Expect.cs
+++ b/Source/Testably.Expectations/Expect.cs
@@ -93,6 +93,20 @@ public static partial class Expect
 		=> new(new ExpectationBuilder<Exception>(subject, doNotPopulateThisValue));
 
 	/// <summary>
+	///     Start expectations for current <see cref="Guid" /> <paramref name="subject" />.
+	/// </summary>
+	public static That<Guid> That(Guid subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<Guid>(subject, doNotPopulateThisValue));
+
+	/// <summary>
+	///     Start expectations for the current <see cref="Guid" />? <paramref name="subject" />.
+	/// </summary>
+	public static That<Guid?> That(Guid? subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<Guid?>(subject, doNotPopulateThisValue));
+
+	/// <summary>
 	///     Start expectations for the current <see cref="object" />? <paramref name="subject" />.
 	/// </summary>
 	public static That<object?> That(object? subject,

--- a/Source/Testably.Expectations/Formatting/Formatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatter.cs
@@ -28,6 +28,7 @@ public class Formatter
 		new DateOnlyFormatter(),
 		new TimeOnlyFormatter(),
 #endif
+		new GuidFormatter(),
 		new NumberFormatter<int>(),
 		new NumberFormatter<uint>(),
 		new NumberFormatter<byte>(),

--- a/Source/Testably.Expectations/Formatting/Formatters/BooleanFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/BooleanFormatter.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Formatting.Formatters;
 

--- a/Source/Testably.Expectations/Formatting/Formatters/CollectionFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/CollectionFormatter.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Text;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Formatting.Formatters;
 

--- a/Source/Testably.Expectations/Formatting/Formatters/DateTimeFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/DateTimeFormatter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Formatting.Formatters;
 

--- a/Source/Testably.Expectations/Formatting/Formatters/DateTimeOffsetFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/DateTimeOffsetFormatter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Formatting.Formatters;
 

--- a/Source/Testably.Expectations/Formatting/Formatters/GuidFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/GuidFormatter.cs
@@ -3,10 +3,10 @@ using System.Text;
 
 namespace Testably.Expectations.Formatting.Formatters;
 
-internal class EnumFormatter : FormatterBase<Enum>
+internal class GuidFormatter : FormatterBase<Guid>
 {
 	/// <inheritdoc />
-	public override void Format(Enum value, StringBuilder stringBuilder,
+	public override void Format(Guid value, StringBuilder stringBuilder,
 		FormattingOptions options)
 	{
 		stringBuilder.Append(value);

--- a/Source/Testably.Expectations/Formatting/Formatters/HttpStatusCodeFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/HttpStatusCodeFormatter.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net;
 using System.Text;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Formatting.Formatters;
 

--- a/Source/Testably.Expectations/Formatting/Formatters/NumberFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/NumberFormatter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Formatting.Formatters;
 

--- a/Source/Testably.Expectations/Formatting/Formatters/StringFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/StringFormatter.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text;
 using Testably.Expectations.Core.Helpers;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Formatting.Formatters;
 

--- a/Source/Testably.Expectations/Formatting/Formatters/TimeSpanFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/TimeSpanFormatter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Formatting.Formatters;
 

--- a/Source/Testably.Expectations/Formatting/Formatters/TypeFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/TypeFormatter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Formatting.Formatters;
 

--- a/Source/Testably.Expectations/Primitives/Enums/ThatEnumExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Enums/ThatEnumExtensions.cs
@@ -23,7 +23,7 @@ public static partial class ThatEnumExtensions
 		where TEnum : struct, Enum
 		=> new(source.ExpectationBuilder.Add(new Constraint<TEnum>(
 					$"is {Formatter.Format(expected)}",
-					actual => expected.Equals(actual)),
+					actual => actual.Equals(expected)),
 				b => b.AppendMethod(nameof(Is), doNotPopulateThisValue)),
 			source);
 
@@ -37,7 +37,7 @@ public static partial class ThatEnumExtensions
 		where TEnum : struct, Enum
 		=> new(source.ExpectationBuilder.Add(new Constraint<TEnum>(
 					$"is not {Formatter.Format(unexpected)}",
-					actual => !unexpected.Equals(actual)),
+					actual => !actual.Equals(unexpected)),
 				b => b.AppendMethod(nameof(IsNot), doNotPopulateThisValue)),
 			source);
 

--- a/Source/Testably.Expectations/Primitives/Guids/ThatGuidExtensions.Constraint.cs
+++ b/Source/Testably.Expectations/Primitives/Guids/ThatGuidExtensions.Constraint.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatGuidExtensions
+{
+	private readonly struct Constraint(string expectation, Func<Guid, bool> successIf)
+		: IConstraint<Guid>
+	{
+		public ConstraintResult IsMetBy(Guid actual)
+		{
+			if (successIf(actual))
+			{
+				return new ConstraintResult.Success<Guid?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> expectation;
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Guids/ThatGuidExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Guids/ThatGuidExtensions.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on <see cref="Guid" /> values.
+/// </summary>
+public static partial class ThatGuidExtensions
+{
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<Guid, That<Guid>> Is(this That<Guid> source,
+		Guid expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new Constraint(
+					$"is {Formatter.Format(expected)}",
+					actual => actual.Equals(expected)),
+				b => b.AppendMethod(nameof(Is), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<Guid, That<Guid>> IsNot(this That<Guid> source,
+		Guid unexpected,
+		[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new Constraint(
+					$"is not {Formatter.Format(unexpected)}",
+					actual => !actual.Equals(unexpected)),
+				b => b.AppendMethod(nameof(IsNot), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is empty.
+	/// </summary>
+	public static AndOrExpectationResult<Guid, That<Guid>> IsEmpty(this That<Guid> source)
+		=> new(source.ExpectationBuilder.Add(new Constraint(
+					"is empty",
+					actual => actual == Guid.Empty),
+				b => b.AppendMethod(nameof(IsEmpty))),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not empty.
+	/// </summary>
+	public static AndOrExpectationResult<Guid, That<Guid>> IsNotEmpty(this That<Guid> source)
+		=> new(source.ExpectationBuilder.Add(new Constraint(
+					"is not empty",
+					actual => actual != Guid.Empty),
+				b => b.AppendMethod(nameof(IsNotEmpty))),
+			source);
+}

--- a/Source/Testably.Expectations/Primitives/Guids/ThatNullableGuidExtensions.Constraint.cs
+++ b/Source/Testably.Expectations/Primitives/Guids/ThatNullableGuidExtensions.Constraint.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Formatting;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatNullableGuidExtensions
+{
+	private readonly struct Constraint(string expectation, Func<Guid?, bool> successIf)
+		: IConstraint<Guid?>
+	{
+		public ConstraintResult IsMetBy(Guid? actual)
+		{
+			if (successIf(actual))
+			{
+				return new ConstraintResult.Success<Guid?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> expectation;
+	}
+}

--- a/Source/Testably.Expectations/Primitives/Guids/ThatNullableGuidExtensions.cs
+++ b/Source/Testably.Expectations/Primitives/Guids/ThatNullableGuidExtensions.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on <see langword="enum" />? values.
+/// </summary>
+public static partial class ThatNullableGuidExtensions
+{
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<Guid?, That<Guid?>> Is(this That<Guid?> source,
+		Guid? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new Constraint(
+					$"is {Formatter.Format(expected)}",
+					actual => actual?.Equals(expected) ?? expected == null),
+				b => b.AppendMethod(nameof(Is), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static AndOrExpectationResult<Guid?, That<Guid?>> IsNot(this That<Guid?> source,
+		Guid? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(
+				new Constraint(
+					$"is not {Formatter.Format(unexpected)}",
+					actual => !actual?.Equals(unexpected) ?? unexpected != null),
+				b => b.AppendMethod(nameof(IsNot), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is empty.
+	/// </summary>
+	public static AndOrExpectationResult<Guid?, That<Guid?>> IsEmpty(this That<Guid?> source)
+		=> new(source.ExpectationBuilder.Add(new Constraint(
+					"is empty",
+					actual => actual != null && actual == Guid.Empty),
+				b => b.AppendMethod(nameof(IsEmpty))),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not empty.
+	/// </summary>
+	public static AndOrExpectationResult<Guid?, That<Guid?>> IsNotEmpty(this That<Guid?> source)
+		=> new(source.ExpectationBuilder.Add(new Constraint(
+					"is not empty",
+					actual => actual != null && actual != Guid.Empty),
+				b => b.AppendMethod(nameof(IsNotEmpty))),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not <see langword="null" />.
+	/// </summary>
+	public static AndOrExpectationResult<Guid?, That<Guid?>> IsNotNull(this That<Guid?> source)
+		=> new(source.ExpectationBuilder.Add(new Constraint(
+					"is not null",
+					actual => actual != null),
+				b => b.AppendMethod(nameof(IsNotNull))),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is <see langword="null" />.
+	/// </summary>
+	public static AndOrExpectationResult<Guid?, That<Guid?>> IsNull(this That<Guid?> source)
+		=> new(source.ExpectationBuilder.Add(new Constraint(
+					"is null",
+					actual => actual == null),
+				b => b.AppendMethod(nameof(IsNull))),
+			source);
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatGuid.IsEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatGuid.IsEmptyTests.cs
@@ -1,0 +1,35 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Guids;
+
+public sealed partial class ThatGuid
+{
+	public sealed class IsEmptyTests
+	{
+		[Fact]
+		public async Task WhenValueIsEmpty_ShouldSucceed()
+		{
+			Guid subject = Guid.Empty;
+
+			async Task Act()
+				=> await Expect.That(subject).IsEmpty();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenValueIsNotEmpty_ShouldFail()
+		{
+			Guid subject = OtherGuid();
+
+			async Task Act()
+				=> await Expect.That(subject).IsEmpty();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   is empty,
+				                   but found {subject}
+				                   at Expect.That(subject).IsEmpty()
+				                   """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatGuid.IsNotEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatGuid.IsNotEmptyTests.cs
@@ -1,0 +1,35 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Guids;
+
+public sealed partial class ThatGuid
+{
+	public sealed class IsNotEmptyTests
+	{
+		[Fact]
+		public async Task WhenValueIsEmpty_ShouldFail()
+		{
+			Guid subject = Guid.Empty;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNotEmpty();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   is not empty,
+				                   but found {subject}
+				                   at Expect.That(subject).IsNotEmpty()
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValueIsNotEmpty_ShouldSucceed()
+		{
+			Guid subject = OtherGuid();
+
+			async Task Act()
+				=> await Expect.That(subject).IsNotEmpty();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatGuid.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatGuid.IsNotTests.cs
@@ -1,0 +1,37 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Guids;
+
+public sealed partial class ThatGuid
+{
+	public sealed class IsNotTests
+	{
+		[Fact]
+		public async Task WhenValuesAreTheSame_ShouldFail()
+		{
+			Guid subject = FixedGuid();
+			Guid unexpected = subject;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNot(unexpected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   is not {unexpected},
+				                   but found {subject}
+				                   at Expect.That(subject).IsNot(unexpected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValuesAreDifferent_ShouldSucceed()
+		{
+			Guid subject = FixedGuid();
+			Guid unexpected = OtherGuid();
+
+			async Task Act()
+				=> await Expect.That(subject).IsNot(unexpected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatGuid.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatGuid.IsTests.cs
@@ -1,0 +1,37 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Guids;
+
+public sealed partial class ThatGuid
+{
+	public sealed class IsTests
+	{
+		[Fact]
+		public async Task WhenValuesAreDifferent_ShouldFail()
+		{
+			Guid subject = FixedGuid();
+			Guid expected = OtherGuid();
+
+			async Task Act()
+				=> await Expect.That(subject).Is(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   is {expected},
+				                   but found {subject}
+				                   at Expect.That(subject).Is(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValuesAreTheSame_ShouldSucceed()
+		{
+			Guid subject = FixedGuid();
+			Guid expected = subject;
+
+			async Task Act()
+				=> await Expect.That(subject).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatGuid.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatGuid.cs
@@ -1,0 +1,14 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Guids;
+
+public sealed partial class ThatGuid
+{
+	/// <summary>
+	///     Use a fixed random <see cref="Guid"/> in each test run to ensure, that the tests don't rely on special times.
+	/// </summary>
+	private static readonly Lazy<Guid> FixedGuidLazy = new(Guid.NewGuid);
+
+	private static Guid FixedGuid()
+		=> FixedGuidLazy.Value;
+	private static Guid OtherGuid()
+		=> Guid.NewGuid();
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.IsEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.IsEmptyTests.cs
@@ -1,0 +1,52 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Guids;
+
+public sealed partial class ThatNullableGuid
+{
+	public sealed class IsEmptyTests
+	{
+		[Fact]
+		public async Task WhenValueIsEmpty_ShouldSucceed()
+		{
+			Guid subject = Guid.Empty;
+
+			async Task Act()
+				=> await Expect.That(subject).IsEmpty();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenValueIsNotEmpty_ShouldFail()
+		{
+			Guid? subject = OtherGuid();
+
+			async Task Act()
+				=> await Expect.That(subject).IsEmpty();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   is empty,
+				                   but found {subject}
+				                   at Expect.That(subject).IsEmpty()
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNull_ShouldFail()
+		{
+			Guid? subject = null;
+
+			async Task Act()
+				=> await Expect.That(subject).IsEmpty();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that subject
+				                  is empty,
+				                  but found <null>
+				                  at Expect.That(subject).IsEmpty()
+				                  """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.IsNotEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.IsNotEmptyTests.cs
@@ -1,0 +1,52 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Guids;
+
+public sealed partial class ThatNullableGuid
+{
+	public sealed class IsNotEmptyTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsNull_ShouldFail()
+		{
+			Guid? subject = null;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNotEmpty();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that subject
+				                  is not empty,
+				                  but found <null>
+				                  at Expect.That(subject).IsNotEmpty()
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenValueIsEmpty_ShouldFail()
+		{
+			Guid subject = Guid.Empty;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNotEmpty();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   is not empty,
+				                   but found {subject}
+				                   at Expect.That(subject).IsNotEmpty()
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValueIsNotEmpty_ShouldSucceed()
+		{
+			Guid? subject = OtherGuid();
+
+			async Task Act()
+				=> await Expect.That(subject).IsNotEmpty();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.IsNotNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.IsNotNullTests.cs
@@ -1,0 +1,35 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Guids;
+
+public sealed partial class ThatNullableGuid
+{
+	public sealed class IsNotNullTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsNotNull_ShouldSucceed()
+		{
+			Guid? subject = OtherGuid();
+
+			async Task Act()
+				=> await Expect.That(subject).IsNotNull();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNull_ShouldFail()
+		{
+			Guid? subject = null;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNotNull();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that subject
+				                  is not null,
+				                  but found <null>
+				                  at Expect.That(subject).IsNotNull()
+				                  """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.IsNotTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.IsNotTests.cs
@@ -1,0 +1,54 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Guids;
+
+public sealed partial class ThatNullableGuid
+{
+	public sealed class IsNotTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreNull_ShouldFail()
+		{
+			Guid? subject = null;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNot(null);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that subject
+				                  is not <null>,
+				                  but found <null>
+				                  at Expect.That(subject).IsNot(null)
+				                  """);
+		}
+
+		[Fact]
+		public async Task WhenValuesAreDifferent_ShouldSucceed()
+		{
+			Guid? subject = FixedGuid();
+			Guid? unexpected = OtherGuid();
+
+			async Task Act()
+				=> await Expect.That(subject).IsNot(unexpected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenValuesAreTheSame_ShouldFail()
+		{
+			Guid? subject = FixedGuid();
+			Guid? unexpected = subject;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNot(unexpected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   is not {unexpected?.ToString() ?? "<null>"},
+				                   but found {subject?.ToString() ?? "<null>"}
+				                   at Expect.That(subject).IsNot(unexpected)
+				                   """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.IsNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.IsNullTests.cs
@@ -1,0 +1,35 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Guids;
+
+public sealed partial class ThatNullableGuid
+{
+	public sealed class IsNullTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsNotNull_ShouldFail()
+		{
+			Guid? subject = OtherGuid();
+
+			async Task Act()
+				=> await Expect.That(subject).IsNull();
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   is null,
+				                   but found {subject}
+				                   at Expect.That(subject).IsNull()
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNull_ShouldSucceed()
+		{
+			Guid? subject = null;
+
+			async Task Act()
+				=> await Expect.That(subject).IsNull();
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.IsTests.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.IsTests.cs
@@ -1,0 +1,65 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Guids;
+
+public sealed partial class ThatNullableGuid
+{
+	public sealed class IsTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreNull_ShouldSucceed()
+		{
+			Guid? subject = null;
+
+			async Task Act()
+				=> await Expect.That(subject).Is(null);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNull_ShouldFail()
+		{
+			Guid? subject = null;
+
+			async Task Act()
+				=> await Expect.That(subject).Is(FixedGuid());
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   is {FixedGuid()},
+				                   but found <null>
+				                   at Expect.That(subject).Is(FixedGuid())
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValuesAreDifferent_ShouldFail()
+		{
+			Guid? subject = FixedGuid();
+			Guid? expected = OtherGuid();
+
+			async Task Act()
+				=> await Expect.That(subject).Is(expected);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   is {expected?.ToString() ?? "<null>"},
+				                   but found {subject?.ToString() ?? "<null>"}
+				                   at Expect.That(subject).Is(expected)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenValuesAreTheSame_ShouldSucceed()
+		{
+			Guid? subject = FixedGuid();
+			Guid? expected = subject;
+
+			async Task Act()
+				=> await Expect.That(subject).Is(expected);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.cs
+++ b/Tests/Testably.Expectations.Tests/Primitives/Guids/ThatNullableGuid.cs
@@ -1,0 +1,14 @@
+﻿namespace Testably.Expectations.Tests.Primitives.Guids;
+
+public sealed partial class ThatNullableGuid
+{
+	/// <summary>
+	///     Use a fixed random <see cref="Guid"/> in each test run to ensure, that the tests don't rely on special times.
+	/// </summary>
+	private static readonly Lazy<Guid> FixedGuidLazy = new(Guid.NewGuid);
+
+	private static Guid? FixedGuid()
+		=> FixedGuidLazy.Value;
+	private static Guid? OtherGuid()
+		=> Guid.NewGuid();
+}


### PR DESCRIPTION
Add the following assertions for `Guid`s:
- `Is(Guid)`
- `IsNot(Guid)`
- `IsEmpty()`
- `IsNotEmpty()`

For nullable `Guid`s additionally:
- `IsNull()`
- `IsNotNull()`