### PR TITLE
feat: add support for BufferedStream

### DIFF
--- a/Source/Testably.Expectations/Expect.cs
+++ b/Source/Testably.Expectations/Expect.cs
@@ -121,6 +121,15 @@ public static partial class Expect
 		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
 		=> new(new ExpectationBuilder<Stream?>(subject, doNotPopulateThisValue));
 
+#if NET6_0_OR_GREATER
+	/// <summary>
+	///     Start expectations for the current <see cref="BufferedStream" /> <paramref name="subject" />.
+	/// </summary>
+	public static That<BufferedStream?> That(BufferedStream? subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new(new ExpectationBuilder<BufferedStream?>(subject, doNotPopulateThisValue));
+#endif
+
 	/// <summary>
 	///     Start expectations for the current <see cref="string" />? <paramref name="subject" />.
 	/// </summary>

--- a/Source/Testably.Expectations/That/Streams/ThatBufferedStreamExtensions.Constraint.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatBufferedStreamExtensions.Constraint.cs
@@ -1,0 +1,31 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.IO;
+using Testably.Expectations.Core.Constraints;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatBufferedStreamExtensions
+{
+	private readonly struct Constraint(
+		string expectation,
+		Func<BufferedStream?, bool> successIf,
+		Func<BufferedStream?, string> onFailure)
+		: IConstraint<BufferedStream?>
+	{
+		public ConstraintResult IsMetBy(BufferedStream? actual)
+		{
+			if (successIf(actual))
+			{
+				return new ConstraintResult.Success<BufferedStream?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), onFailure(actual));
+		}
+
+		public override string ToString()
+			=> expectation;
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Streams/ThatBufferedStreamExtensions.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatBufferedStreamExtensions.cs
@@ -1,0 +1,46 @@
+﻿#if NET6_0_OR_GREATER
+using System.IO;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on <see cref="BufferedStream" /> values.
+/// </summary>
+public static partial class ThatBufferedStreamExtensions
+{
+	/// <summary>
+	///     Verifies that the subject <see cref="BufferedStream" /> has the <paramref name="expected" /> buffer size.
+	/// </summary>
+	public static AndOrExpectationResult<BufferedStream?, That<BufferedStream?>>
+		DoesNotHaveBufferSize(this That<BufferedStream?> source,
+			long expected,
+			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new Constraint(
+					$"does not have buffer size {expected}",
+					actual => actual != null && actual.BufferSize != expected,
+					actual => actual == null ? "found <null>" : "it had"),
+				b => b.AppendMethod(nameof(DoesNotHaveBufferSize), doNotPopulateThisValue)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject <see cref="BufferedStream" /> has the <paramref name="expected" /> buffer size.
+	/// </summary>
+	public static AndOrExpectationResult<BufferedStream?, That<BufferedStream?>> HasBufferSize(
+		this That<BufferedStream?> source,
+		long expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder.Add(new Constraint(
+					$"has buffer size {expected}",
+					actual => actual?.BufferSize == expected,
+					actual => actual == null
+						? "found <null>"
+						: $"it had buffer size {actual.BufferSize}"),
+				b => b.AppendMethod(nameof(HasBufferSize), doNotPopulateThisValue)),
+			source);
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/That/Streams/ThatBufferedStream.DoesNotHaveBufferSizeTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Streams/ThatBufferedStream.DoesNotHaveBufferSizeTests.cs
@@ -1,0 +1,59 @@
+﻿#if NET6_0_OR_GREATER
+using System.IO;
+
+namespace Testably.Expectations.Tests.That.Streams;
+
+public sealed partial class ThatBufferedStream
+{
+	public sealed class DoesNotHaveBufferSizeTests
+	{
+		[Theory]
+		[AutoData]
+		public async Task WhenSubjectHasDifferentBufferSize_ShouldSucceed(int buffersize)
+		{
+			int actualBufferSize = buffersize > 10000 ? buffersize - 1 : buffersize + 1;
+			using BufferedStream subject = GetBufferedStream(actualBufferSize);
+
+			async Task Act()
+				=> await Expect.That(subject).DoesNotHaveBufferSize(buffersize);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenSubjectHasSameBufferSize_ShouldFail(int buffersize)
+		{
+			using BufferedStream subject = GetBufferedStream(buffersize);
+
+			async Task Act()
+				=> await Expect.That(subject).DoesNotHaveBufferSize(buffersize);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   does not have buffer size {buffersize},
+				                   but it had
+				                   at Expect.That(subject).DoesNotHaveBufferSize(buffersize)
+				                   """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNull_ShouldFail()
+		{
+			using BufferedStream? subject = null;
+
+			async Task Act()
+				=> await Expect.That(subject).DoesNotHaveBufferSize(0);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that subject
+				                  does not have buffer size 0,
+				                  but found <null>
+				                  at Expect.That(subject).DoesNotHaveBufferSize(0)
+				                  """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/That/Streams/ThatBufferedStream.HasBufferSizeTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Streams/ThatBufferedStream.HasBufferSizeTests.cs
@@ -1,0 +1,59 @@
+﻿#if NET6_0_OR_GREATER
+using System.IO;
+
+namespace Testably.Expectations.Tests.That.Streams;
+
+public sealed partial class ThatBufferedStream
+{
+	public sealed class HasBufferSizeTests
+	{
+		[Theory]
+		[AutoData]
+		public async Task WhenSubjectHasDifferentBufferSize_ShouldFail(int buffersize)
+		{
+			int actualBufferSize = buffersize > 10000 ? buffersize - 1 : buffersize + 1;
+			using BufferedStream subject = GetBufferedStream(actualBufferSize);
+
+			async Task Act()
+				=> await Expect.That(subject).HasBufferSize(buffersize);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage($"""
+				                   Expected that subject
+				                   has buffer size {buffersize},
+				                   but it had buffer size {actualBufferSize}
+				                   at Expect.That(subject).HasBufferSize(buffersize)
+				                   """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenSubjectHasSameBufferSize_ShouldSucceed(int buffersize)
+		{
+			using BufferedStream subject = GetBufferedStream(buffersize);
+
+			async Task Act()
+				=> await Expect.That(subject).HasBufferSize(buffersize);
+
+			await Expect.That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNull_ShouldFail()
+		{
+			using BufferedStream? subject = null;
+
+			async Task Act()
+				=> await Expect.That(subject).HasBufferSize(0);
+
+			await Expect.That(Act).Throws<XunitException>()
+				.Which.HasMessage("""
+				                  Expected that subject
+				                  has buffer size 0,
+				                  but found <null>
+				                  at Expect.That(subject).HasBufferSize(0)
+				                  """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/That/Streams/ThatBufferedStream.cs
+++ b/Tests/Testably.Expectations.Tests/That/Streams/ThatBufferedStream.cs
@@ -1,0 +1,11 @@
+﻿#if NET6_0_OR_GREATER
+using System.IO;
+
+namespace Testably.Expectations.Tests.That.Streams;
+
+public sealed partial class ThatBufferedStream
+{
+	public static BufferedStream GetBufferedStream(int bufferSize)
+		=> new(new MemoryStream(), bufferSize);
+}
+#endif


### PR DESCRIPTION
After #45, also add support for `BufferedStream` with the following methods:
- `HasBufferSize(int)` / `DoesNotHaveBufferSize(int)`