### PR TITLE
feat: ignore auto-generated files from Rider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,30 @@
-# Ignore the Directory.Build.props in the root directory so that
-# the setting of specific constants can improve the developer experience
-# without affecting the origin GIT repository
-/Directory.Build.props
+## Common IntelliJ Platform excludes
+##
+## Get latest from https://github.com/JetBrains/resharper-rider-samples/blob/master/.gitignore
+
+**/.idea/**/.idea/*
+
+# User specific
+**/.idea/**/workspace.xml
+**/.idea/**/tasks.xml
+**/.idea/shelf/*
+**/.idea/dictionaries
+**/.idea/httpRequests/
+
+# Sensitive or high-churn files
+**/.idea/**/dataSources/
+**/.idea/**/dataSources.ids
+**/.idea/**/dataSources.xml
+**/.idea/**/dataSources.local.xml
+**/.idea/**/sqlDataSources.xml
+**/.idea/**/dynamic.xml
+
+# Rider
+# Rider auto-generates .iml files, and contentModel.xml
+**/.idea/**/*.iml
+**/.idea/**/contentModel.xml
+**/.idea/**/modules.xml
+
 
 # Set up Visual Studio to use WSL to execute unit tests in Ubuntu:
 # https://learn.microsoft.com/en-us/visualstudio/test/remote-testing


### PR DESCRIPTION
[JetBrains Rider](https://www.jetbrains.com/rider/) auto-generates files in the ".idea" directory, which should not be included in GIT.
Update `.gitignore` to exclude these files.