### PR TITLE
feat: improve wording of `Which` and `Satisfy`

### DIFF
--- a/Source/Testably.Expectations/Core/Helpers/StringBuilderHelpers.cs
+++ b/Source/Testably.Expectations/Core/Helpers/StringBuilderHelpers.cs
@@ -22,6 +22,15 @@ internal static class StringBuilderHelpers
 	}
 
 	public static StringBuilder AppendGenericMethod<T1, T2>(this StringBuilder builder,
+		string methodName, string param1)
+	{
+		return builder.Append('.').Append(methodName)
+			.Append('<').Append(Formatter.Format(typeof(T1))).Append(", ")
+			.Append(Formatter.Format(typeof(T2))).Append('>')
+			.Append('(').Append(param1).Append(')');
+	}
+
+	public static StringBuilder AppendGenericMethod<T1, T2>(this StringBuilder builder,
 		string methodName, string param1, string param2)
 	{
 		return builder.Append('.').Append(methodName)

--- a/Source/Testably.Expectations/Expect.cs
+++ b/Source/Testably.Expectations/Expect.cs
@@ -12,7 +12,7 @@ namespace Testably.Expectations;
 public static class Expect
 {
 	/// <summary>
-	///     Start expectations for the current <paramref name="subject" />.
+	///     Specify expectations for the current <paramref name="subject" />.
 	/// </summary>
 	public static IExpectThat<T> That<T>(T? subject,
 		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
@@ -21,7 +21,7 @@ public static class Expect
 	}
 
 	/// <summary>
-	///     Start expectations for the current <see cref="Action" /> <paramref name="delegate" />.
+	///     Specify expectations for the current <see cref="Action" /> <paramref name="delegate" />.
 	/// </summary>
 	public static IExpectThat<ThatDelegate.WithoutValue> That(Action @delegate,
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
@@ -32,7 +32,7 @@ public static class Expect
 	}
 
 	/// <summary>
-	///     Start expectations for the current <see cref="Func{Task}" /> <paramref name="delegate" />.
+	///     Specify expectations for the current <see cref="Func{Task}" /> <paramref name="delegate" />.
 	/// </summary>
 	public static IExpectThat<ThatDelegate.WithoutValue> That(Func<Task> @delegate,
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
@@ -41,7 +41,7 @@ public static class Expect
 			doNotPopulateThisValue));
 
 	/// <summary>
-	///     Start expectations for the current <see cref="Task" /> <paramref name="delegate" />.
+	///     Specify expectations for the current <see cref="Task" /> <paramref name="delegate" />.
 	/// </summary>
 	public static IExpectThat<ThatDelegate.WithoutValue> That(Task @delegate,
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
@@ -51,7 +51,7 @@ public static class Expect
 
 #if NET6_0_OR_GREATER
 	/// <summary>
-	///     Start expectations for the current <see cref="ValueTask" /> <paramref name="delegate" />.
+	///     Specify expectations for the current <see cref="ValueTask" /> <paramref name="delegate" />.
 	/// </summary>
 	public static IExpectThat<ThatDelegate.WithoutValue> That(ValueTask @delegate,
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
@@ -61,7 +61,7 @@ public static class Expect
 #endif
 
 	/// <summary>
-	///     Start expectations for the current <see cref="Func{TValue}" /> <paramref name="delegate" />.
+	///     Specify expectations for the current <see cref="Func{TValue}" /> <paramref name="delegate" />.
 	/// </summary>
 	public static IExpectThat<ThatDelegate.WithValue<TValue>> That<TValue>(Func<TValue> @delegate,
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
@@ -70,7 +70,7 @@ public static class Expect
 			doNotPopulateThisValue));
 
 	/// <summary>
-	///     Start expectations for the current <see cref="Func{T}" /> of <see cref="Task{TValue}" />
+	///     Specify expectations for the current <see cref="Func{T}" /> of <see cref="Task{TValue}" />
 	///     <paramref name="delegate" />.
 	/// </summary>
 	public static IExpectThat<ThatDelegate.WithValue<TValue>> That<TValue>(
@@ -81,7 +81,7 @@ public static class Expect
 			doNotPopulateThisValue));
 
 	/// <summary>
-	///     Start expectations for the current <see cref="Task{TValue}" /> <paramref name="delegate" />.
+	///     Specify expectations for the current <see cref="Task{TValue}" /> <paramref name="delegate" />.
 	/// </summary>
 	public static IExpectThat<ThatDelegate.WithValue<TValue>> That<TValue>(Task<TValue> @delegate,
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
@@ -91,7 +91,7 @@ public static class Expect
 
 #if NET6_0_OR_GREATER
 	/// <summary>
-	///     Start expectations for the current <see cref="ValueTask{TValue}" /> <paramref name="delegate" />.
+	///     Specify expectations for the current <see cref="ValueTask{TValue}" /> <paramref name="delegate" />.
 	/// </summary>
 	public static IExpectThat<ThatDelegate.WithValue<TValue>> That<TValue>(
 		ValueTask<TValue> @delegate,

--- a/Source/Testably.Expectations/That/Objects/ThatObjectShould.Satisfy.cs
+++ b/Source/Testably.Expectations/That/Objects/ThatObjectShould.Satisfy.cs
@@ -11,22 +11,41 @@ namespace Testably.Expectations;
 public static partial class ThatObjectShould
 {
 	/// <summary>
-	///     Verifies that the value satisfies the <paramref name="expectations" /> on the properties selected by the
-	///     <paramref name="selector" />.
+	///     Verifies that the value on the property selected by the <paramref name="selector" />...
 	/// </summary>
-	public static AndOrExpectationResult<T, That<object?>> Satisfy<T, TProperty>(
+	public static SatisfyResult<TProperty, AndOrExpectationResult<T, That<object?>>> Satisfy<T,
+		TProperty>(
 		this That<object?> source,
 		Expression<Func<T, TProperty?>> selector,
-		Action<That<TProperty?>> expectations,
-		[CallerArgumentExpression("selector")] string doNotPopulateThisValue1 = "",
-		[CallerArgumentExpression("expectations")]
-		string doNotPopulateThisValue2 = "")
-		=> new(source.ExpectationBuilder.Which<T, TProperty?>(
-				PropertyAccessor<T, TProperty?>.FromExpression(selector),
-				expectations,
-				b => b.AppendGenericMethod<T, TProperty>(nameof(Satisfy), doNotPopulateThisValue1,
-					doNotPopulateThisValue2),
-				whichTextSeparator: "satisfy ",
-				whichPropertyTextSeparator: "to "),
-			source);
+		[CallerArgumentExpression("selector")] string doNotPopulateThisValue1 = "")
+		=> new((expectations, doNotPopulateThisValue2) =>
+			new AndOrExpectationResult<T, That<object?>>(
+				source.ExpectationBuilder.Which<T, TProperty?>(
+					PropertyAccessor<T, TProperty?>.FromExpression(selector),
+					expectations,
+					b => b.AppendGenericMethod<T, TProperty>(nameof(Satisfy),
+							doNotPopulateThisValue1)
+						.AppendMethod(nameof(SatisfyResult<TProperty, T>.To),
+							doNotPopulateThisValue2),
+					whichTextSeparator: "satisfy ",
+					whichPropertyTextSeparator: "to "),
+				source));
+
+	/// <summary>
+	///     Intermediate result for chaining Satisfy and To methods.
+	/// </summary>
+	public class SatisfyResult<TProperty, TReturn>(
+		Func<Action<That<TProperty?>>, string, TReturn> resultCallback)
+	{
+		/// <summary>
+		///     ...satisfies the <paramref name="expectations" />
+		/// </summary>
+		public TReturn To(
+			Action<That<TProperty?>> expectations,
+			[CallerArgumentExpression("expectations")]
+			string doNotPopulateThisValue = "")
+		{
+			return resultCallback(expectations, doNotPopulateThisValue);
+		}
+	}
 }

--- a/Tests/Testably.Expectations.Tests/Core/ConstraintResultTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/ConstraintResultTests.cs
@@ -20,10 +20,7 @@ public sealed class ConstraintResultTests
 	public async Task Failure_WithValue_ShouldStoreValueAndTexts(string expectationText,
 		string resultText)
 	{
-		Dummy value = new()
-		{
-			Value = 1
-		};
+		Dummy value = new() { Value = 1 };
 
 		ConstraintResult.Failure<Dummy> subject = new(value, expectationText, resultText);
 
@@ -42,7 +39,7 @@ public sealed class ConstraintResultTests
 		ConstraintResult result = subject.Invert();
 
 		await Expect.That(result).Should().Be<ConstraintResult.Success>()
-			.Which(s => s.ExpectationText, e => e.Be(expectationText));
+			.Which(s => s.ExpectationText).Should(e => e.Be(expectationText));
 	}
 
 	[Theory]
@@ -55,7 +52,7 @@ public sealed class ConstraintResultTests
 		ConstraintResult result = subject.Invert(_ => expectationText, _ => resultText);
 
 		await Expect.That(result).Should().Be<ConstraintResult.Success>()
-			.Which(s => s.ExpectationText, e => e.Be(expectationText));
+			.Which(s => s.ExpectationText).Should(e => e.Be(expectationText));
 	}
 
 	[Theory]
@@ -63,16 +60,13 @@ public sealed class ConstraintResultTests
 	public async Task Invert_FromFailureWithValue_ShouldIncludeValue(string expectationText,
 		string resultText)
 	{
-		Dummy value = new()
-		{
-			Value = 1
-		};
+		Dummy value = new() { Value = 1 };
 		ConstraintResult.Failure<Dummy> subject = new(value, expectationText, resultText);
 
 		ConstraintResult result = subject.Invert();
 
 		await Expect.That(result).Should().Be<ConstraintResult.Success<Dummy>>()
-			.Which(s => s.Value, e => e.BeEquivalentTo(value));
+			.Which(s => s.Value).Should(e => e.BeEquivalentTo(value));
 	}
 
 	[Theory]
@@ -80,16 +74,13 @@ public sealed class ConstraintResultTests
 	public async Task Invert_FromFailureWithValue_ShouldKeepExpectationText(string expectationText,
 		string resultText)
 	{
-		Dummy value = new()
-		{
-			Value = 1
-		};
+		Dummy value = new() { Value = 1 };
 		ConstraintResult.Failure<Dummy> subject = new(value, expectationText, resultText);
 
 		ConstraintResult result = subject.Invert();
 
 		await Expect.That(result).Should().Be<ConstraintResult.Success<Dummy>>()
-			.Which(s => s.ExpectationText, e => e.Be(expectationText));
+			.Which(s => s.ExpectationText).Should(e => e.Be(expectationText));
 	}
 
 	[Theory]
@@ -98,16 +89,13 @@ public sealed class ConstraintResultTests
 		string expectationText,
 		string resultText)
 	{
-		Dummy value = new()
-		{
-			Value = 1
-		};
+		Dummy value = new() { Value = 1 };
 		ConstraintResult.Failure<Dummy> subject = new(value, "foo", "bar");
 
 		ConstraintResult result = subject.Invert(_ => expectationText, _ => resultText);
 
 		await Expect.That(result).Should().Be<ConstraintResult.Success<Dummy>>()
-			.Which(s => s.ExpectationText, e => e.Be(expectationText));
+			.Which(s => s.ExpectationText).Should(e => e.Be(expectationText));
 	}
 
 	[Theory]
@@ -120,8 +108,8 @@ public sealed class ConstraintResultTests
 		ConstraintResult result = subject.Invert();
 
 		await Expect.That(result).Should().Be<ConstraintResult.Failure>()
-			.Which(s => s.ExpectationText, e => e.Be(expectationText))
-			.Which(s => s.ResultText, e => e.Be("it did"));
+			.Which(s => s.ExpectationText).Should(e => e.Be(expectationText))
+			.Which(s => s.ResultText).Should(e => e.Be("it did"));
 	}
 
 	[Theory]
@@ -134,24 +122,21 @@ public sealed class ConstraintResultTests
 		ConstraintResult result = subject.Invert(_ => expectationText, _ => resultText);
 
 		await Expect.That(result).Should().Be<ConstraintResult.Failure>()
-			.Which(p => p.ExpectationText, e => e.Be(expectationText))
-			.Which(p => p.ResultText, e => e.Be(resultText));
+			.Which(p => p.ExpectationText).Should(e => e.Be(expectationText))
+			.Which(p => p.ResultText).Should(e => e.Be(resultText));
 	}
 
 	[Theory]
 	[AutoData]
 	public async Task Invert_FromSuccessWithValue_ShouldIncludeValue(string expectationText)
 	{
-		Dummy value = new()
-		{
-			Value = 1
-		};
+		Dummy value = new() { Value = 1 };
 		ConstraintResult.Success<Dummy> subject = new(value, expectationText);
 
 		ConstraintResult result = subject.Invert();
 
 		await Expect.That(result).Should().Be<ConstraintResult.Failure<Dummy>>()
-			.Which(p => p.Value, e => e.BeEquivalentTo(value));
+			.Which(p => p.Value).Should(e => e.BeEquivalentTo(value));
 	}
 
 	[Theory]
@@ -159,17 +144,14 @@ public sealed class ConstraintResultTests
 	public async Task Invert_FromSuccessWithValue_ShouldKeepExpectationTextAndUseDefaultResultText(
 		string expectationText)
 	{
-		Dummy value = new()
-		{
-			Value = 1
-		};
+		Dummy value = new() { Value = 1 };
 		ConstraintResult.Success<Dummy> subject = new(value, expectationText);
 
 		ConstraintResult result = subject.Invert();
 
 		await Expect.That(result).Should().Be<ConstraintResult.Failure<Dummy>>()
-			.Which(p => p.ExpectationText, e => e.Be(expectationText))
-			.Which(p => p.ResultText, e => e.Be("it did"));
+			.Which(p => p.ExpectationText).Should(e => e.Be(expectationText))
+			.Which(p => p.ResultText).Should(e => e.Be("it did"));
 	}
 
 	[Theory]
@@ -177,27 +159,21 @@ public sealed class ConstraintResultTests
 	public async Task Invert_FromSuccessWithValue_ShouldUpdateExpectationAndResultText(
 		string expectationText, string resultText)
 	{
-		Dummy value = new()
-		{
-			Value = 1
-		};
+		Dummy value = new() { Value = 1 };
 		ConstraintResult.Success<Dummy> subject = new(value, "foo");
 
 		ConstraintResult result = subject.Invert(_ => expectationText, _ => resultText);
 
 		await Expect.That(result).Should().Be<ConstraintResult.Failure<Dummy>>()
-			.Which(p => p.ExpectationText, e => e.Be(expectationText))
-			.Which(p => p.ResultText, e => e.Be(resultText));
+			.Which(p => p.ExpectationText).Should(e => e.Be(expectationText))
+			.Which(p => p.ResultText).Should(e => e.Be(resultText));
 	}
 
 	[Theory]
 	[AutoData]
 	public async Task Success_WithValue_ShouldStoreValue(string expectationText)
 	{
-		Dummy value = new()
-		{
-			Value = 1
-		};
+		Dummy value = new() { Value = 1 };
 
 		ConstraintResult.Success<Dummy> subject = new(value, expectationText);
 

--- a/Tests/Testably.Expectations.Tests/Core/Nodes/WhichNodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Nodes/WhichNodeTests.cs
@@ -16,7 +16,7 @@ public sealed class WhichNodeTests
 
 		async Task Act()
 			=> await Expect.That(subject).Should().Be<Dummy>()
-				.Which(p => p.Value, e => e.Be("bar"));
+				.Which(p => p.Value).Should(e => e.Be("bar"));
 
 		await Expect.That(Act).Should().Throw<XunitException>()
 			.Which.HaveMessage("""
@@ -27,7 +27,7 @@ public sealed class WhichNodeTests
 			                    "foo"
 			                    "bar"
 			                     ↑ (expected)
-			                  at Expect.That(subject).Should().Be<Dummy>().Which(p => p.Value, e => e.Be("bar"))
+			                  at Expect.That(subject).Should().Be<Dummy>().Which(p => p.Value).Should(e => e.Be("bar"))
 			                  """);
 	}
 

--- a/Tests/Testably.Expectations.Tests/That/Objects/ObjectShould.SatisfyTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Objects/ObjectShould.SatisfyTests.cs
@@ -10,14 +10,14 @@ public sealed partial class ObjectShould
 			Other subject = new() { Value = 1 };
 
 			async Task Act()
-				=> await Expect.That(subject).Should().Satisfy<Other, int>(o => o.Value, v => v.Be(2));
+				=> await Expect.That(subject).Should().Satisfy<Other, int>(o => o.Value).To(v => v.Be(2));
 
 			await Expect.That(Act).Should().Throw<XunitException>()
 				.Which.HaveMessage("""
 				                  Expected subject to
 				                  satisfy Value to be 2,
 				                  but found 1
-				                  at Expect.That(subject).Should().Satisfy<Other, int>(o => o.Value, v => v.Be(2))
+				                  at Expect.That(subject).Should().Satisfy<Other, int>(o => o.Value).To(v => v.Be(2))
 				                  """);
 		}
 	}


### PR DESCRIPTION
Improve Which/Should and Satisfy/To method by adding an intermediate result, so it now reads
```csharp
await Expect.That(subject).Should().Be<Dummy>().Which(p => p.Value).Should(e => e.Be("bar"));
await Expect.That(subject).Should().Satisfy<Other, int>(o => o.Value).To(v => v.Be(2));
```