### PR TITLE
feat: add `BeFinite` and `BeInfinite`

### DIFF
--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeFinite.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeFinite.cs
@@ -1,0 +1,65 @@
+﻿using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatNumberShould
+{
+	/// <summary>
+	///     Verifies that the subject is seen as finite (neither <see cref="float.IsInfinity" /> nor <see cref="float.IsNaN"/>).
+	/// </summary>
+	public static AndOrExpectationResult<float, IThat<float>> BeFinite(
+		this IThat<float> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<float>(
+					float.PositiveInfinity,
+					"be finite",
+					(a, _) => !float.IsInfinity(a) && !float.IsNaN(a),
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeFinite)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is seen as finite (neither <see cref="double.IsInfinity" /> nor <see cref="double.IsNaN"/>).
+	/// </summary>
+	public static AndOrExpectationResult<double, IThat<double>> BeFinite(
+		this IThat<double> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<double>(
+					double.PositiveInfinity,
+					"be finite",
+					(a, _) => !double.IsInfinity(a) && !double.IsNaN(a),
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeFinite)),
+			source);
+	
+	/// <summary>
+	///     Verifies that the subject is not seen as finite (either <see cref="float.IsInfinity" /> or <see cref="float.IsNaN"/>).
+	/// </summary>
+	public static AndOrExpectationResult<float, IThat<float>> NotBeFinite(
+		this IThat<float> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<float>(
+					float.PositiveInfinity,
+					"not be finite",
+					(a, _) => float.IsInfinity(a) || float.IsNaN(a),
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(NotBeFinite)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not seen as finite (either <see cref="double.IsInfinity" /> or <see cref="double.IsNaN"/>).
+	/// </summary>
+	public static AndOrExpectationResult<double, IThat<double>> NotBeFinite(
+		this IThat<double> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<double>(
+					double.PositiveInfinity,
+					"not be finite",
+					(a, _) => double.IsInfinity(a) || double.IsNaN(a),
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(NotBeFinite)),
+			source);
+}

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeInfinite.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeInfinite.cs
@@ -1,0 +1,64 @@
+﻿using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatNumberShould
+{
+	/// <summary>
+	///     Verifies that the subject is seen as infinite (<see cref="float.IsInfinity" />).
+	/// </summary>
+	public static AndOrExpectationResult<float, IThat<float>> BeInfinite(this IThat<float> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<float>(
+					float.PositiveInfinity,
+					"be infinite",
+					(a, _) => float.IsInfinity(a),
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeInfinite)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is seen as infinite (<see cref="double.IsInfinity" />).
+	/// </summary>
+	public static AndOrExpectationResult<double, IThat<double>> BeInfinite(
+		this IThat<double> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<double>(
+					double.PositiveInfinity,
+					"be infinite",
+					(a, _) => double.IsInfinity(a),
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeInfinite)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not seen as infinite (not <see cref="float.IsInfinity" />).
+	/// </summary>
+	public static AndOrExpectationResult<float, IThat<float>> NotBeInfinite(
+		this IThat<float> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<float>(
+					float.PositiveInfinity,
+					"not be infinite",
+					(a, _) => !float.IsInfinity(a),
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(NotBeInfinite)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not seen as infinite (not <see cref="double.IsInfinity" />).
+	/// </summary>
+	public static AndOrExpectationResult<double, IThat<double>> NotBeInfinite(
+		this IThat<double> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<double>(
+					double.PositiveInfinity,
+					"not be infinite",
+					(a, _) => !double.IsInfinity(a),
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(NotBeInfinite)),
+			source);
+}

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeNaN.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeNaN.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Testably.Expectations.Core;
-using Testably.Expectations.Core.Constraints;
+﻿using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
@@ -14,7 +12,11 @@ public static partial class ThatNumberShould
 	/// </summary>
 	public static AndOrExpectationResult<float, IThat<float>> BeNaN(this IThat<float> source)
 		=> new(source.ExpectationBuilder
-				.AddConstraint(new IsNaNValueConstraint<float>(float.IsNaN))
+				.AddConstraint(new GenericConstraint<float>(
+					float.NaN,
+					"be NaN",
+					(a, _) => float.IsNaN(a),
+					(a, _) => $"found {Formatter.Format(a)}"))
 				.AppendMethodStatement(nameof(BeNaN)),
 			source);
 
@@ -23,25 +25,37 @@ public static partial class ThatNumberShould
 	/// </summary>
 	public static AndOrExpectationResult<double, IThat<double>> BeNaN(this IThat<double> source)
 		=> new(source.ExpectationBuilder
-				.AddConstraint(new IsNaNValueConstraint<double>(double.IsNaN))
+				.AddConstraint(new GenericConstraint<double>(
+					double.NaN,
+					"be NaN",
+					(a, _) => double.IsNaN(a),
+					(a, _) => $"found {Formatter.Format(a)}"))
 				.AppendMethodStatement(nameof(BeNaN)),
 			source);
 
-	private readonly struct IsNaNValueConstraint<TNumber>(Func<TNumber, bool> isNaN)
-		: IValueConstraint<TNumber>
-		where TNumber : struct, IComparable<TNumber>
-	{
-		public ConstraintResult IsMetBy(TNumber actual)
-		{
-			if (isNaN(actual))
-			{
-				return new ConstraintResult.Success<TNumber>(actual, ToString());
-			}
+	/// <summary>
+	///     Verifies that the subject is not seen as not a number (<see cref="float.NaN" />).
+	/// </summary>
+	public static AndOrExpectationResult<float, IThat<float>> NotBeNaN(this IThat<float> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<float>(
+					float.NaN,
+					"not be NaN",
+					(a, _) => !float.IsNaN(a),
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(NotBeNaN)),
+			source);
 
-			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
-		}
-
-		public override string ToString()
-			=> "be NaN";
-	}
+	/// <summary>
+	///     Verifies that the subject is not seen as not a number (<see cref="double.NaN" />).
+	/// </summary>
+	public static AndOrExpectationResult<double, IThat<double>> NotBeNaN(this IThat<double> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<double>(
+					double.NaN,
+					"not be NaN",
+					(a, _) => !double.IsNaN(a),
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(NotBeNaN)),
+			source);
 }

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.cs
@@ -1,5 +1,7 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
+using Testably.Expectations.Core.Constraints;
 // ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
@@ -209,4 +211,26 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
 		=> subject.Should(expectationBuilder => expectationBuilder
 			.AppendMethodStatement(nameof(Should)));
+	
+	
+	private readonly struct GenericConstraint<T>(
+		T expected,
+		string expectation,
+		Func<T, T, bool> condition,
+		Func<T, T, string> failureMessageFactory)
+		: IValueConstraint<T>
+	{
+		public ConstraintResult IsMetBy(T actual)
+		{
+			if (condition(actual, expected))
+			{
+				return new ConstraintResult.Success<T>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), failureMessageFactory(actual, expected));
+		}
+
+		public override string ToString()
+			=> expectation;
+	}
 }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -272,10 +272,20 @@ namespace Testably.Expectations
             where TNumber :  struct, System.IComparable<TNumber> { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TNumber?, Testably.Expectations.Core.IThat<TNumber?>> Be<TNumber>(this Testably.Expectations.Core.IThat<TNumber?> source, TNumber? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TNumber :  struct, System.IComparable<TNumber> { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> BeFinite(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> BeFinite(this Testably.Expectations.Core.IThat<float> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> BeInfinite(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> BeInfinite(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> BeNaN(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> BeNaN(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TNumber, Testably.Expectations.Core.IThat<TNumber>> NotBe<TNumber>(this Testably.Expectations.Core.IThat<TNumber> source, TNumber expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TNumber :  struct, System.IComparable<TNumber> { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> NotBeFinite(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> NotBeFinite(this Testably.Expectations.Core.IThat<float> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> NotBeInfinite(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> NotBeInfinite(this Testably.Expectations.Core.IThat<float> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> NotBeNaN(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> NotBeNaN(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Core.IThat<int> Should(this Testably.Expectations.Core.IExpectSubject<int> subject) { }
         public static Testably.Expectations.Core.IThat<System.IntPtr> Should(this Testably.Expectations.Core.IExpectSubject<System.IntPtr> subject) { }
         public static Testably.Expectations.Core.IThat<System.IntPtr?> Should(this Testably.Expectations.Core.IExpectSubject<System.IntPtr?> subject) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -272,10 +272,20 @@ namespace Testably.Expectations
             where TNumber :  struct, System.IComparable<TNumber> { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TNumber?, Testably.Expectations.Core.IThat<TNumber?>> Be<TNumber>(this Testably.Expectations.Core.IThat<TNumber?> source, TNumber? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TNumber :  struct, System.IComparable<TNumber> { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> BeFinite(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> BeFinite(this Testably.Expectations.Core.IThat<float> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> BeInfinite(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> BeInfinite(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> BeNaN(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> BeNaN(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TNumber, Testably.Expectations.Core.IThat<TNumber>> NotBe<TNumber>(this Testably.Expectations.Core.IThat<TNumber> source, TNumber expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TNumber :  struct, System.IComparable<TNumber> { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> NotBeFinite(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> NotBeFinite(this Testably.Expectations.Core.IThat<float> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> NotBeInfinite(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> NotBeInfinite(this Testably.Expectations.Core.IThat<float> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> NotBeNaN(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> NotBeNaN(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Core.IThat<int> Should(this Testably.Expectations.Core.IExpectSubject<int> subject) { }
         public static Testably.Expectations.Core.IThat<System.IntPtr> Should(this Testably.Expectations.Core.IExpectSubject<System.IntPtr> subject) { }
         public static Testably.Expectations.Core.IThat<System.IntPtr?> Should(this Testably.Expectations.Core.IExpectSubject<System.IntPtr?> subject) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -232,10 +232,20 @@ namespace Testably.Expectations
             where TNumber :  struct, System.IComparable<TNumber> { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TNumber?, Testably.Expectations.Core.IThat<TNumber?>> Be<TNumber>(this Testably.Expectations.Core.IThat<TNumber?> source, TNumber? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TNumber :  struct, System.IComparable<TNumber> { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> BeFinite(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> BeFinite(this Testably.Expectations.Core.IThat<float> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> BeInfinite(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> BeInfinite(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> BeNaN(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> BeNaN(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TNumber, Testably.Expectations.Core.IThat<TNumber>> NotBe<TNumber>(this Testably.Expectations.Core.IThat<TNumber> source, TNumber expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TNumber :  struct, System.IComparable<TNumber> { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> NotBeFinite(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> NotBeFinite(this Testably.Expectations.Core.IThat<float> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> NotBeInfinite(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> NotBeInfinite(this Testably.Expectations.Core.IThat<float> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<double, Testably.Expectations.Core.IThat<double>> NotBeNaN(this Testably.Expectations.Core.IThat<double> source) { }
+        public static Testably.Expectations.Results.AndOrExpectationResult<float, Testably.Expectations.Core.IThat<float>> NotBeNaN(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Core.IThat<int> Should(this Testably.Expectations.Core.IExpectSubject<int> subject) { }
         public static Testably.Expectations.Core.IThat<System.IntPtr> Should(this Testably.Expectations.Core.IExpectSubject<System.IntPtr> subject) { }
         public static Testably.Expectations.Core.IThat<System.IntPtr?> Should(this Testably.Expectations.Core.IExpectSubject<System.IntPtr?> subject) { }

--- a/Tests/Testably.Expectations.Tests/That/Numbers/NumberShould.BeFiniteTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Numbers/NumberShould.BeFiniteTests.cs
@@ -1,0 +1,188 @@
+﻿using System.Globalization;
+
+namespace Testably.Expectations.Tests.That.Numbers;
+
+public sealed partial class NumberShould
+{
+	public sealed class BeFiniteTests
+	{
+		[Fact]
+		public async Task ForDouble_ShouldSupportChaining()
+		{
+			double subject = double.Epsilon;
+
+			async Task Act()
+				=> await Expect.That(subject).Should().BeFinite()
+					.And.Be(subject);
+
+			await Expect.That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(double.PositiveInfinity)]
+		[InlineData(double.NegativeInfinity)]
+		[InlineData(double.NaN)]
+		public async Task ForDouble_WhenSubjectIsInfinity_ShouldFail(double subject)
+		{
+			async Task Act() => await Expect.That(subject).Should().BeFinite();
+
+			await Expect.That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be finite,
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().BeFinite()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1d)]
+		[InlineData(0d)]
+		[InlineData(1d)]
+		[InlineData(double.MinValue)]
+		[InlineData(double.MaxValue)]
+		[InlineData(double.Epsilon)]
+		public async Task ForDouble_WhenSubjectIsNormalValue_ShouldSucceed(double subject)
+		{
+			async Task Act()
+				=> await Expect.That(subject).Should().BeFinite();
+
+			await Expect.That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForFloat_ShouldSupportChaining()
+		{
+			float subject = float.Epsilon;
+
+			async Task Act() => await Expect.That(subject).Should().BeFinite()
+				.And.Be(subject);
+
+			await Expect.That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(float.PositiveInfinity)]
+		[InlineData(float.NegativeInfinity)]
+		[InlineData(float.NaN)]
+		public async Task ForFloat_WhenSubjectIsInfinity_ShouldFail(float subject)
+		{
+			async Task Act()
+				=> await Expect.That(subject).Should().BeFinite();
+
+			await Expect.That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be finite,
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().BeFinite()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1f)]
+		[InlineData(0f)]
+		[InlineData(1f)]
+		[InlineData(float.MinValue)]
+		[InlineData(float.MaxValue)]
+		[InlineData(float.Epsilon)]
+		public async Task ForFloat_WhenSubjectIsNormalValue_ShouldSucceed(float subject)
+		{
+			async Task Act()
+				=> await Expect.That(subject).Should().BeFinite();
+
+			await Expect.That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeFiniteTests
+	{
+		[Fact]
+		public async Task ForDouble_ShouldSupportChaining()
+		{
+			double subject = double.PositiveInfinity;
+
+			async Task Act()
+				=> await Expect.That(subject).Should().NotBeFinite()
+					.And.Be(subject);
+
+			await Expect.That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(double.PositiveInfinity)]
+		[InlineData(double.NegativeInfinity)]
+		[InlineData(double.NaN)]
+		public async Task ForDouble_WhenSubjectIsInfinity_ShouldSucceed(double subject)
+		{
+			async Task Act() => await Expect.That(subject).Should().NotBeFinite();
+
+			await Expect.That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1d)]
+		[InlineData(0d)]
+		[InlineData(1d)]
+		[InlineData(double.MinValue)]
+		[InlineData(double.MaxValue)]
+		[InlineData(double.Epsilon)]
+		public async Task ForDouble_WhenSubjectIsNormalValue_ShouldFail(double subject)
+		{
+			async Task Act()
+				=> await Expect.That(subject).Should().NotBeFinite();
+
+			await Expect.That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be finite,
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().NotBeFinite()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForFloat_ShouldSupportChaining()
+		{
+			float subject = float.PositiveInfinity;
+
+			async Task Act() => await Expect.That(subject).Should().NotBeFinite()
+				.And.Be(subject);
+
+			await Expect.That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(float.PositiveInfinity)]
+		[InlineData(float.NegativeInfinity)]
+		[InlineData(float.NaN)]
+		public async Task ForFloat_WhenSubjectIsInfinity_ShouldSucceed(float subject)
+		{
+			async Task Act()
+				=> await Expect.That(subject).Should().NotBeFinite();
+
+			await Expect.That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1f)]
+		[InlineData(0f)]
+		[InlineData(1f)]
+		[InlineData(float.MinValue)]
+		[InlineData(float.MaxValue)]
+		[InlineData(float.Epsilon)]
+		public async Task ForFloat_WhenSubjectIsNormalValue_ShouldFail(float subject)
+		{
+			async Task Act()
+				=> await Expect.That(subject).Should().NotBeFinite();
+
+			await Expect.That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be finite,
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().NotBeFinite()
+				              """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/That/Numbers/NumberShould.BeInfiniteTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Numbers/NumberShould.BeInfiniteTests.cs
@@ -4,26 +4,26 @@ namespace Testably.Expectations.Tests.That.Numbers;
 
 public sealed partial class NumberShould
 {
-	public sealed class BeNaNTests
+	public sealed class BeInfiniteTests
 	{
 		[Fact]
 		public async Task ForDouble_ShouldSupportChaining()
 		{
-			double subject = double.NaN;
+			double subject = double.PositiveInfinity;
 
 			async Task Act()
-				=> await Expect.That(subject).Should().BeNaN()
+				=> await Expect.That(subject).Should().BeInfinite()
 					.And.Be(subject);
 
 			await Expect.That(Act).Should().NotThrow();
 		}
 
-		[Fact]
-		public async Task ForDouble_WhenSubjectIsNaN_ShouldSucceed()
+		[Theory]
+		[InlineData(double.PositiveInfinity)]
+		[InlineData(double.NegativeInfinity)]
+		public async Task ForDouble_WhenSubjectIsInfinity_ShouldSucceed(double subject)
 		{
-			double subject = double.NaN;
-
-			async Task Act() => await Expect.That(subject).Should().BeNaN();
+			async Task Act() => await Expect.That(subject).Should().BeInfinite();
 
 			await Expect.That(Act).Should().NotThrow();
 		}
@@ -35,40 +35,39 @@ public sealed partial class NumberShould
 		[InlineData(double.MinValue)]
 		[InlineData(double.MaxValue)]
 		[InlineData(double.Epsilon)]
-		[InlineData(double.NegativeInfinity)]
-		[InlineData(double.PositiveInfinity)]
+		[InlineData(double.NaN)]
 		public async Task ForDouble_WhenSubjectIsNormalValue_ShouldFail(double subject)
 		{
 			async Task Act()
-				=> await Expect.That(subject).Should().BeNaN();
+				=> await Expect.That(subject).Should().BeInfinite();
 
 			await Expect.That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be NaN,
+				              be infinite,
 				              but found {subject.ToString(CultureInfo.InvariantCulture)}
-				              at Expect.That(subject).Should().BeNaN()
+				              at Expect.That(subject).Should().BeInfinite()
 				              """);
 		}
 
 		[Fact]
 		public async Task ForFloat_ShouldSupportChaining()
 		{
-			float subject = float.NaN;
+			float subject = float.PositiveInfinity;
 
-			async Task Act() => await Expect.That(subject).Should().BeNaN()
+			async Task Act() => await Expect.That(subject).Should().BeInfinite()
 				.And.Be(subject);
 
 			await Expect.That(Act).Should().NotThrow();
 		}
 
-		[Fact]
-		public async Task ForFloat_WhenSubjectIsNaN_ShouldSucceed()
+		[Theory]
+		[InlineData(float.PositiveInfinity)]
+		[InlineData(float.NegativeInfinity)]
+		public async Task ForFloat_WhenSubjectIsInfinity_ShouldSucceed(float subject)
 		{
-			float subject = float.NaN;
-
 			async Task Act()
-				=> await Expect.That(subject).Should().BeNaN();
+				=> await Expect.That(subject).Should().BeInfinite();
 
 			await Expect.That(Act).Should().NotThrow();
 		}
@@ -80,24 +79,23 @@ public sealed partial class NumberShould
 		[InlineData(float.MinValue)]
 		[InlineData(float.MaxValue)]
 		[InlineData(float.Epsilon)]
-		[InlineData(float.NegativeInfinity)]
-		[InlineData(float.PositiveInfinity)]
+		[InlineData(float.NaN)]
 		public async Task ForFloat_WhenSubjectIsNormalValue_ShouldFail(float subject)
 		{
 			async Task Act()
-				=> await Expect.That(subject).Should().BeNaN();
+				=> await Expect.That(subject).Should().BeInfinite();
 
 			await Expect.That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be NaN,
+				              be infinite,
 				              but found {subject.ToString(CultureInfo.InvariantCulture)}
-				              at Expect.That(subject).Should().BeNaN()
+				              at Expect.That(subject).Should().BeInfinite()
 				              """);
 		}
 	}
 
-	public sealed class NotBeNaNTests
+	public sealed class NotBeInfiniteTests
 	{
 		[Fact]
 		public async Task ForDouble_ShouldSupportChaining()
@@ -105,25 +103,25 @@ public sealed partial class NumberShould
 			double subject = double.Epsilon;
 
 			async Task Act()
-				=> await Expect.That(subject).Should().NotBeNaN()
+				=> await Expect.That(subject).Should().NotBeInfinite()
 					.And.Be(subject);
 
 			await Expect.That(Act).Should().NotThrow();
 		}
 
-		[Fact]
-		public async Task ForDouble_WhenSubjectIsNaN_ShouldFail()
+		[Theory]
+		[InlineData(double.PositiveInfinity)]
+		[InlineData(double.NegativeInfinity)]
+		public async Task ForDouble_WhenSubjectIsInfinity_ShouldFail(double subject)
 		{
-			double subject = double.NaN;
-
-			async Task Act() => await Expect.That(subject).Should().NotBeNaN();
+			async Task Act() => await Expect.That(subject).Should().NotBeInfinite();
 
 			await Expect.That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be NaN,
+				              not be infinite,
 				              but found {subject.ToString(CultureInfo.InvariantCulture)}
-				              at Expect.That(subject).Should().NotBeNaN()
+				              at Expect.That(subject).Should().NotBeInfinite()
 				              """);
 		}
 
@@ -134,12 +132,11 @@ public sealed partial class NumberShould
 		[InlineData(double.MinValue)]
 		[InlineData(double.MaxValue)]
 		[InlineData(double.Epsilon)]
-		[InlineData(double.NegativeInfinity)]
-		[InlineData(double.PositiveInfinity)]
+		[InlineData(double.NaN)]
 		public async Task ForDouble_WhenSubjectIsNormalValue_ShouldSucceed(double subject)
 		{
 			async Task Act()
-				=> await Expect.That(subject).Should().NotBeNaN();
+				=> await Expect.That(subject).Should().NotBeInfinite();
 
 			await Expect.That(Act).Should().NotThrow();
 		}
@@ -149,26 +146,26 @@ public sealed partial class NumberShould
 		{
 			float subject = float.Epsilon;
 
-			async Task Act() => await Expect.That(subject).Should().NotBeNaN()
+			async Task Act() => await Expect.That(subject).Should().NotBeInfinite()
 				.And.Be(subject);
 
 			await Expect.That(Act).Should().NotThrow();
 		}
 
-		[Fact]
-		public async Task ForFloat_WhenSubjectIsNaN_ShouldFail()
+		[Theory]
+		[InlineData(float.PositiveInfinity)]
+		[InlineData(float.NegativeInfinity)]
+		public async Task ForFloat_WhenSubjectIsInfinity_ShouldFail(float subject)
 		{
-			float subject = float.NaN;
-
 			async Task Act()
-				=> await Expect.That(subject).Should().NotBeNaN();
+				=> await Expect.That(subject).Should().NotBeInfinite();
 
 			await Expect.That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be NaN,
+				              not be infinite,
 				              but found {subject.ToString(CultureInfo.InvariantCulture)}
-				              at Expect.That(subject).Should().NotBeNaN()
+				              at Expect.That(subject).Should().NotBeInfinite()
 				              """);
 		}
 
@@ -179,12 +176,11 @@ public sealed partial class NumberShould
 		[InlineData(float.MinValue)]
 		[InlineData(float.MaxValue)]
 		[InlineData(float.Epsilon)]
-		[InlineData(float.NegativeInfinity)]
-		[InlineData(float.PositiveInfinity)]
+		[InlineData(float.NaN)]
 		public async Task ForFloat_WhenSubjectIsNormalValue_ShouldSucceed(float subject)
 		{
 			async Task Act()
-				=> await Expect.That(subject).Should().NotBeNaN();
+				=> await Expect.That(subject).Should().NotBeInfinite();
 
 			await Expect.That(Act).Should().NotThrow();
 		}


### PR DESCRIPTION
Add the following methods  for `double` and `float`:
- `BeFinite` / `NotBeFinite`
   which checks that the number is neither infinity nor NaN
- `BeInfinite` / NotBeInfinite`
   which checks that the number is positive or negative infinity
- `NotBeNaN`
   missing negative method for `BeNaN`

*Fixes #56*