### PR TITLE
fix: return thrown exception

### DIFF
--- a/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.cs
+++ b/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.cs
@@ -89,16 +89,16 @@ public static partial class ThatExceptionShould
 			Exception? innerException = actual?.InnerException;
 			if (actual?.InnerException is TInnerException exception)
 			{
-				return new ConstraintResult.Success<Exception?>(exception, ToString());
+				return new ConstraintResult.Success<Exception?>(actual, ToString());
 			}
 
 			if (innerException is not null)
 			{
-				return new ConstraintResult.Failure<Exception?>(innerException, ToString(),
+				return new ConstraintResult.Failure<Exception?>(actual, ToString(),
 					$"found {innerException.FormatForMessage()}");
 			}
 
-			return new ConstraintResult.Failure(ToString(),
+			return new ConstraintResult.Failure<Exception?>(actual, ToString(),
 				"found <null>");
 		}
 

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.OnlyIfTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.OnlyIfTests.cs
@@ -36,7 +36,7 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
-		public async Task WhenAwaited_OnlyIfTrue_ShouldReturnException()
+		public async Task WhenAwaited_OnlyIfTrue_ShouldReturnThrownException()
 		{
 			Exception exception = CreateCustomException();
 			Action action = () => throw exception;

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.OnlyIfTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.OnlyIfTests.cs
@@ -25,6 +25,29 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
+		public async Task WhenAwaited_OnlyIfFalse_ShouldReturnNull()
+		{
+			Action action = () => { };
+
+			CustomException? result =
+				await Expect.That(action).Should().Throw<CustomException>().OnlyIf(false);
+
+			await Expect.That(result).Should().BeNull();
+		}
+
+		[Fact]
+		public async Task WhenAwaited_OnlyIfTrue_ShouldReturnException()
+		{
+			Exception exception = CreateCustomException();
+			Action action = () => throw exception;
+
+			CustomException? result =
+				await Expect.That(action).Should().Throw<CustomException>().OnlyIf(true);
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
 		public async Task WhenFalse_ShouldFailWhenAnExceptionWasThrown()
 		{
 			Exception exception = new("");

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.ThrowExactlyTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.ThrowExactlyTests.cs
@@ -87,7 +87,7 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
-		public async Task WhenAwaited_ShouldReturnException()
+		public async Task WhenAwaited_ShouldReturnThrownException()
 		{
 			Exception exception = CreateCustomException();
 			Action action = () => throw exception;

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.ThrowExactlyTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.ThrowExactlyTests.cs
@@ -85,5 +85,17 @@ public sealed partial class DelegateShould
 
 			await Expect.That(Act).Should().NotThrow();
 		}
+
+		[Fact]
+		public async Task WhenAwaited_ShouldReturnException()
+		{
+			Exception exception = CreateCustomException();
+			Action action = () => throw exception;
+
+			CustomException result =
+				await Expect.That(action).Should().ThrowExactly<CustomException>();
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.ThrowExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.ThrowExceptionTests.cs
@@ -44,5 +44,16 @@ public sealed partial class DelegateShould
 
 			await Expect.That(Act).Should().NotThrow();
 		}
+
+		[Fact]
+		public async Task WhenAwaited_ShouldReturnException()
+		{
+			Exception exception = CreateCustomException();
+			Action action = () => throw exception;
+
+			Exception result = await Expect.That(action).Should().ThrowException();
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.ThrowExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.ThrowExceptionTests.cs
@@ -46,7 +46,7 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
-		public async Task WhenAwaited_ShouldReturnException()
+		public async Task WhenAwaited_ShouldReturnThrownException()
 		{
 			Exception exception = CreateCustomException();
 			Action action = () => throw exception;

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.ThrowTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateShould.ThrowTests.cs
@@ -16,6 +16,18 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
+		public async Task WhenAwaited_ShouldReturnThrownException()
+		{
+			Exception exception = CreateCustomException();
+			Action action = () => throw exception;
+
+			CustomException result =
+				await Expect.That(action).Should().Throw<CustomException>();
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
 		public async Task WithoutThrownException_ShouldFail()
 		{
 			string expectedMessage = """

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateThrows.WithInnerExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateThrows.WithInnerExceptionTests.cs
@@ -32,5 +32,28 @@ public sealed partial class DelegateThrows
 				             at Expect.That(action).Should().ThrowException().WithInnerException()
 				             """);
 		}
+
+		[Fact]
+		public async Task WithExpectations_ShouldReturnThrownException()
+		{
+			Exception exception = new("outer", new Exception("inner"));
+
+			Exception result = await Expect.That(() => throw exception)
+				.Should().ThrowException().WithInnerException(
+					e => e.HaveMessage("inner"));
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
+		public async Task WithoutExpectations_ShouldReturnThrownException()
+		{
+			Exception exception = new("outer", new Exception("inner"));
+
+			Exception result = await Expect.That(() => throw exception)
+				.Should().ThrowException().WithInnerException();
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateThrows.WithInnerExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateThrows.WithInnerExceptionTests.cs
@@ -5,6 +5,29 @@ public sealed partial class DelegateThrows
 	public sealed class WithInnerExceptionTests
 	{
 		[Fact]
+		public async Task WhenAwaited_WithExpectations_ShouldReturnThrownException()
+		{
+			Exception exception = new("outer", new Exception("inner"));
+
+			Exception result = await Expect.That(() => throw exception)
+				.Should().ThrowException().WithInnerException(
+					e => e.HaveMessage("inner"));
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
+		public async Task WhenAwaited_WithoutExpectations_ShouldReturnThrownException()
+		{
+			Exception exception = new("outer", new Exception("inner"));
+
+			Exception result = await Expect.That(() => throw exception)
+				.Should().ThrowException().WithInnerException();
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
 		public async Task WhenInnerExceptionIsPresent_ShouldSucceed()
 		{
 			Action action = () => throw new Exception("outer", new Exception("inner"));
@@ -31,29 +54,6 @@ public sealed partial class DelegateThrows
 				             but found <null>
 				             at Expect.That(action).Should().ThrowException().WithInnerException()
 				             """);
-		}
-
-		[Fact]
-		public async Task WithExpectations_ShouldReturnThrownException()
-		{
-			Exception exception = new("outer", new Exception("inner"));
-
-			Exception result = await Expect.That(() => throw exception)
-				.Should().ThrowException().WithInnerException(
-					e => e.HaveMessage("inner"));
-
-			await Expect.That(result).Should().BeSameAs(exception);
-		}
-
-		[Fact]
-		public async Task WithoutExpectations_ShouldReturnThrownException()
-		{
-			Exception exception = new("outer", new Exception("inner"));
-
-			Exception result = await Expect.That(() => throw exception)
-				.Should().ThrowException().WithInnerException();
-
-			await Expect.That(result).Should().BeSameAs(exception);
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateThrows.WithInnerTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateThrows.WithInnerTests.cs
@@ -5,6 +5,29 @@ public sealed partial class DelegateThrows
 	public sealed class WithInnerTests
 	{
 		[Fact]
+		public async Task WhenAwaited_WithExpectations_ShouldReturnThrownException()
+		{
+			Exception exception = new CustomException("outer", new CustomException("inner"));
+
+			Exception result = await Expect.That(() => throw exception)
+				.Should().ThrowException().WithInner<CustomException>(
+					e => e.HaveMessage("inner"));
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
+		public async Task WhenAwaited_WithoutExpectations_ShouldReturnThrownException()
+		{
+			Exception exception = new CustomException("outer", new CustomException("inner"));
+
+			Exception result = await Expect.That(() => throw exception)
+				.Should().ThrowException().WithInner<CustomException>();
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
 		public async Task WhenInnerExceptionIsPresent_ShouldSucceed()
 		{
 			Action action = () => throw new CustomException("outer", new CustomException("inner"));
@@ -31,29 +54,6 @@ public sealed partial class DelegateThrows
 				             but found <null>
 				             at Expect.That(action).Should().ThrowException().WithInner<CustomException>()
 				             """);
-		}
-
-		[Fact]
-		public async Task WithExpectations_ShouldReturnThrownException()
-		{
-			Exception exception = new CustomException("outer", new CustomException("inner"));
-
-			Exception result = await Expect.That(() => throw exception)
-				.Should().ThrowException().WithInner<CustomException>(
-					e => e.HaveMessage("inner"));
-
-			await Expect.That(result).Should().BeSameAs(exception);
-		}
-
-		[Fact]
-		public async Task WithoutExpectations_ShouldReturnThrownException()
-		{
-			Exception exception = new CustomException("outer", new CustomException("inner"));
-
-			Exception result = await Expect.That(() => throw exception)
-				.Should().ThrowException().WithInner<CustomException>();
-
-			await Expect.That(result).Should().BeSameAs(exception);
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateThrows.WithInnerTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateThrows.WithInnerTests.cs
@@ -32,5 +32,28 @@ public sealed partial class DelegateThrows
 				             at Expect.That(action).Should().ThrowException().WithInner<CustomException>()
 				             """);
 		}
+
+		[Fact]
+		public async Task WithExpectations_ShouldReturnThrownException()
+		{
+			Exception exception = new CustomException("outer", new CustomException("inner"));
+
+			Exception result = await Expect.That(() => throw exception)
+				.Should().ThrowException().WithInner<CustomException>(
+					e => e.HaveMessage("inner"));
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
+		public async Task WithoutExpectations_ShouldReturnThrownException()
+		{
+			Exception exception = new CustomException("outer", new CustomException("inner"));
+
+			Exception result = await Expect.That(() => throw exception)
+				.Should().ThrowException().WithInner<CustomException>();
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateThrows.WithMessageTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateThrows.WithMessageTests.cs
@@ -28,17 +28,6 @@ public sealed partial class DelegateThrows
 		}
 
 		[Fact]
-		public async Task ShouldReturnThrownException()
-		{
-			Exception exception = new("outer", new Exception("inner"));
-
-			Exception result = await Expect.That(() => throw exception)
-				.Should().ThrowException().WithMessage("outer").AsWildcard();
-
-			await Expect.That(result).Should().BeSameAs(exception);
-		}
-
-		[Fact]
 		public async Task ShouldSupportNestedChecks()
 		{
 			Exception exception = new CustomException("outer",
@@ -65,6 +54,17 @@ public sealed partial class DelegateThrows
 				=> await Expect.That(subject).Should().HaveMessage(actual);
 
 			await Expect.That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenAwaited_ShouldReturnThrownException()
+		{
+			Exception exception = new("outer", new Exception("inner"));
+
+			Exception result = await Expect.That(() => throw exception)
+				.Should().ThrowException().WithMessage("outer").AsWildcard();
+
+			await Expect.That(result).Should().BeSameAs(exception);
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/That/Delegates/DelegateThrows.WithMessageTests.cs
+++ b/Tests/Testably.Expectations.Tests/That/Delegates/DelegateThrows.WithMessageTests.cs
@@ -28,6 +28,17 @@ public sealed partial class DelegateThrows
 		}
 
 		[Fact]
+		public async Task ShouldReturnThrownException()
+		{
+			Exception exception = new("outer", new Exception("inner"));
+
+			Exception result = await Expect.That(() => throw exception)
+				.Should().ThrowException().WithMessage("outer").AsWildcard();
+
+			await Expect.That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
 		public async Task ShouldSupportNestedChecks()
 		{
 			Exception exception = new CustomException("outer",


### PR DESCRIPTION
When verifying that an exception was thrown, the exception should be returned (if the result is awaited).