### PR TITLE
feat: add be of type to collections

### DIFF
--- a/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.Be.cs
+++ b/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.Be.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.EvaluationContext;
+using Testably.Expectations.Results;
+// ReSharper disable once CheckNamespace
+
+namespace Testably.Expectations;
+
+/// <summary>
+///     A quantifiable result matching items against the expected
+///     <see cref="QuantifiedCollectionResult{TResult}.Quantity" />.
+/// </summary>
+public class SyncQuantifiedCollectionResult<TResult, TItem, TCollection>(
+	TResult result,
+	ExpectationBuilder expectationBuilder,
+	CollectionQuantifier quantity)
+	: QuantifiedCollectionResult<TResult>(result, expectationBuilder, quantity)
+	where TCollection : IEnumerable<TItem>
+	where TResult : IThat<TCollection>
+{
+	/// <summary>
+	///     ...are of type <typeparamref name="TExpected" />.
+	/// </summary>
+	public AndOrExpectationResult<TCollection, IThat<TCollection>> Be<TExpected>()
+		=> new(ExpectationBuilder
+				.AddConstraint(
+					new BeOfTypeConstraint<TExpected>(
+						Quantity,
+						(a, c) => Quantity.GetEvaluator<TItem, TCollection>(a, c)))
+				.AppendGenericMethodStatement<TExpected>(nameof(Be)),
+			Result);
+
+	private readonly struct BeOfTypeConstraint<TExpected>(
+		CollectionQuantifier quantifier,
+		Func<TCollection, IEvaluationContext, ICollectionEvaluator<TItem>> evaluatorFactory)
+		: IAsyncContextConstraint<TCollection>
+	{
+		public async Task<ConstraintResult> IsMetBy(TCollection actual, IEvaluationContext context)
+		{
+			ICollectionEvaluator<TItem> evaluator = evaluatorFactory(actual, context);
+			CollectionEvaluatorResult result = await evaluator
+				.CheckCondition(default(TItem), (a, _) => a is TExpected)
+				.ConfigureAwait(false);
+
+			if (result.IsSuccess)
+			{
+				return new ConstraintResult.Success<TCollection>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(),
+				$"{result.Error} items were");
+		}
+
+		public override string ToString()
+			=> $"have {quantifier} of type {typeof(TExpected).Name}";
+	}
+}

--- a/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.Be.cs
+++ b/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.Be.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;

--- a/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.Be.cs
+++ b/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.Be.cs
@@ -10,35 +10,69 @@ using Testably.Expectations.Results;
 namespace Testably.Expectations;
 
 /// <summary>
-///     A quantifiable result matching items against the expected
-///     <see cref="QuantifiedCollectionResult{TResult}.Quantity" />.
+///     A container for specific instances of a quantified result.
 /// </summary>
-public class SyncQuantifiedCollectionResult<TResult, TItem, TCollection>(
-	TResult result,
-	ExpectationBuilder expectationBuilder,
-	CollectionQuantifier quantity)
-	: QuantifiedCollectionResult<TResult>(result, expectationBuilder, quantity)
-	where TCollection : IEnumerable<TItem>
-	where TResult : IThat<TCollection>
+public class QuantifiedCollectionResult
 {
 	/// <summary>
-	///     ...are of type <typeparamref name="TExpected" />.
+	///     A quantifiable result matching items against the expected
+	///     <see cref="QuantifiedCollectionResult{TResult}.Quantity" />.
 	/// </summary>
-	public AndOrExpectationResult<TCollection, IThat<TCollection>> Be<TExpected>()
-		=> new(ExpectationBuilder
-				.AddConstraint(
-					new BeOfTypeConstraint<TExpected>(
-						Quantity,
-						(a, c) => Quantity.GetEvaluator<TItem, TCollection>(a, c)))
-				.AppendGenericMethodStatement<TExpected>(nameof(Be)),
-			Result);
+	public class Sync<TResult, TItem, TCollection>(
+		TResult result,
+		ExpectationBuilder expectationBuilder,
+		CollectionQuantifier quantity)
+		: QuantifiedCollectionResult<TResult>(result, expectationBuilder, quantity)
+		where TCollection : IEnumerable<TItem>
+		where TResult : IThat<TCollection>
+	{
+		/// <summary>
+		///     ...are of type <typeparamref name="TExpected" />.
+		/// </summary>
+		public AndOrExpectationResult<TCollection, IThat<TCollection>> Be<TExpected>()
+			=> new(ExpectationBuilder
+					.AddConstraint(
+						new BeOfTypeConstraint<TItem, TCollection, TExpected>(
+							Quantity,
+							(a, c) => Quantity.GetEvaluator<TItem, TCollection>(a, c)))
+					.AppendGenericMethodStatement<TExpected>(nameof(Be)),
+				Result);
+	}
 
-	private readonly struct BeOfTypeConstraint<TExpected>(
+#if NET6_0_OR_GREATER
+	/// <summary>
+	///     A quantifiable result matching items against the expected
+	///     <see cref="QuantifiedCollectionResult{TResult}.Quantity" />.
+	/// </summary>
+	public class Async<TResult, TItem, TCollection>(
+		TResult result,
+		ExpectationBuilder expectationBuilder,
+		CollectionQuantifier quantity)
+		: QuantifiedCollectionResult<TResult>(result, expectationBuilder, quantity)
+		where TCollection : IAsyncEnumerable<TItem>
+		where TResult : IThat<TCollection>
+	{
+		/// <summary>
+		///     ...are of type <typeparamref name="TExpected" />.
+		/// </summary>
+		public AndOrExpectationResult<TCollection, IThat<TCollection>> Be<TExpected>()
+			=> new(ExpectationBuilder
+					.AddConstraint(
+						new BeOfTypeConstraint<TItem, TCollection, TExpected>(
+							Quantity,
+							(a, c) => Quantity.GetAsyncEvaluator<TItem, TCollection>(a, c)))
+					.AppendGenericMethodStatement<TExpected>(nameof(Be)),
+				Result);
+	}
+#endif
+
+	private readonly struct BeOfTypeConstraint<TItem, TCollection, TExpected>(
 		CollectionQuantifier quantifier,
 		Func<TCollection, IEvaluationContext, ICollectionEvaluator<TItem>> evaluatorFactory)
 		: IAsyncContextConstraint<TCollection>
 	{
-		public async Task<ConstraintResult> IsMetBy(TCollection actual, IEvaluationContext context)
+		public async Task<ConstraintResult> IsMetBy(TCollection actual,
+			IEvaluationContext context)
 		{
 			ICollectionEvaluator<TItem> evaluator = evaluatorFactory(actual, context);
 			CollectionEvaluatorResult result = await evaluator

--- a/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.cs
+++ b/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
-using Testably.Expectations.Core;
-using Testably.Expectations.Core.Constraints;
-using Testably.Expectations.Core.EvaluationContext;
-using Testably.Expectations.Formatting;
-using Testably.Expectations.Results;
+﻿using Testably.Expectations.Core;
 // ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
@@ -14,7 +6,7 @@ namespace Testably.Expectations;
 /// <summary>
 ///     A quantifiable result matching items against the expected <see cref="Quantity" />.
 /// </summary>
-public partial class QuantifiedCollectionResult<TResult>(
+public class QuantifiedCollectionResult<TResult>(
 	TResult result,
 	ExpectationBuilder expectationBuilder,
 	CollectionQuantifier quantity)

--- a/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.cs
+++ b/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.cs
@@ -14,7 +14,7 @@ namespace Testably.Expectations;
 /// <summary>
 ///     A quantifiable result matching items against the expected <see cref="Quantity" />.
 /// </summary>
-public class QuantifiedCollectionResult<TResult>(
+public partial class QuantifiedCollectionResult<TResult>(
 	TResult result,
 	ExpectationBuilder expectationBuilder,
 	CollectionQuantifier quantity)

--- a/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.cs
+++ b/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.cs
@@ -1,4 +1,12 @@
-﻿using Testably.Expectations.Core;
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.EvaluationContext;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
 // ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.All.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.All.cs
@@ -10,7 +10,8 @@ public static partial class ThatAsyncEnumerableShould
 	/// <summary>
 	///     Verifies that all items in the enumerable...
 	/// </summary>
-	public static QuantifiedCollectionResult<IThat<IAsyncEnumerable<TItem>>> All<TItem>(
+	public static QuantifiedCollectionResult.Async
+		<IThat<IAsyncEnumerable<TItem>>, TItem, IAsyncEnumerable<TItem>> All<TItem>(
 		this IThat<IAsyncEnumerable<TItem>> source)
 		=> new(source,
 			source.ExpectationBuilder.AppendMethodStatement(nameof(All)),

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.AtLeast.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.AtLeast.cs
@@ -11,7 +11,8 @@ public static partial class ThatAsyncEnumerableShould
 	/// <summary>
 	///     Verifies that at least <paramref name="minimum" /> items...
 	/// </summary>
-	public static QuantifiedCollectionResult<IThat<IAsyncEnumerable<TItem>>> AtLeast<TItem>(
+	public static QuantifiedCollectionResult.Async
+		<IThat<IAsyncEnumerable<TItem>>, TItem, IAsyncEnumerable<TItem>> AtLeast<TItem>(
 		this IThat<IAsyncEnumerable<TItem>> source,
 		int minimum, [CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
 		=> new(source,

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.AtMost.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.AtMost.cs
@@ -11,7 +11,8 @@ public static partial class ThatAsyncEnumerableShould
 	/// <summary>
 	///     Verifies that at most <paramref name="maximum" /> items...
 	/// </summary>
-	public static QuantifiedCollectionResult<IThat<IAsyncEnumerable<TItem>>> AtMost<TItem>(
+	public static QuantifiedCollectionResult.Async
+		<IThat<IAsyncEnumerable<TItem>>, TItem, IAsyncEnumerable<TItem>> AtMost<TItem>(
 		this IThat<IAsyncEnumerable<TItem>> source,
 		int maximum, [CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "")
 		=> new(source,

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.Between.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.Between.cs
@@ -12,18 +12,21 @@ public static partial class ThatAsyncEnumerableShould
 	/// <summary>
 	///     Verifies that between <paramref name="minimum" />...
 	/// </summary>
-	public static BetweenResult<QuantifiedCollectionResult<IThat<IAsyncEnumerable<TItem>>>>
+	public static BetweenResult<QuantifiedCollectionResult.Async
+			<IThat<IAsyncEnumerable<TItem>>, TItem, IAsyncEnumerable<TItem>>>
 		Between<TItem>(
 			this IThat<IAsyncEnumerable<TItem>> source,
 			int minimum,
 			[CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(Between), doNotPopulateThisValue);
-		return new BetweenResult<QuantifiedCollectionResult<IThat<IAsyncEnumerable<TItem>>>>(
+		return new BetweenResult<QuantifiedCollectionResult.Async
+			<IThat<IAsyncEnumerable<TItem>>, TItem, IAsyncEnumerable<TItem>>>(
 			source.ExpectationBuilder,
-			maximum => new QuantifiedCollectionResult<IThat<IAsyncEnumerable<TItem>>>(source,
-				source.ExpectationBuilder,
-				CollectionQuantifier.Between(minimum, maximum)));
+			maximum => new QuantifiedCollectionResult.Async
+				<IThat<IAsyncEnumerable<TItem>>, TItem, IAsyncEnumerable<TItem>>(source,
+					source.ExpectationBuilder,
+					CollectionQuantifier.Between(minimum, maximum)));
 	}
 }
 #endif

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.None.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.None.cs
@@ -10,7 +10,8 @@ public static partial class ThatAsyncEnumerableShould
 	/// <summary>
 	///     Verifies that no items in the enumerable...
 	/// </summary>
-	public static QuantifiedCollectionResult<IThat<IAsyncEnumerable<TItem>>> None<TItem>(
+	public static QuantifiedCollectionResult.Async
+		<IThat<IAsyncEnumerable<TItem>>, TItem, IAsyncEnumerable<TItem>> None<TItem>(
 		this IThat<IAsyncEnumerable<TItem>> source)
 		=> new(source,
 			source.ExpectationBuilder.AppendMethodStatement(nameof(None)),

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.All.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.All.cs
@@ -9,11 +9,13 @@ public static partial class ThatEnumerableShould
 	/// <summary>
 	///     Verifies that all items in the enumerable...
 	/// </summary>
-	public static QuantifiedCollectionResult<IThat<IEnumerable<TItem>>> All<TItem>(
-		this IThat<IEnumerable<TItem>> source)
+	public static SyncQuantifiedCollectionResult
+		<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>> All<TItem>(
+			this IThat<IEnumerable<TItem>> source)
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(All));
-		return new QuantifiedCollectionResult<IThat<IEnumerable<TItem>>>(
+		return new SyncQuantifiedCollectionResult<
+			IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
 			source,
 			source.ExpectationBuilder,
 			CollectionQuantifier.All);

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.All.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.All.cs
@@ -9,12 +9,12 @@ public static partial class ThatEnumerableShould
 	/// <summary>
 	///     Verifies that all items in the enumerable...
 	/// </summary>
-	public static SyncQuantifiedCollectionResult
+	public static QuantifiedCollectionResult.Sync
 		<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>> All<TItem>(
 			this IThat<IEnumerable<TItem>> source)
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(All));
-		return new SyncQuantifiedCollectionResult<
+		return new QuantifiedCollectionResult.Sync<
 			IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
 			source,
 			source.ExpectationBuilder,

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtLeast.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtLeast.cs
@@ -10,13 +10,13 @@ public static partial class ThatEnumerableShould
 	/// <summary>
 	///     Verifies that at least <paramref name="minimum" /> items...
 	/// </summary>
-	public static SyncQuantifiedCollectionResult
+	public static QuantifiedCollectionResult.Sync
 		<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>> AtLeast<TItem>(
 			this IThat<IEnumerable<TItem>> source,
 			int minimum, [CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(AtLeast), doNotPopulateThisValue);
-		return new SyncQuantifiedCollectionResult<IThat<IEnumerable<TItem>>, TItem,
+		return new QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem,
 			IEnumerable<TItem>>(
 			source,
 			source.ExpectationBuilder,

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtLeast.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtLeast.cs
@@ -10,12 +10,14 @@ public static partial class ThatEnumerableShould
 	/// <summary>
 	///     Verifies that at least <paramref name="minimum" /> items...
 	/// </summary>
-	public static QuantifiedCollectionResult<IThat<IEnumerable<TItem>>> AtLeast<TItem>(
-		this IThat<IEnumerable<TItem>> source,
-		int minimum, [CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
+	public static SyncQuantifiedCollectionResult
+		<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>> AtLeast<TItem>(
+			this IThat<IEnumerable<TItem>> source,
+			int minimum, [CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(AtLeast), doNotPopulateThisValue);
-		return new QuantifiedCollectionResult<IThat<IEnumerable<TItem>>>(
+		return new SyncQuantifiedCollectionResult<IThat<IEnumerable<TItem>>, TItem,
+			IEnumerable<TItem>>(
 			source,
 			source.ExpectationBuilder,
 			CollectionQuantifier.AtLeast(minimum));

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtMost.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtMost.cs
@@ -10,13 +10,13 @@ public static partial class ThatEnumerableShould
 	/// <summary>
 	///     Verifies that at most <paramref name="maximum" /> items...
 	/// </summary>
-	public static SyncQuantifiedCollectionResult
+	public static QuantifiedCollectionResult.Sync
 		<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>> AtMost<TItem>(
 		this IThat<IEnumerable<TItem>> source,
 		int maximum, [CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "")
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(AtMost), doNotPopulateThisValue);
-		return new SyncQuantifiedCollectionResult<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
+		return new QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
 			source,
 			source.ExpectationBuilder,
 			CollectionQuantifier.AtMost(maximum));

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtMost.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtMost.cs
@@ -10,12 +10,13 @@ public static partial class ThatEnumerableShould
 	/// <summary>
 	///     Verifies that at most <paramref name="maximum" /> items...
 	/// </summary>
-	public static QuantifiedCollectionResult<IThat<IEnumerable<TItem>>> AtMost<TItem>(
+	public static SyncQuantifiedCollectionResult
+		<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>> AtMost<TItem>(
 		this IThat<IEnumerable<TItem>> source,
 		int maximum, [CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "")
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(AtMost), doNotPopulateThisValue);
-		return new QuantifiedCollectionResult<IThat<IEnumerable<TItem>>>(
+		return new SyncQuantifiedCollectionResult<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
 			source,
 			source.ExpectationBuilder,
 			CollectionQuantifier.AtMost(maximum));

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.Between.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.Between.cs
@@ -11,7 +11,7 @@ public static partial class ThatEnumerableShould
 	/// <summary>
 	///     Verifies that between <paramref name="minimum" />...
 	/// </summary>
-	public static BetweenResult<SyncQuantifiedCollectionResult
+	public static BetweenResult<QuantifiedCollectionResult.Sync
 			<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>>
 		Between<TItem>(
 			this IThat<IEnumerable<TItem>> source,
@@ -19,9 +19,9 @@ public static partial class ThatEnumerableShould
 			[CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(Between), doNotPopulateThisValue);
-		return new BetweenResult<SyncQuantifiedCollectionResult<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>>(
+		return new BetweenResult<QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>>(
 			source.ExpectationBuilder,
-			maximum => new SyncQuantifiedCollectionResult<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
+			maximum => new QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
 				source,
 				source.ExpectationBuilder,
 				CollectionQuantifier.Between(minimum, maximum)));

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.Between.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.Between.cs
@@ -11,16 +11,17 @@ public static partial class ThatEnumerableShould
 	/// <summary>
 	///     Verifies that between <paramref name="minimum" />...
 	/// </summary>
-	public static BetweenResult<QuantifiedCollectionResult<IThat<IEnumerable<TItem>>>>
+	public static BetweenResult<SyncQuantifiedCollectionResult
+			<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>>
 		Between<TItem>(
 			this IThat<IEnumerable<TItem>> source,
 			int minimum,
 			[CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(Between), doNotPopulateThisValue);
-		return new BetweenResult<QuantifiedCollectionResult<IThat<IEnumerable<TItem>>>>(
+		return new BetweenResult<SyncQuantifiedCollectionResult<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>>(
 			source.ExpectationBuilder,
-			maximum => new QuantifiedCollectionResult<IThat<IEnumerable<TItem>>>(
+			maximum => new SyncQuantifiedCollectionResult<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
 				source,
 				source.ExpectationBuilder,
 				CollectionQuantifier.Between(minimum, maximum)));

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.None.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.None.cs
@@ -9,11 +9,11 @@ public static partial class ThatEnumerableShould
 	/// <summary>
 	///     Verifies that no items in the enumerable...
 	/// </summary>
-	public static SyncQuantifiedCollectionResult<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>> None<TItem>(
+	public static QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>> None<TItem>(
 		this IThat<IEnumerable<TItem>> source)
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(None));
-		return new SyncQuantifiedCollectionResult<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
+		return new QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
 			source,
 			source.ExpectationBuilder,
 			CollectionQuantifier.None);

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.None.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.None.cs
@@ -9,11 +9,11 @@ public static partial class ThatEnumerableShould
 	/// <summary>
 	///     Verifies that no items in the enumerable...
 	/// </summary>
-	public static QuantifiedCollectionResult<IThat<IEnumerable<TItem>>> None<TItem>(
+	public static SyncQuantifiedCollectionResult<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>> None<TItem>(
 		this IThat<IEnumerable<TItem>> source)
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(None));
-		return new QuantifiedCollectionResult<IThat<IEnumerable<TItem>>>(
+		return new SyncQuantifiedCollectionResult<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
 			source,
 			source.ExpectationBuilder,
 			CollectionQuantifier.None);

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -50,6 +50,24 @@ namespace Testably.Expectations
     {
         System.Threading.Tasks.Task<Testably.Expectations.CollectionEvaluatorResult> CheckCondition<TExpected>(TExpected expected, System.Func<TItem, TExpected, bool> predicate);
     }
+    public class QuantifiedCollectionResult
+    {
+        public QuantifiedCollectionResult() { }
+        public class Async<TResult, TItem, TCollection> : Testably.Expectations.QuantifiedCollectionResult<TResult>
+            where TResult : Testably.Expectations.Core.IThat<TCollection>
+            where TCollection : System.Collections.Generic.IAsyncEnumerable<TItem>
+        {
+            public Async(TResult result, Testably.Expectations.Core.ExpectationBuilder expectationBuilder, Testably.Expectations.CollectionQuantifier quantity) { }
+            public Testably.Expectations.Results.AndOrExpectationResult<TCollection, Testably.Expectations.Core.IThat<TCollection>> Be<TExpected>() { }
+        }
+        public class Sync<TResult, TItem, TCollection> : Testably.Expectations.QuantifiedCollectionResult<TResult>
+            where TResult : Testably.Expectations.Core.IThat<TCollection>
+            where TCollection : System.Collections.Generic.IEnumerable<TItem>
+        {
+            public Sync(TResult result, Testably.Expectations.Core.ExpectationBuilder expectationBuilder, Testably.Expectations.CollectionQuantifier quantity) { }
+            public Testably.Expectations.Results.AndOrExpectationResult<TCollection, Testably.Expectations.Core.IThat<TCollection>> Be<TExpected>() { }
+        }
+    }
     public class QuantifiedCollectionResult<TResult>
     {
         public QuantifiedCollectionResult(TResult result, Testably.Expectations.Core.ExpectationBuilder expectationBuilder, Testably.Expectations.CollectionQuantifier quantity) { }
@@ -71,13 +89,13 @@ namespace Testably.Expectations
     }
     public static class ThatAsyncEnumerableShould
     {
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> All<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> AtLeast<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> AtMost<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int maximum, [System.Runtime.CompilerServices.CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Async<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>, TItem, System.Collections.Generic.IAsyncEnumerable<TItem>> All<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Async<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>, TItem, System.Collections.Generic.IAsyncEnumerable<TItem>> AtLeast<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Async<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>, TItem, System.Collections.Generic.IAsyncEnumerable<TItem>> AtMost<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int maximum, [System.Runtime.CompilerServices.CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IAsyncEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> BeEmpty<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
-        public static Testably.Expectations.Results.BetweenResult<Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>>> Between<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.BetweenResult<Testably.Expectations.QuantifiedCollectionResult.Async<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>, TItem, System.Collections.Generic.IAsyncEnumerable<TItem>>> Between<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IAsyncEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> Contain<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, TItem expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> None<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Async<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>, TItem, System.Collections.Generic.IAsyncEnumerable<TItem>> None<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IAsyncEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> NotBeEmpty<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
         public static Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> Should<TItem>(this Testably.Expectations.Core.IExpectSubject<System.Collections.Generic.IAsyncEnumerable<TItem>> subject) { }
     }
@@ -179,13 +197,13 @@ namespace Testably.Expectations
     }
     public static class ThatEnumerableShould
     {
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> All<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtLeast<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtMost<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int maximum, [System.Runtime.CompilerServices.CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>> All<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>> AtLeast<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>> AtMost<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int maximum, [System.Runtime.CompilerServices.CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> BeEmpty<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
-        public static Testably.Expectations.Results.BetweenResult<Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>> Between<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.BetweenResult<Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>>> Between<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> None<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>> None<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> NotBeEmpty<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> Should<TItem>(this Testably.Expectations.Core.IExpectSubject<System.Collections.Generic.IEnumerable<TItem>> subject) { }
     }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -50,6 +50,24 @@ namespace Testably.Expectations
     {
         System.Threading.Tasks.Task<Testably.Expectations.CollectionEvaluatorResult> CheckCondition<TExpected>(TExpected expected, System.Func<TItem, TExpected, bool> predicate);
     }
+    public class QuantifiedCollectionResult
+    {
+        public QuantifiedCollectionResult() { }
+        public class Async<TResult, TItem, TCollection> : Testably.Expectations.QuantifiedCollectionResult<TResult>
+            where TResult : Testably.Expectations.Core.IThat<TCollection>
+            where TCollection : System.Collections.Generic.IAsyncEnumerable<TItem>
+        {
+            public Async(TResult result, Testably.Expectations.Core.ExpectationBuilder expectationBuilder, Testably.Expectations.CollectionQuantifier quantity) { }
+            public Testably.Expectations.Results.AndOrExpectationResult<TCollection, Testably.Expectations.Core.IThat<TCollection>> Be<TExpected>() { }
+        }
+        public class Sync<TResult, TItem, TCollection> : Testably.Expectations.QuantifiedCollectionResult<TResult>
+            where TResult : Testably.Expectations.Core.IThat<TCollection>
+            where TCollection : System.Collections.Generic.IEnumerable<TItem>
+        {
+            public Sync(TResult result, Testably.Expectations.Core.ExpectationBuilder expectationBuilder, Testably.Expectations.CollectionQuantifier quantity) { }
+            public Testably.Expectations.Results.AndOrExpectationResult<TCollection, Testably.Expectations.Core.IThat<TCollection>> Be<TExpected>() { }
+        }
+    }
     public class QuantifiedCollectionResult<TResult>
     {
         public QuantifiedCollectionResult(TResult result, Testably.Expectations.Core.ExpectationBuilder expectationBuilder, Testably.Expectations.CollectionQuantifier quantity) { }
@@ -71,13 +89,13 @@ namespace Testably.Expectations
     }
     public static class ThatAsyncEnumerableShould
     {
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> All<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> AtLeast<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> AtMost<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int maximum, [System.Runtime.CompilerServices.CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Async<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>, TItem, System.Collections.Generic.IAsyncEnumerable<TItem>> All<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Async<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>, TItem, System.Collections.Generic.IAsyncEnumerable<TItem>> AtLeast<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Async<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>, TItem, System.Collections.Generic.IAsyncEnumerable<TItem>> AtMost<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int maximum, [System.Runtime.CompilerServices.CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IAsyncEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> BeEmpty<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
-        public static Testably.Expectations.Results.BetweenResult<Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>>> Between<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.BetweenResult<Testably.Expectations.QuantifiedCollectionResult.Async<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>, TItem, System.Collections.Generic.IAsyncEnumerable<TItem>>> Between<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IAsyncEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> Contain<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, TItem expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> None<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Async<Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>, TItem, System.Collections.Generic.IAsyncEnumerable<TItem>> None<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IAsyncEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> NotBeEmpty<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
         public static Testably.Expectations.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> Should<TItem>(this Testably.Expectations.Core.IExpectSubject<System.Collections.Generic.IAsyncEnumerable<TItem>> subject) { }
     }
@@ -179,13 +197,13 @@ namespace Testably.Expectations
     }
     public static class ThatEnumerableShould
     {
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> All<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtLeast<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtMost<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int maximum, [System.Runtime.CompilerServices.CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>> All<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>> AtLeast<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>> AtMost<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int maximum, [System.Runtime.CompilerServices.CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> BeEmpty<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
-        public static Testably.Expectations.Results.BetweenResult<Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>> Between<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.BetweenResult<Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>>> Between<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> None<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>> None<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> NotBeEmpty<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> Should<TItem>(this Testably.Expectations.Core.IExpectSubject<System.Collections.Generic.IEnumerable<TItem>> subject) { }
     }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -46,6 +46,17 @@ namespace Testably.Expectations
     {
         System.Threading.Tasks.Task<Testably.Expectations.CollectionEvaluatorResult> CheckCondition<TExpected>(TExpected expected, System.Func<TItem, TExpected, bool> predicate);
     }
+    public class QuantifiedCollectionResult
+    {
+        public QuantifiedCollectionResult() { }
+        public class Sync<TResult, TItem, TCollection> : Testably.Expectations.QuantifiedCollectionResult<TResult>
+            where TResult : Testably.Expectations.Core.IThat<TCollection>
+            where TCollection : System.Collections.Generic.IEnumerable<TItem>
+        {
+            public Sync(TResult result, Testably.Expectations.Core.ExpectationBuilder expectationBuilder, Testably.Expectations.CollectionQuantifier quantity) { }
+            public Testably.Expectations.Results.AndOrExpectationResult<TCollection, Testably.Expectations.Core.IThat<TCollection>> Be<TExpected>() { }
+        }
+    }
     public class QuantifiedCollectionResult<TResult>
     {
         public QuantifiedCollectionResult(TResult result, Testably.Expectations.Core.ExpectationBuilder expectationBuilder, Testably.Expectations.CollectionQuantifier quantity) { }
@@ -151,13 +162,13 @@ namespace Testably.Expectations
     }
     public static class ThatEnumerableShould
     {
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> All<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtLeast<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtMost<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int maximum, [System.Runtime.CompilerServices.CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>> All<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>> AtLeast<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>> AtMost<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int maximum, [System.Runtime.CompilerServices.CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> BeEmpty<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
-        public static Testably.Expectations.Results.BetweenResult<Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>> Between<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.BetweenResult<Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>>> Between<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, [System.Runtime.CompilerServices.CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.QuantifiedCollectionResult<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> None<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
+        public static Testably.Expectations.QuantifiedCollectionResult.Sync<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>, TItem, System.Collections.Generic.IEnumerable<TItem>> None<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static Testably.Expectations.Results.AndOrExpectationResult<System.Collections.Generic.IEnumerable<TItem>, Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> NotBeEmpty<TItem>(this Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> Should<TItem>(this Testably.Expectations.Core.IExpectSubject<System.Collections.Generic.IEnumerable<TItem>> subject) { }
     }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiedCollectionResult.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiedCollectionResult.BeTests.cs
@@ -1,0 +1,44 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.Collections;
+
+public sealed partial class QuantifiedCollectionResult
+{
+	public sealed class BeTests
+	{
+		[Fact]
+		public async Task WhenCollectionContainsOtherValues_ShouldFail()
+		{
+			object[] subject =
+			[
+				new MyClass(),
+				new SubClass(),
+				new OtherClass()
+			];
+
+			async Task Act()
+				=> await That(subject).Should().All().Be<MyClass>();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have all items of type MyClass,
+				             but not all of 3 items were
+				             at Expect.That(subject).Should().All().Be<MyClass>()
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenCollectionOnlyContainsEqualValues_ShouldSucceed()
+		{
+			object[] subject =
+			[
+				new MyClass(),
+				new SubClass(),
+			];
+
+			async Task Act()
+				=> await That(subject).Should().All().Be<MyClass>();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiedCollectionResult.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiedCollectionResult.BeTests.cs
@@ -9,9 +9,9 @@ public sealed partial class QuantifiedCollectionResult
 		{
 			object[] subject =
 			[
-				new MyClass(),
-				new SubClass(),
-				new OtherClass()
+				new MyClass(1),
+				new SubClass(1),
+				new OtherClass(1)
 			];
 
 			async Task Act()
@@ -31,8 +31,8 @@ public sealed partial class QuantifiedCollectionResult
 		{
 			object[] subject =
 			[
-				new MyClass(),
-				new SubClass(),
+				new MyClass(1),
+				new SubClass(1),
 			];
 
 			async Task Act()

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiedCollectionResult.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiedCollectionResult.cs
@@ -4,9 +4,9 @@ namespace Testably.Expectations.Tests.ThatTests.Collections;
 
 public partial class QuantifiedCollectionResult
 {
-	public class MyClass;
+	public class MyClass(int Value);
 
-	public class SubClass : MyClass;
+	public class SubClass(int Value) : MyClass(Value);
 
-	public class OtherClass;
+	public class OtherClass(int Value);
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiedCollectionResult.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiedCollectionResult.cs
@@ -1,12 +1,10 @@
-﻿using System.Collections.Generic;
-
-namespace Testably.Expectations.Tests.ThatTests.Collections;
+﻿namespace Testably.Expectations.Tests.ThatTests.Collections;
 
 public partial class QuantifiedCollectionResult
 {
 	public class MyClass(int Value);
 
-	public class SubClass(int Value) : MyClass(Value);
+	public class SubClass(int value) : MyClass(value);
 
 	public class OtherClass(int Value);
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiedCollectionResult.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiedCollectionResult.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Testably.Expectations.Tests.ThatTests.Collections;
+
+public partial class QuantifiedCollectionResult
+{
+	public class MyClass;
+
+	public class SubClass : MyClass;
+
+	public class OtherClass;
+}


### PR DESCRIPTION
Add overload `Be<TExpected>` to collections that verify, that the quantified result is of the expected type.