### PR TITLE
feat: add recursive inner exceptions

### DIFF
--- a/Source/Testably.Expectations/Core/Helpers/ExceptionHelpers.cs
+++ b/Source/Testably.Expectations/Core/Helpers/ExceptionHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Testably.Expectations.Core.Helpers;
 
@@ -13,5 +14,34 @@ internal static class ExceptionHelpers
 		}
 
 		return message;
+	}
+	
+	
+	public static IEnumerable<Exception> GetInnerExpectations(this Exception? actual)
+	{
+		if (actual == null)
+		{
+			yield break;
+		}
+		if (actual.InnerException != null)
+		{
+			yield return actual.InnerException;
+			foreach (var inner in GetInnerExpectations(actual.InnerException))
+			{
+				yield return inner;
+			}
+		}
+
+		if (actual is AggregateException aggregateException)
+		{
+			foreach (var innerException in aggregateException.InnerExceptions)
+			{
+				yield return innerException;
+				foreach (var inner in GetInnerExpectations(innerException))
+				{
+					yield return inner;
+				}
+			}
+		}
 	}
 }

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.All.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.All.cs
@@ -13,7 +13,7 @@ public abstract partial class CollectionQuantifier
 	private class AllQuantifier : CollectionQuantifier
 	{
 		/// <inheritdoc />
-		public override string ToString() => "all items";
+		public override string ToString(bool includeItems) => $"all{(includeItems ? " items" : "")}";
 
 		/// <inheritdoc />
 		protected override bool ContinueEvaluation(

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.AtLeast.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.AtLeast.cs
@@ -13,8 +13,8 @@ public abstract partial class CollectionQuantifier
 	private class AtLeastQuantifier(int minimum) : CollectionQuantifier
 	{
 		/// <inheritdoc />
-		public override string ToString()
-			=> $"at least {minimum} {(minimum == 1 ? "item" : "items")}";
+		public override string ToString(bool includeItems)
+			=> $"at least {minimum}{(includeItems ? (minimum == 1 ? " item" : " items") : "")}";
 
 		/// <inheritdoc />
 		protected override bool ContinueEvaluation(

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.AtMost.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.AtMost.cs
@@ -13,8 +13,8 @@ public abstract partial class CollectionQuantifier
 	private class AtMostQuantifier(int maximum) : CollectionQuantifier
 	{
 		/// <inheritdoc />
-		public override string ToString()
-			=> $"at most {maximum} {(maximum == 1 ? "item" : "items")}";
+		public override string ToString(bool includeItems)
+			=> $"at most {maximum}{(includeItems ? (maximum == 1 ? " item" : " items") : "")}";
 
 		/// <inheritdoc />
 		protected override bool ContinueEvaluation(

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.Between.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.Between.cs
@@ -14,7 +14,7 @@ public abstract partial class CollectionQuantifier
 	private class BetweenQuantifier(int minimum, int maximum) : CollectionQuantifier
 	{
 		/// <inheritdoc />
-		public override string ToString() => $"between {minimum} and {maximum} items";
+		public override string ToString(bool includeItems) => $"between {minimum} and {maximum}{(includeItems ? " items" : "")}";
 
 		/// <inheritdoc />
 		protected override bool ContinueEvaluation(

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.None.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.None.cs
@@ -13,7 +13,8 @@ public abstract partial class CollectionQuantifier
 	private class NoneQuantifier : CollectionQuantifier
 	{
 		/// <inheritdoc />
-		public override string ToString() => "no items";
+		public override string ToString(bool includeItems) =>
+			includeItems ? "no items" : "none";
 
 		/// <inheritdoc />
 		protected override bool ContinueEvaluation(

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.cs
@@ -37,6 +37,15 @@ public abstract partial class CollectionQuantifier
 			context.UseMaterializedEnumerable<TItem, IEnumerable<TItem>>(enumerable));
 
 	/// <summary>
+	///     Returns a string representation which depending on <paramref name="includeItems" /> ends with `Items`.
+	/// </summary>
+	public abstract string ToString(bool includeItems);
+
+	/// <inheritdoc />
+	public override string ToString()
+		=> ToString(true);
+
+	/// <summary>
 	///     Checks for each iteration, if the evaluation should continue.
 	/// </summary>
 	protected abstract bool ContinueEvaluation(
@@ -44,12 +53,6 @@ public abstract partial class CollectionQuantifier
 		int notMatchingCount,
 		int? totalCount,
 		[NotNullWhen(false)] out CollectionEvaluatorResult? result);
-
-	public abstract string ToString(bool includeItems);
-
-	/// <inheritdoc />
-	public override string ToString()
-		=> ToString(true);
 
 	private class SynchronousCollectionEvaluator<TItem>(
 		CollectionQuantifier quantifier,

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.cs
@@ -45,6 +45,12 @@ public abstract partial class CollectionQuantifier
 		int? totalCount,
 		[NotNullWhen(false)] out CollectionEvaluatorResult? result);
 
+	public abstract string ToString(bool includeItems);
+
+	/// <inheritdoc />
+	public override string ToString()
+		=> ToString(true);
+
 	private class SynchronousCollectionEvaluator<TItem>(
 		CollectionQuantifier quantifier,
 		IEnumerable<TItem> enumerable)

--- a/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Satisfy.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Satisfy.cs
@@ -53,6 +53,26 @@ public static partial class ThatQuantifiedCollectionResultShouldSync
 						(a, c) => source.Quantity.GetEvaluator<TItem, IEnumerable<TItem>>(a, c)))
 				.AppendMethodStatement(nameof(Satisfy), doNotPopulateThisValue),
 			source.Result);
+
+	/// <summary>
+	///     ...satisfy the <paramref name="predicate" />.
+	/// </summary>
+	public static AndOrExpectationResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
+		Satisfy<TItem>(
+			this QuantifiedCollectionResult<IThat<IEnumerable<TItem>>> source,
+			Func<TItem, bool> predicate,
+			[CallerArgumentExpression("predicate")]
+			string doNotPopulateThisValue = "")
+		=> new(source.ExpectationBuilder
+				.AddConstraint(
+					new ThatQuantifiedCollectionResultShould.SatisfyConstraint<TItem,
+						IEnumerable<TItem>>(
+						predicate,
+						doNotPopulateThisValue,
+						source.Quantity,
+						(a, c) => source.Quantity.GetEvaluator<TItem, IEnumerable<TItem>>(a, c)))
+				.AppendMethodStatement(nameof(Satisfy), doNotPopulateThisValue),
+			source.Result);
 }
 
 #if NET6_0_OR_GREATER
@@ -128,6 +148,6 @@ public static partial class ThatQuantifiedCollectionResultShould
 		}
 
 		public override string ToString()
-			=> $"have {quantifier} items satisfying {Formatter.Format(expression)}";
+			=> $"have {quantifier} satisfying {Formatter.Format(expression)}";
 	}
 }

--- a/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Satisfy.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Satisfy.cs
@@ -53,26 +53,6 @@ public static partial class ThatQuantifiedCollectionResultShouldSync
 						(a, c) => source.Quantity.GetEvaluator<TItem, IEnumerable<TItem>>(a, c)))
 				.AppendMethodStatement(nameof(Satisfy), doNotPopulateThisValue),
 			source.Result);
-
-	/// <summary>
-	///     ...satisfy the <paramref name="predicate" />.
-	/// </summary>
-	public static AndOrExpectationResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
-		Satisfy<TItem>(
-			this QuantifiedCollectionResult<IThat<IEnumerable<TItem>>> source,
-			Func<TItem, bool> predicate,
-			[CallerArgumentExpression("predicate")]
-			string doNotPopulateThisValue = "")
-		=> new(source.ExpectationBuilder
-				.AddConstraint(
-					new ThatQuantifiedCollectionResultShould.SatisfyConstraint<TItem,
-						IEnumerable<TItem>>(
-						predicate,
-						doNotPopulateThisValue,
-						source.Quantity,
-						(a, c) => source.Quantity.GetEvaluator<TItem, IEnumerable<TItem>>(a, c)))
-				.AppendMethodStatement(nameof(Satisfy), doNotPopulateThisValue),
-			source.Result);
 }
 
 #if NET6_0_OR_GREATER

--- a/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Satisfy.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Satisfy.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.EvaluationContext;
+using Testably.Expectations.Core.Helpers;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
@@ -124,10 +126,10 @@ public static partial class ThatQuantifiedCollectionResultShould
 				return new ConstraintResult.Success<TCollection>(actual, ToString());
 			}
 
-			return new ConstraintResult.Failure(ToString(), $"found {result.Error} items");
+			return new ConstraintResult.Failure(ToString(), $"{result.Error} did");
 		}
 
 		public override string ToString()
-			=> $"have {quantifier} satisfying {Formatter.Format(expression)}";
+			=> $"{quantifier.ToString(false)} satisfy {Formatter.Format(expression)}";
 	}
 }

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
@@ -14,6 +14,10 @@ public partial class ThatDelegateThrows<TException>
 	///     Verifies that the actual exception recursively has inner exceptions which satisfy the
 	///     <paramref name="expectations" />.
 	/// </summary>
+	/// <remarks>
+	///     Recursively applies the expectations on the <see cref="Exception.InnerException" /> (if not <see langword="null" />
+	///     and for <see cref="AggregateException" /> also on the <see cref="AggregateException.InnerExceptions" />.
+	/// </remarks>
 	public AndOrExpectationResult<TException?, ThatDelegateThrows<TException>>
 		WithRecursiveInnerExceptions(
 			Action<IThat<IEnumerable<Exception>>> expectations,

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
@@ -23,7 +23,7 @@ public partial class ThatDelegateThrows<TException>
 				.ForProperty(
 					PropertyAccessor<Exception?, IEnumerable<Exception>>.FromFunc(
 						e => e.GetInnerExpectations(), "recursive inner exceptions "),
-					(property, expectation) => $"have {property}which {expectation}")
+					(property, expectation) => $"with {property}which {expectation}")
 				.AddExpectations(e
 					=> expectations(new Expect.ThatSubject<IEnumerable<Exception>>(e)))
 				.AppendMethodStatement(nameof(WithRecursiveInnerExceptions),

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Results;
+// ReSharper disable once CheckNamespace
+
+namespace Testably.Expectations;
+
+public partial class ThatDelegateThrows<TException>
+{
+	/// <summary>
+	///     Verifies that the actual exception recursively has inner exceptions which satisfy the
+	///     <paramref name="expectations" />.
+	/// </summary>
+	public AndOrExpectationResult<TException?, ThatDelegateThrows<TException>>
+		WithRecursiveInnerExceptions(
+			Action<IThat<IEnumerable<Exception>>> expectations,
+			[CallerArgumentExpression("expectations")]
+			string doNotPopulateThisValue = "")
+		=> new(ExpectationBuilder
+				.ForProperty(
+					PropertyAccessor<Exception?, IEnumerable<Exception>>.FromFunc(
+						e => e.GetInnerExpectations(), "recursive inner exceptions "),
+					(property, expectation) => $"have {property}which {expectation}")
+				.AddExpectations(e
+					=> expectations(new Expect.ThatSubject<IEnumerable<Exception>>(e)))
+				.AppendMethodStatement(nameof(WithRecursiveInnerExceptions),
+					doNotPopulateThisValue),
+			this);
+}

--- a/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveRecursiveInnerExceptions.cs
+++ b/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveRecursiveInnerExceptions.cs
@@ -14,18 +14,23 @@ namespace Testably.Expectations;
 public partial class ThatExceptionShould<TException>
 {
 	/// <summary>
-	///     Verifies that the actual exception recursively has inner exceptions which satisfy the <paramref name="expectations" />.
+	///     Verifies that the actual exception recursively has inner exceptions which satisfy the
+	///     <paramref name="expectations" />.
 	/// </summary>
-	public AndOrExpectationResult<TException?, ThatExceptionShould<TException>> HaveRecursiveInnerExceptions(
-		Action<IThat<IEnumerable<Exception>>> expectations,
-		[CallerArgumentExpression("expectations")]
-		string doNotPopulateThisValue = "")
+	public AndOrExpectationResult<TException?, ThatExceptionShould<TException>>
+		HaveRecursiveInnerExceptions(
+			Action<IThat<IEnumerable<Exception>>> expectations,
+			[CallerArgumentExpression("expectations")]
+			string doNotPopulateThisValue = "")
 		=> new(ExpectationBuilder
-				.ForProperty(PropertyAccessor<Exception?, IEnumerable<Exception>>.FromFunc(e => e.GetInnerExpectations(), "recursive inner exceptions "),
+				.ForProperty(PropertyAccessor<Exception?, IEnumerable<Exception>>.FromFunc(
+						e => e.GetInnerExpectations(),
+						"recursive inner exceptions "),
 					(property, expectation) => $"have {property}which {expectation}")
-				.AddExpectations(e => expectations(new Expect.ThatSubject<IEnumerable<Exception>>(e)))
-				.AppendMethodStatement(nameof(HaveRecursiveInnerExceptions),
+				.AddExpectations(e => expectations(
+					new Expect.ThatSubject<IEnumerable<Exception>>(e)))
+				.AppendMethodStatement(
+					nameof(HaveRecursiveInnerExceptions),
 					doNotPopulateThisValue),
 			this);
-	
 }

--- a/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveRecursiveInnerExceptions.cs
+++ b/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveRecursiveInnerExceptions.cs
@@ -17,6 +17,10 @@ public partial class ThatExceptionShould<TException>
 	///     Verifies that the actual exception recursively has inner exceptions which satisfy the
 	///     <paramref name="expectations" />.
 	/// </summary>
+	/// <remarks>
+	///     Recursively applies the expectations on the <see cref="Exception.InnerException" /> (if not <see langword="null" />
+	///     and for <see cref="AggregateException" /> also on the <see cref="AggregateException.InnerExceptions" />.
+	/// </remarks>
 	public AndOrExpectationResult<TException?, ThatExceptionShould<TException>>
 		HaveRecursiveInnerExceptions(
 			Action<IThat<IEnumerable<Exception>>> expectations,

--- a/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveRecursiveInnerExceptions.cs
+++ b/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveRecursiveInnerExceptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
 using Testably.Expectations.Results;
 
 // ReSharper disable once CheckNamespace
@@ -13,45 +14,18 @@ namespace Testably.Expectations;
 public partial class ThatExceptionShould<TException>
 {
 	/// <summary>
-	///     Verifies that the actual exception has an inner exception which satisfies the <paramref name="expectations" />.
+	///     Verifies that the actual exception recursively has inner exceptions which satisfy the <paramref name="expectations" />.
 	/// </summary>
 	public AndOrExpectationResult<TException?, ThatExceptionShould<TException>> HaveRecursiveInnerExceptions(
 		Action<IThat<IEnumerable<Exception>>> expectations,
 		[CallerArgumentExpression("expectations")]
 		string doNotPopulateThisValue = "")
 		=> new(ExpectationBuilder
-				.ForProperty(PropertyAccessor<Exception?, IEnumerable<Exception>>.FromFunc(GetInnerExpectations, "recursive inner exceptions "),
+				.ForProperty(PropertyAccessor<Exception?, IEnumerable<Exception>>.FromFunc(e => e.GetInnerExpectations(), "recursive inner exceptions "),
 					(property, expectation) => $"have {property}which {expectation}")
 				.AddExpectations(e => expectations(new Expect.ThatSubject<IEnumerable<Exception>>(e)))
 				.AppendMethodStatement(nameof(HaveRecursiveInnerExceptions),
 					doNotPopulateThisValue),
 			this);
 	
-	private IEnumerable<Exception> GetInnerExpectations(Exception? actual)
-	{
-		if (actual == null)
-		{
-			yield break;
-		}
-		if (actual.InnerException != null)
-		{
-			yield return actual.InnerException;
-			foreach (var inner in GetInnerExpectations(actual.InnerException))
-			{
-				yield return inner;
-			}
-		}
-
-		if (actual is AggregateException aggregateException)
-		{
-			foreach (var innerException in aggregateException.InnerExceptions)
-			{
-				yield return innerException;
-				foreach (var inner in GetInnerExpectations(innerException))
-				{
-					yield return inner;
-				}
-			}
-		}
-	}
 }

--- a/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveRecursiveInnerExceptions.cs
+++ b/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveRecursiveInnerExceptions.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+using Testably.Expectations.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on <see cref="Exception" /> values.
+/// </summary>
+public partial class ThatExceptionShould<TException>
+{
+	/// <summary>
+	///     Verifies that the actual exception has an inner exception which satisfies the <paramref name="expectations" />.
+	/// </summary>
+	public AndOrExpectationResult<TException?, ThatExceptionShould<TException>> HaveRecursiveInnerExceptions(
+		Action<IThat<IEnumerable<Exception>>> expectations,
+		[CallerArgumentExpression("expectations")]
+		string doNotPopulateThisValue = "")
+		=> new(ExpectationBuilder
+				.ForProperty(PropertyAccessor<Exception?, IEnumerable<Exception>>.FromFunc(GetInnerExpectations, "recursive inner exceptions "),
+					(property, expectation) => $"have {property}which {expectation}")
+				.AddExpectations(e => expectations(new Expect.ThatSubject<IEnumerable<Exception>>(e)))
+				.AppendMethodStatement(nameof(HaveRecursiveInnerExceptions),
+					doNotPopulateThisValue),
+			this);
+	
+	private IEnumerable<Exception> GetInnerExpectations(Exception? actual)
+	{
+		if (actual == null)
+		{
+			yield break;
+		}
+		if (actual.InnerException != null)
+		{
+			yield return actual.InnerException;
+			foreach (var inner in GetInnerExpectations(actual.InnerException))
+			{
+				yield return inner;
+			}
+		}
+
+		if (actual is AggregateException aggregateException)
+		{
+			foreach (var innerException in aggregateException.InnerExceptions)
+			{
+				yield return innerException;
+				foreach (var inner in GetInnerExpectations(innerException))
+				{
+					yield return inner;
+				}
+			}
+		}
+	}
+}

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -18,6 +18,8 @@ namespace Testably.Expectations
             where TCollection : System.Collections.Generic.IAsyncEnumerable<TItem> { }
         public Testably.Expectations.ICollectionEvaluator<TItem> GetEvaluator<TItem, TCollection>(TCollection enumerable, Testably.Expectations.Core.EvaluationContext.IEvaluationContext context)
             where TCollection : System.Collections.Generic.IEnumerable<TItem> { }
+        public override string ToString() { }
+        public abstract string ToString(bool includeItems);
         public static Testably.Expectations.CollectionQuantifier AtLeast(int minimum) { }
         public static Testably.Expectations.CollectionQuantifier AtMost(int maximum) { }
         public static Testably.Expectations.CollectionQuantifier Between(int minimum, int maximum) { }
@@ -173,6 +175,7 @@ namespace Testably.Expectations
         public Testably.Expectations.Results.AndOrExpectationResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInnerException() { }
         public Testably.Expectations.Results.AndOrExpectationResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInnerException(System.Action<Testably.Expectations.ThatExceptionShould<System.Exception?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("expectations")] string doNotPopulateThisValue = "") { }
         public Testably.Expectations.Results.StringMatcherExpectationResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithMessage(Testably.Expectations.Options.StringMatcher expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public Testably.Expectations.Results.AndOrExpectationResult<TException?, Testably.Expectations.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions(System.Action<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("expectations")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatEnumShould
     {
@@ -228,6 +231,7 @@ namespace Testably.Expectations
         public Testably.Expectations.Results.AndOrExpectationResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInnerException() { }
         public Testably.Expectations.Results.AndOrExpectationResult<TException?, Testably.Expectations.ThatExceptionShould<TException>> HaveInnerException(System.Action<Testably.Expectations.ThatExceptionShould<System.Exception?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("expectations")] string doNotPopulateThisValue = "") { }
         public Testably.Expectations.Results.StringMatcherExpectationResult<TException?, Testably.Expectations.ThatExceptionShould<TException>> HaveMessage(Testably.Expectations.Options.StringMatcher expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public Testably.Expectations.Results.AndOrExpectationResult<TException?, Testably.Expectations.ThatExceptionShould<TException>> HaveRecursiveInnerExceptions(System.Action<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("expectations")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatGenericShould
     {

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -18,6 +18,8 @@ namespace Testably.Expectations
             where TCollection : System.Collections.Generic.IAsyncEnumerable<TItem> { }
         public Testably.Expectations.ICollectionEvaluator<TItem> GetEvaluator<TItem, TCollection>(TCollection enumerable, Testably.Expectations.Core.EvaluationContext.IEvaluationContext context)
             where TCollection : System.Collections.Generic.IEnumerable<TItem> { }
+        public override string ToString() { }
+        public abstract string ToString(bool includeItems);
         public static Testably.Expectations.CollectionQuantifier AtLeast(int minimum) { }
         public static Testably.Expectations.CollectionQuantifier AtMost(int maximum) { }
         public static Testably.Expectations.CollectionQuantifier Between(int minimum, int maximum) { }
@@ -173,6 +175,7 @@ namespace Testably.Expectations
         public Testably.Expectations.Results.AndOrExpectationResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInnerException() { }
         public Testably.Expectations.Results.AndOrExpectationResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInnerException(System.Action<Testably.Expectations.ThatExceptionShould<System.Exception?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("expectations")] string doNotPopulateThisValue = "") { }
         public Testably.Expectations.Results.StringMatcherExpectationResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithMessage(Testably.Expectations.Options.StringMatcher expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public Testably.Expectations.Results.AndOrExpectationResult<TException?, Testably.Expectations.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions(System.Action<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("expectations")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatEnumShould
     {
@@ -228,6 +231,7 @@ namespace Testably.Expectations
         public Testably.Expectations.Results.AndOrExpectationResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInnerException() { }
         public Testably.Expectations.Results.AndOrExpectationResult<TException?, Testably.Expectations.ThatExceptionShould<TException>> HaveInnerException(System.Action<Testably.Expectations.ThatExceptionShould<System.Exception?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("expectations")] string doNotPopulateThisValue = "") { }
         public Testably.Expectations.Results.StringMatcherExpectationResult<TException?, Testably.Expectations.ThatExceptionShould<TException>> HaveMessage(Testably.Expectations.Options.StringMatcher expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public Testably.Expectations.Results.AndOrExpectationResult<TException?, Testably.Expectations.ThatExceptionShould<TException>> HaveRecursiveInnerExceptions(System.Action<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("expectations")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatGenericShould
     {

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -16,6 +16,8 @@ namespace Testably.Expectations
         protected abstract bool ContinueEvaluation(int matchingCount, int notMatchingCount, int? totalCount, [System.Diagnostics.CodeAnalysis.NotNullWhen(false)] out Testably.Expectations.CollectionEvaluatorResult? result);
         public Testably.Expectations.ICollectionEvaluator<TItem> GetEvaluator<TItem, TCollection>(TCollection enumerable, Testably.Expectations.Core.EvaluationContext.IEvaluationContext context)
             where TCollection : System.Collections.Generic.IEnumerable<TItem> { }
+        public override string ToString() { }
+        public abstract string ToString(bool includeItems);
         public static Testably.Expectations.CollectionQuantifier AtLeast(int minimum) { }
         public static Testably.Expectations.CollectionQuantifier AtMost(int maximum) { }
         public static Testably.Expectations.CollectionQuantifier Between(int minimum, int maximum) { }
@@ -138,6 +140,7 @@ namespace Testably.Expectations
         public Testably.Expectations.Results.AndOrExpectationResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInnerException() { }
         public Testably.Expectations.Results.AndOrExpectationResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInnerException(System.Action<Testably.Expectations.ThatExceptionShould<System.Exception?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("expectations")] string doNotPopulateThisValue = "") { }
         public Testably.Expectations.Results.StringMatcherExpectationResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithMessage(Testably.Expectations.Options.StringMatcher expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public Testably.Expectations.Results.AndOrExpectationResult<TException?, Testably.Expectations.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions(System.Action<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("expectations")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatEnumShould
     {
@@ -193,6 +196,7 @@ namespace Testably.Expectations
         public Testably.Expectations.Results.AndOrExpectationResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInnerException() { }
         public Testably.Expectations.Results.AndOrExpectationResult<TException?, Testably.Expectations.ThatExceptionShould<TException>> HaveInnerException(System.Action<Testably.Expectations.ThatExceptionShould<System.Exception?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("expectations")] string doNotPopulateThisValue = "") { }
         public Testably.Expectations.Results.StringMatcherExpectationResult<TException?, Testably.Expectations.ThatExceptionShould<TException>> HaveMessage(Testably.Expectations.Options.StringMatcher expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public Testably.Expectations.Results.AndOrExpectationResult<TException?, Testably.Expectations.ThatExceptionShould<TException>> HaveRecursiveInnerExceptions(System.Action<Testably.Expectations.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("expectations")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatGenericShould
     {

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithMessageTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithMessageTests.cs
@@ -32,7 +32,8 @@ public sealed partial class DelegateThrows
 		{
 			Exception exception = new CustomException("outer",
 				new SubCustomException("inner1",
-					new ArgumentException("inner2", "param2")));
+					// ReSharper disable once NotResolvedInText
+					new ArgumentException("inner2", paramName: "param2")));
 			void Act() => throw exception;
 
 			CustomException result = await That(Act).Should().Throw<CustomException>()

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithRecursiveInnerExceptionsTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithRecursiveInnerExceptionsTests.cs
@@ -1,0 +1,37 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.Delegates;
+
+public sealed partial class DelegateThrows
+{
+	public sealed class WithRecursiveInnerExceptionsTests
+	{
+		[Fact]
+		public async Task WhenAwaited_WithExpectations_ShouldReturnThrownException()
+		{
+			Exception exception = new("outer", new Exception("inner"));
+
+			Exception result = await That(() => throw exception)
+				.Should().ThrowException().WithRecursiveInnerExceptions(
+					e => e.None().Satisfy(e => false));
+
+			await That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
+		public async Task WhenNoInnerExceptionIsPresent_ShouldFail()
+		{
+			string actual = "actual text";
+			Action action = () => throw new Exception(actual, new Exception("inner"));
+
+			async Task Act()
+				=> await That(action).Should().ThrowException().WithRecursiveInnerExceptions(e => e.All().Satisfy(_ => false));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected action to
+				             throw an Exception with recursive inner exceptions which all satisfy "_ => false"
+				             but not all did
+				             at Expect.That(action).Should().ThrowException().WithRecursiveInnerExceptions(e => e.None().Satisfy(_ => true))
+				             """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Exceptions/ExceptionShould.HaveRecursiveInnerExceptionsTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Exceptions/ExceptionShould.HaveRecursiveInnerExceptionsTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Testably.Expectations.Tests.ThatTests.Exceptions;
+
+public sealed partial class ExceptionShould
+{
+	public class HaveRecursiveInnerExceptionsTests
+	{
+		[Fact]
+		public async Task WhenAllInnerExceptionsMatchTheCondition_ShouldSucceed()
+		{
+			Exception subject = new("outer",
+				new Exception("inner1", 
+					new AggregateException("inner2",
+						new Exception("inner3A"),
+						new Exception("inner3B"))));
+
+			var result = Expect.That(new AggregateException().InnerExceptions).Should().All()
+				.Satisfy(e => e.Message == "inner3A");
+			
+			async Task Act()
+				=> await That(subject).Should().HaveRecursiveInnerExceptions(c => c.All().Satisfy(e => e.Message.StartsWith("inner")));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenInnerExceptionsDoNotMatchTheCondition_ShouldFail()
+		{
+			Exception subject = new("outer",
+				new Exception("inner1", 
+					new AggregateException("inner2",
+						new Exception("inner3A"),
+						new Exception("inner3B"))));
+
+			var result = Expect.That(new AggregateException().InnerExceptions).Should().All()
+				.Satisfy(e => e.Message == "inner3A");
+			
+			async Task Act()
+				=> await That(subject).Should().HaveRecursiveInnerExceptions(c => c.All().Satisfy(e => e.Message != "inner3A"));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have recursive inner exceptions which have all items satisfying "e => e.Message != "inner3A"",
+				             but found not all items
+				             at Expect.That(subject).Should().HaveRecursiveInnerExceptions(c => c.All().Satisfy(e => e.Message != "inner3A"))
+				             """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Exceptions/ExceptionShould.HaveRecursiveInnerExceptionsTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Exceptions/ExceptionShould.HaveRecursiveInnerExceptionsTests.cs
@@ -44,7 +44,7 @@ public sealed partial class ExceptionShould
 				.WithMessage("""
 				             Expected subject to
 				             have recursive inner exceptions which have all items satisfying "e => e.Message != "inner3A"",
-				             but found not all items
+				             but not all items did
 				             at Expect.That(subject).Should().HaveRecursiveInnerExceptions(c => c.All().Satisfy(e => e.Message != "inner3A"))
 				             """);
 		}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Exceptions/ExceptionShould.HaveRecursiveInnerExceptionsTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Exceptions/ExceptionShould.HaveRecursiveInnerExceptionsTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-
-namespace Testably.Expectations.Tests.ThatTests.Exceptions;
+﻿namespace Testably.Expectations.Tests.ThatTests.Exceptions;
 
 public sealed partial class ExceptionShould
 {
@@ -11,41 +8,59 @@ public sealed partial class ExceptionShould
 		public async Task WhenAllInnerExceptionsMatchTheCondition_ShouldSucceed()
 		{
 			Exception subject = new("outer",
-				new Exception("inner1", 
+				new Exception("inner1",
 					new AggregateException("inner2",
 						new Exception("inner3A"),
 						new Exception("inner3B"))));
 
-			var result = Expect.That(new AggregateException().InnerExceptions).Should().All()
-				.Satisfy(e => e.Message == "inner3A");
-			
 			async Task Act()
-				=> await That(subject).Should().HaveRecursiveInnerExceptions(c => c.All().Satisfy(e => e.Message.StartsWith("inner")));
+				=> await That(subject).Should().HaveRecursiveInnerExceptions(c
+					=> c.All().Satisfy(e => e.Message.StartsWith("inner")));
 
 			await That(Act).Should().NotThrow();
 		}
 
 		[Fact]
-		public async Task WhenInnerExceptionsDoNotMatchTheCondition_ShouldFail()
+		public async Task WhenInnerExceptionsDoNotMatchTheCondition_ForAll_ShouldFail()
 		{
 			Exception subject = new("outer",
-				new Exception("inner1", 
+				new Exception("inner1",
 					new AggregateException("inner2",
 						new Exception("inner3A"),
 						new Exception("inner3B"))));
 
-			var result = Expect.That(new AggregateException().InnerExceptions).Should().All()
-				.Satisfy(e => e.Message == "inner3A");
-			
 			async Task Act()
-				=> await That(subject).Should().HaveRecursiveInnerExceptions(c => c.All().Satisfy(e => e.Message != "inner3A"));
+				=> await That(subject).Should().HaveRecursiveInnerExceptions(
+					c => c.All().Satisfy(e => e.Message != "inner3A"));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
 				             Expected subject to
-				             have recursive inner exceptions which have all items satisfying "e => e.Message != "inner3A"",
-				             but not all items did
+				             have recursive inner exceptions which all satisfy "e => e.Message != "inner3A"",
+				             but not all did
 				             at Expect.That(subject).Should().HaveRecursiveInnerExceptions(c => c.All().Satisfy(e => e.Message != "inner3A"))
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenInnerExceptionsDoNotMatchTheCondition_ForNone_ShouldFail()
+		{
+			Exception subject = new("outer",
+				new Exception("inner1",
+					new AggregateException("inner2",
+						new Exception("inner3A"),
+						new Exception("inner3B"))));
+
+			async Task Act()
+				=> await That(subject).Should().HaveRecursiveInnerExceptions(
+					c => c.None().Satisfy(e => e.Message != "inner3A"));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have recursive inner exceptions which none satisfy "e => e.Message != "inner3A"",
+				             but at least one did
+				             at Expect.That(subject).Should().HaveRecursiveInnerExceptions(c => c.None().Satisfy(e => e.Message != "inner3A"))
 				             """);
 		}
 	}


### PR DESCRIPTION
Fixes #58
Add `HaveRecursiveInnerExceptions` / `WithRecursiveInnerExceptions` to specify expectations on the enumerable of inner exceptions.