### PR TITLE
fix: nullability of enum expectations

### DIFF
--- a/Source/Testably.Expectations/That/Enums/ThatEnumShould.Be.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatEnumShould.Be.cs
@@ -13,7 +13,7 @@ public static partial class ThatEnumShould
 	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
 	public static AndOrExpectationResult<TEnum, IThat<TEnum>> Be<TEnum>(this IThat<TEnum> source,
-		TEnum expected,
+		TEnum? expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		where TEnum : struct, Enum
 		=> new(source.ExpectationBuilder
@@ -27,7 +27,7 @@ public static partial class ThatEnumShould
 	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static AndOrExpectationResult<TEnum, IThat<TEnum>> NotBe<TEnum>(this IThat<TEnum> source,
-		TEnum unexpected,
+		TEnum? unexpected,
 		[CallerArgumentExpression("unexpected")]
 		string doNotPopulateThisValue = "")
 		where TEnum : struct, Enum

--- a/Source/Testably.Expectations/That/Enums/ThatEnumShould.HaveFlag.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatEnumShould.HaveFlag.cs
@@ -14,14 +14,14 @@ public static partial class ThatEnumShould
 	/// </summary>
 	public static AndOrExpectationResult<TEnum, IThat<TEnum>> HaveFlag<TEnum>(
 		this IThat<TEnum> source,
-		TEnum expectedFlag,
+		TEnum? expectedFlag,
 		[CallerArgumentExpression("expectedFlag")]
 		string doNotPopulateThisValue = "")
 		where TEnum : struct, Enum
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ValueConstraint<TEnum>(
 					$"have flag {Formatter.Format(expectedFlag)}",
-					actual => actual.HasFlag(expectedFlag)))
+					actual => expectedFlag != null && actual.HasFlag(expectedFlag)))
 				.AppendMethodStatement(nameof(HaveFlag), doNotPopulateThisValue),
 			source);
 
@@ -30,14 +30,14 @@ public static partial class ThatEnumShould
 	/// </summary>
 	public static AndOrExpectationResult<TEnum, IThat<TEnum>> NotHaveFlag<TEnum>(
 		this IThat<TEnum> source,
-		TEnum unexpectedFlag,
+		TEnum? unexpectedFlag,
 		[CallerArgumentExpression("unexpectedFlag")]
 		string doNotPopulateThisValue = "")
 		where TEnum : struct, Enum
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ValueConstraint<TEnum>(
 					$"not have flag {Formatter.Format(unexpectedFlag)}",
-					actual => !actual.HasFlag(unexpectedFlag)))
+					actual => unexpectedFlag == null || !actual.HasFlag(unexpectedFlag)))
 				.AppendMethodStatement(nameof(NotHaveFlag), doNotPopulateThisValue),
 			source);
 }

--- a/Source/Testably.Expectations/That/Enums/ThatEnumShould.HaveValue.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatEnumShould.HaveValue.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
 // ReSharper disable once CheckNamespace
@@ -14,12 +15,12 @@ public static partial class ThatEnumShould
 	/// </summary>
 	public static AndOrExpectationResult<TEnum, IThat<TEnum>> HaveValue<TEnum>(
 		this IThat<TEnum> source,
-		long expected,
+		long? expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		where TEnum : struct, Enum
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ValueConstraint<TEnum>(
-					$"have value {expected}",
+					$"have value {Formatter.Format(expected)}",
 					actual => Convert.ToInt64(actual, CultureInfo.InvariantCulture) == expected))
 				.AppendMethodStatement(nameof(HaveValue), doNotPopulateThisValue),
 			source);
@@ -29,13 +30,13 @@ public static partial class ThatEnumShould
 	/// </summary>
 	public static AndOrExpectationResult<TEnum, IThat<TEnum>> NotHaveValue<TEnum>(
 		this IThat<TEnum> source,
-		long unexpected,
+		long? unexpected,
 		[CallerArgumentExpression("unexpected")]
 		string doNotPopulateThisValue = "")
 		where TEnum : struct, Enum
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ValueConstraint<TEnum>(
-					$"not have value {unexpected}",
+					$"not have value {Formatter.Format(unexpected)}",
 					actual => Convert.ToInt64(actual, CultureInfo.InvariantCulture) != unexpected))
 				.AppendMethodStatement(nameof(NotHaveValue), doNotPopulateThisValue),
 			source);

--- a/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.HaveFlag.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.HaveFlag.cs
@@ -14,14 +14,15 @@ public static partial class ThatNullableEnumShould
 	/// </summary>
 	public static AndOrExpectationResult<TEnum?, IThat<TEnum?>> HaveFlag<TEnum>(
 		this IThat<TEnum?> source,
-		TEnum expectedFlag,
+		TEnum? expectedFlag,
 		[CallerArgumentExpression("expectedFlag")]
 		string doNotPopulateThisValue = "")
 		where TEnum : struct, Enum
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ValueConstraint<TEnum>(
 					$"have flag {Formatter.Format(expectedFlag)}",
-					actual => actual != null && actual.Value.HasFlag(expectedFlag)))
+					actual => actual == null && expectedFlag == null ||
+					          actual != null && expectedFlag != null && actual.Value.HasFlag(expectedFlag)))
 				.AppendMethodStatement(nameof(HaveFlag), doNotPopulateThisValue),
 			source);
 
@@ -30,14 +31,16 @@ public static partial class ThatNullableEnumShould
 	/// </summary>
 	public static AndOrExpectationResult<TEnum?, IThat<TEnum?>> NotHaveFlag<TEnum>(
 		this IThat<TEnum?> source,
-		TEnum unexpectedFlag,
+		TEnum? unexpectedFlag,
 		[CallerArgumentExpression("unexpectedFlag")]
 		string doNotPopulateThisValue = "")
 		where TEnum : struct, Enum
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ValueConstraint<TEnum>(
 					$"not have flag {Formatter.Format(unexpectedFlag)}",
-					actual => actual != null && !actual.Value.HasFlag(unexpectedFlag)))
+					actual => actual != null && unexpectedFlag == null ||
+				              actual == null && unexpectedFlag != null ||
+				              actual != null && unexpectedFlag != null && !actual.Value.HasFlag(unexpectedFlag)))
 				.AppendMethodStatement(nameof(NotHaveFlag), doNotPopulateThisValue),
 			source);
 }

--- a/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.HaveValue.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.HaveValue.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
 // ReSharper disable once CheckNamespace
@@ -14,15 +15,15 @@ public static partial class ThatNullableEnumShould
 	/// </summary>
 	public static AndOrExpectationResult<TEnum?, IThat<TEnum?>> HaveValue<TEnum>(
 		this IThat<TEnum?> source,
-		long expected,
+		long? expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		where TEnum : struct, Enum
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ValueConstraint<TEnum>(
-					$"have value {expected}",
+					$"have value {Formatter.Format(expected)}",
 					actual => actual != null &&
-					          Convert.ToInt64(actual.Value, CultureInfo.InvariantCulture) ==
-					          expected))
+					          Convert.ToInt64(actual, CultureInfo.InvariantCulture)
+					          == expected))
 				.AppendMethodStatement(nameof(HaveValue), doNotPopulateThisValue),
 			source);
 
@@ -31,13 +32,13 @@ public static partial class ThatNullableEnumShould
 	/// </summary>
 	public static AndOrExpectationResult<TEnum?, IThat<TEnum?>> NotHaveValue<TEnum>(
 		this IThat<TEnum?> source,
-		long unexpected,
+		long? unexpected,
 		[CallerArgumentExpression("unexpected")]
 		string doNotPopulateThisValue = "")
 		where TEnum : struct, Enum
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ValueConstraint<TEnum>(
-					$"not have value {unexpected}",
+					$"not have value {Formatter.Format(unexpected)}",
 					actual => actual != null &&
 					          Convert.ToInt64(actual.Value, CultureInfo.InvariantCulture) !=
 					          unexpected))

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -178,21 +178,21 @@ namespace Testably.Expectations
     }
     public static class ThatEnumShould
     {
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> Be<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> Be<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> BeDefined<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source)
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> HaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum expectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedFlag")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> HaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum? expectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedFlag")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> HaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, long expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> HaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, long? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotBe<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotBe<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotBeDefined<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source)
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotHaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum unexpectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpectedFlag")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotHaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum? unexpectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpectedFlag")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotHaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, long unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotHaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, long? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Core.IThat<TEnum> Should<TEnum>(this Testably.Expectations.Core.IExpectSubject<TEnum> subject)
             where TEnum :  struct, System.Enum { }
@@ -291,9 +291,9 @@ namespace Testably.Expectations
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> BeNull<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source)
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> HaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum expectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedFlag")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> HaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum? expectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedFlag")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> HaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, long expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> HaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, long? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotBe<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
@@ -301,9 +301,9 @@ namespace Testably.Expectations
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotBeNull<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source)
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotHaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum unexpectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpectedFlag")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotHaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum? unexpectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpectedFlag")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotHaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, long unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotHaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, long? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Core.IThat<TEnum?> Should<TEnum>(this Testably.Expectations.Core.IExpectSubject<TEnum?> subject)
             where TEnum :  struct, System.Enum { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -178,21 +178,21 @@ namespace Testably.Expectations
     }
     public static class ThatEnumShould
     {
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> Be<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> Be<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> BeDefined<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source)
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> HaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum expectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedFlag")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> HaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum? expectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedFlag")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> HaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, long expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> HaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, long? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotBe<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotBe<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotBeDefined<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source)
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotHaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum unexpectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpectedFlag")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotHaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum? unexpectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpectedFlag")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotHaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, long unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotHaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, long? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Core.IThat<TEnum> Should<TEnum>(this Testably.Expectations.Core.IExpectSubject<TEnum> subject)
             where TEnum :  struct, System.Enum { }
@@ -291,9 +291,9 @@ namespace Testably.Expectations
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> BeNull<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source)
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> HaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum expectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedFlag")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> HaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum? expectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedFlag")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> HaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, long expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> HaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, long? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotBe<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
@@ -301,9 +301,9 @@ namespace Testably.Expectations
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotBeNull<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source)
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotHaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum unexpectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpectedFlag")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotHaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum? unexpectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpectedFlag")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotHaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, long unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotHaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, long? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Core.IThat<TEnum?> Should<TEnum>(this Testably.Expectations.Core.IExpectSubject<TEnum?> subject)
             where TEnum :  struct, System.Enum { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -143,21 +143,21 @@ namespace Testably.Expectations
     }
     public static class ThatEnumShould
     {
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> Be<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> Be<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> BeDefined<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source)
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> HaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum expectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedFlag")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> HaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum? expectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedFlag")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> HaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, long expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> HaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, long? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotBe<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotBe<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotBeDefined<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source)
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotHaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum unexpectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpectedFlag")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotHaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, TEnum? unexpectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpectedFlag")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotHaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, long unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum, Testably.Expectations.Core.IThat<TEnum>> NotHaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum> source, long? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Core.IThat<TEnum> Should<TEnum>(this Testably.Expectations.Core.IExpectSubject<TEnum> subject)
             where TEnum :  struct, System.Enum { }
@@ -244,9 +244,9 @@ namespace Testably.Expectations
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> BeNull<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source)
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> HaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum expectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedFlag")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> HaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum? expectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedFlag")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> HaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, long expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> HaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, long? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotBe<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
@@ -254,9 +254,9 @@ namespace Testably.Expectations
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotBeNull<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source)
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotHaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum unexpectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpectedFlag")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotHaveFlag<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, TEnum? unexpectedFlag, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpectedFlag")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
-        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotHaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, long unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+        public static Testably.Expectations.Results.AndOrExpectationResult<TEnum?, Testably.Expectations.Core.IThat<TEnum?>> NotHaveValue<TEnum>(this Testably.Expectations.Core.IThat<TEnum?> source, long? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where TEnum :  struct, System.Enum { }
         public static Testably.Expectations.Core.IThat<TEnum?> Should<TEnum>(this Testably.Expectations.Core.IExpectSubject<TEnum?> subject)
             where TEnum :  struct, System.Enum { }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.BeTests.cs
@@ -4,6 +4,23 @@ public sealed partial class EnumShould
 {
 	public sealed class BeTests
 	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			MyColors subject = MyColors.Yellow;
+
+			async Task Act()
+				=> await That(subject).Should().Be(null);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(null)
+				              """);
+		}
+
 		[Theory]
 		[InlineData(MyColors.Blue, MyColors.Green)]
 		[InlineData(MyColors.Green, MyColors.Blue)]
@@ -66,6 +83,17 @@ public sealed partial class EnumShould
 				              but found {subject}
 				              at Expect.That(subject).Should().NotBe(unexpected)
 				              """);
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			MyColors subject = MyColors.Yellow;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(null);
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.BeTests.cs
@@ -4,6 +4,68 @@ public sealed partial class EnumShould
 {
 	public sealed class BeTests
 	{
+		[Theory]
+		[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
+		public async Task ForLong_WhenSubjectIsDifferent_ShouldFail(EnumLong subject,
+			EnumLong expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(EnumLong.Int64Max)]
+		[InlineData(EnumLong.Int64LessOne)]
+		public async Task ForLong_WhenSubjectTheSame_ShouldSucceed(EnumLong subject)
+		{
+			EnumLong expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne)]
+		[InlineData(EnumULong.UInt64Max, EnumULong.Int64Max)]
+		public async Task ForULong_WhenSubjectIsDifferent_ShouldFail(EnumULong subject,
+			EnumULong expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(EnumULong.Int64Max)]
+		[InlineData(EnumULong.UInt64LessOne)]
+		[InlineData(EnumULong.UInt64Max)]
+		public async Task ForULong_WhenSubjectTheSame_ShouldSucceed(EnumULong subject)
+		{
+			EnumULong expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
 		[Fact]
 		public async Task WhenExpectedIsNull_ShouldFail()
 		{
@@ -55,6 +117,68 @@ public sealed partial class EnumShould
 	public sealed class NotBeTests
 	{
 		[Theory]
+		[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
+		public async Task ForLong_WhenSubjectIsDifferent_ShouldSucceed(EnumLong subject,
+			EnumLong unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(EnumLong.Int64Max)]
+		[InlineData(EnumLong.Int64LessOne)]
+		public async Task ForLong_WhenSubjectTheSame_ShouldFail(EnumLong subject)
+		{
+			EnumLong unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne)]
+		[InlineData(EnumULong.UInt64Max, EnumULong.Int64Max)]
+		public async Task ForULong_WhenSubjectIsDifferent_ShouldSucceed(EnumULong subject,
+			EnumULong unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(EnumULong.Int64Max)]
+		[InlineData(EnumULong.UInt64LessOne)]
+		[InlineData(EnumULong.UInt64Max)]
+		public async Task ForULong_WhenSubjectTheSame_ShouldFail(EnumULong subject)
+		{
+			EnumULong unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
 		[InlineData(MyColors.Blue, MyColors.Green)]
 		[InlineData(MyColors.Green, MyColors.Blue)]
 		public async Task WhenSubjectIsDifferent_ShouldSucceed(MyColors subject,
@@ -86,7 +210,7 @@ public sealed partial class EnumShould
 		}
 
 		[Fact]
-		public async Task WhenUnexpectedIsNull_ShouldFail()
+		public async Task WhenUnexpectedIsNull_ShouldSucceed()
 		{
 			MyColors subject = MyColors.Yellow;
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveFlagTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveFlagTests.cs
@@ -4,6 +4,23 @@ public sealed partial class EnumShould
 {
 	public sealed class HaveFlagTests
 	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			MyColors subject = MyColors.Yellow;
+
+			async Task Act()
+				=> await That(subject).Should().HaveFlag(null);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              have flag <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().HaveFlag(null)
+				              """);
+		}
+
 		[Theory]
 		[InlineData(MyColors.Blue | MyColors.Red, MyColors.Green)]
 		[InlineData(MyColors.Green | MyColors.Yellow, MyColors.Blue)]
@@ -43,6 +60,69 @@ public sealed partial class EnumShould
 
 			async Task Act()
 				=> await That(subject).Should().HaveFlag(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotHaveFlagTests
+	{
+		[Theory]
+		[InlineData(MyColors.Blue)]
+		[InlineData(MyColors.Green)]
+		public async Task WhenSubjectDoesNotHaveFlag_ShouldSucceed(MyColors unexpected)
+		{
+			MyColors subject = MyColors.Yellow | (MyColors.Red & ~unexpected);
+
+			async Task Act()
+				=> await That(subject).Should().NotHaveFlag(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(MyColors.Blue | MyColors.Green, MyColors.Green)]
+		[InlineData(MyColors.Blue | MyColors.Yellow, MyColors.Blue)]
+		public async Task WhenSubjectHasFlag_ShouldFail(MyColors subject, MyColors unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotHaveFlag(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not have flag {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotHaveFlag(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(MyColors.Blue)]
+		[InlineData(MyColors.Green)]
+		public async Task WhenSubjectIsTheSame_ShouldFail(MyColors subject)
+		{
+			MyColors unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotHaveFlag(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not have flag {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotHaveFlag(unexpected)
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldSucceed()
+		{
+			MyColors subject = MyColors.Yellow;
+
+			async Task Act()
+				=> await That(subject).Should().NotHaveFlag(null);
 
 			await That(Act).Should().NotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveValueTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveValueTests.cs
@@ -4,6 +4,23 @@ public sealed partial class EnumShould
 {
 	public sealed class HaveValueTests
 	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			MyColors subject = MyColors.Yellow;
+
+			async Task Act()
+				=> await That(subject).Should().HaveValue(null);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              have value <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().HaveValue(null)
+				              """);
+		}
+
 		[Theory]
 		[InlineData(MyNumbers.One, 2L)]
 		[InlineData(MyNumbers.Two, -7)]
@@ -34,58 +51,6 @@ public sealed partial class EnumShould
 				=> await That(subject).Should().HaveValue(expected);
 
 			await That(Act).Should().NotThrow();
-		}
-	}
-
-	public sealed class NotHaveFlagTests
-	{
-		[Theory]
-		[InlineData(MyColors.Blue)]
-		[InlineData(MyColors.Green)]
-		public async Task WhenSubjectDoesNotHaveFlag_ShouldSucceed(MyColors unexpected)
-		{
-			MyColors subject = MyColors.Yellow | (MyColors.Red & ~unexpected);
-
-			async Task Act()
-				=> await That(subject).Should().NotHaveFlag(unexpected);
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Theory]
-		[InlineData(MyColors.Blue | MyColors.Green, MyColors.Green)]
-		[InlineData(MyColors.Blue | MyColors.Yellow, MyColors.Blue)]
-		public async Task WhenSubjectHasFlag_ShouldFail(MyColors subject, MyColors unexpected)
-		{
-			async Task Act()
-				=> await That(subject).Should().NotHaveFlag(unexpected);
-
-			await That(Act).Should().Throw<XunitException>()
-				.WithMessage($"""
-				              Expected subject to
-				              not have flag {unexpected},
-				              but found {subject}
-				              at Expect.That(subject).Should().NotHaveFlag(unexpected)
-				              """);
-		}
-
-		[Theory]
-		[InlineData(MyColors.Blue)]
-		[InlineData(MyColors.Green)]
-		public async Task WhenSubjectIsTheSame_ShouldFail(MyColors subject)
-		{
-			MyColors unexpected = subject;
-
-			async Task Act()
-				=> await That(subject).Should().NotHaveFlag(unexpected);
-
-			await That(Act).Should().Throw<XunitException>()
-				.WithMessage($"""
-				              Expected subject to
-				              not have flag {unexpected},
-				              but found {subject}
-				              at Expect.That(subject).Should().NotHaveFlag(unexpected)
-				              """);
 		}
 	}
 
@@ -121,6 +86,17 @@ public sealed partial class EnumShould
 				              but found {subject}
 				              at Expect.That(subject).Should().NotHaveValue(unexpected)
 				              """);
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			MyColors subject = MyColors.Yellow;
+
+			async Task Act()
+				=> await That(subject).Should().NotHaveValue(null);
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveValueTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveValueTests.cs
@@ -89,7 +89,7 @@ public sealed partial class EnumShould
 		}
 
 		[Fact]
-		public async Task WhenUnexpectedIsNull_ShouldFail()
+		public async Task WhenUnexpectedIsNull_ShouldSucceed()
 		{
 			MyColors subject = MyColors.Yellow;
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.cs
@@ -2,6 +2,19 @@
 
 public sealed partial class EnumShould
 {
+	public enum EnumLong : long
+	{
+		Int64Max = long.MaxValue,
+		Int64LessOne = long.MaxValue - 1
+	}
+
+	public enum EnumULong : ulong
+	{
+		Int64Max = long.MaxValue,
+		UInt64LessOne = ulong.MaxValue - 1,
+		UInt64Max = ulong.MaxValue
+	}
+
 	[Flags]
 	public enum MyColors
 	{

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeTests.cs
@@ -4,6 +4,68 @@ public sealed partial class NullableEnumShould
 {
 	public sealed class BeTests
 	{
+		[Theory]
+		[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
+		public async Task ForLong_WhenSubjectIsDifferent_ShouldFail(EnumLong? subject,
+			EnumLong? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(EnumLong.Int64Max)]
+		[InlineData(EnumLong.Int64LessOne)]
+		public async Task ForLong_WhenSubjectTheSame_ShouldSucceed(EnumLong? subject)
+		{
+			EnumLong? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne)]
+		[InlineData(EnumULong.UInt64Max, EnumULong.Int64Max)]
+		public async Task ForULong_WhenSubjectIsDifferent_ShouldFail(EnumULong? subject,
+			EnumULong? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(EnumULong.Int64Max)]
+		[InlineData(EnumULong.UInt64LessOne)]
+		[InlineData(EnumULong.UInt64Max)]
+		public async Task ForULong_WhenSubjectTheSame_ShouldSucceed(EnumULong? subject)
+		{
+			EnumULong? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
 		[Fact]
 		public async Task WhenExpectedIsNull_ShouldFail()
 		{
@@ -86,6 +148,68 @@ public sealed partial class NullableEnumShould
 
 	public sealed class NotBeTests
 	{
+		[Theory]
+		[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
+		public async Task ForLong_WhenSubjectIsDifferent_ShouldSucceed(EnumLong? subject,
+			EnumLong? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(EnumLong.Int64Max)]
+		[InlineData(EnumLong.Int64LessOne)]
+		public async Task ForLong_WhenSubjectTheSame_ShouldFail(EnumLong? subject)
+		{
+			EnumLong? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne)]
+		[InlineData(EnumULong.UInt64Max, EnumULong.Int64Max)]
+		public async Task ForULong_WhenSubjectIsDifferent_ShouldSucceed(EnumULong? subject,
+			EnumULong? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(EnumULong.Int64Max)]
+		[InlineData(EnumULong.UInt64LessOne)]
+		[InlineData(EnumULong.UInt64Max)]
+		public async Task ForULong_WhenSubjectTheSame_ShouldFail(EnumULong? subject)
+		{
+			EnumULong? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
 		[Fact]
 		public async Task WhenSubjectAndExpectedAreNull_ShouldFail()
 		{
@@ -140,7 +264,7 @@ public sealed partial class NullableEnumShould
 		}
 
 		[Fact]
-		public async Task WhenUnexpectedIsNull_ShouldFail()
+		public async Task WhenUnexpectedIsNull_ShouldSucceed()
 		{
 			MyColors? subject = MyColors.Yellow;
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeTests.cs
@@ -5,6 +5,23 @@ public sealed partial class NullableEnumShould
 	public sealed class BeTests
 	{
 		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			MyColors? subject = MyColors.Yellow;
+
+			async Task Act()
+				=> await That(subject).Should().Be(null);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(null)
+				              """);
+		}
+
+		[Fact]
 		public async Task WhenSubjectAndExpectedAreNull_ShouldSucceed()
 		{
 			MyColors? subject = null;
@@ -120,6 +137,17 @@ public sealed partial class NullableEnumShould
 				              but found {subject?.ToString() ?? "<null>"}
 				              at Expect.That(subject).Should().NotBe(unexpected)
 				              """);
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			MyColors? subject = MyColors.Yellow;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(null);
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveFlagTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveFlagTests.cs
@@ -4,6 +4,34 @@ public sealed partial class NullableEnumShould
 {
 	public sealed class HaveFlagTests
 	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			MyColors? subject = MyColors.Yellow;
+
+			async Task Act()
+				=> await That(subject).Should().HaveFlag(null);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              have flag <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().HaveFlag(null)
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedIsNull_ShouldSucceed()
+		{
+			MyColors? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().HaveFlag(null);
+
+			await That(Act).Should().NotThrow();
+		}
+
 		[Theory]
 		[InlineData(MyColors.Blue | MyColors.Red, MyColors.Green)]
 		[InlineData(MyColors.Green | MyColors.Yellow, MyColors.Blue)]
@@ -51,6 +79,23 @@ public sealed partial class NullableEnumShould
 
 	public sealed class NotHaveFlagTests
 	{
+		[Fact]
+		public async Task WhenSubjectAndUnexpectedIsNull_ShouldFail()
+		{
+			MyColors? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotHaveFlag(null);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not have flag <null>,
+				             but found <null>
+				             at Expect.That(subject).Should().NotHaveFlag(null)
+				             """);
+		}
+
 		[Theory]
 		[InlineData(MyColors.Blue)]
 		[InlineData(MyColors.Green)]
@@ -98,6 +143,17 @@ public sealed partial class NullableEnumShould
 				              but found {subject}
 				              at Expect.That(subject).Should().NotHaveFlag(unexpected)
 				              """);
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldSucceed()
+		{
+			MyColors? subject = MyColors.Yellow;
+
+			async Task Act()
+				=> await That(subject).Should().NotHaveFlag(null);
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveValueTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveValueTests.cs
@@ -4,12 +4,29 @@ public sealed partial class NullableEnumShould
 {
 	public sealed class HaveValueTests
 	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			MyColors? subject = MyColors.Yellow;
+
+			async Task Act()
+				=> await That(subject).Should().HaveValue(null);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              have value <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().HaveValue(null)
+				              """);
+		}
+
 		[Theory]
 		[InlineData(MyNumbers.One, 2L)]
-		[InlineData(MyNumbers.Two, -7)]
-		[InlineData(MyNumbers.Three, 0)]
+		[InlineData(MyNumbers.Two, -7L)]
+		[InlineData(MyNumbers.Three, 0L)]
 		public async Task WhenSubjectDoesNotHaveExpectedValue_ShouldFail(MyNumbers? subject,
-			long expected)
+			long? expected)
 		{
 			async Task Act()
 				=> await That(subject).Should().HaveValue(expected);
@@ -24,11 +41,11 @@ public sealed partial class NullableEnumShould
 		}
 
 		[Theory]
-		[InlineData(MyNumbers.One, 1)]
-		[InlineData(MyNumbers.Two, 2)]
-		[InlineData(MyNumbers.Three, 3)]
+		[InlineData(MyNumbers.One, 1L)]
+		[InlineData(MyNumbers.Two, 2L)]
+		[InlineData(MyNumbers.Three, 3L)]
 		public async Task WhenSubjectHasExpectedValue_ShouldSucceed(MyNumbers? subject,
-			long expected)
+			long? expected)
 		{
 			async Task Act()
 				=> await That(subject).Should().HaveValue(expected);
@@ -41,10 +58,10 @@ public sealed partial class NullableEnumShould
 	{
 		[Theory]
 		[InlineData(MyNumbers.One, 2L)]
-		[InlineData(MyNumbers.Two, -7)]
-		[InlineData(MyNumbers.Three, 0)]
+		[InlineData(MyNumbers.Two, -7L)]
+		[InlineData(MyNumbers.Three, 0L)]
 		public async Task WhenSubjectDoesNotHaveUnexpectedValue_ShouldSucceed(MyNumbers? subject,
-			long unexpected)
+			long? unexpected)
 		{
 			async Task Act()
 				=> await That(subject).Should().NotHaveValue(unexpected);
@@ -53,11 +70,11 @@ public sealed partial class NullableEnumShould
 		}
 
 		[Theory]
-		[InlineData(MyNumbers.One, 1)]
-		[InlineData(MyNumbers.Two, 2)]
-		[InlineData(MyNumbers.Three, 3)]
+		[InlineData(MyNumbers.One, 1L)]
+		[InlineData(MyNumbers.Two, 2L)]
+		[InlineData(MyNumbers.Three, 3L)]
 		public async Task WhenSubjectHasUnexpectedValue_ShouldFail(MyNumbers? subject,
-			long unexpected)
+			long? unexpected)
 		{
 			async Task Act()
 				=> await That(subject).Should().NotHaveValue(unexpected);
@@ -69,6 +86,17 @@ public sealed partial class NullableEnumShould
 				              but found {subject}
 				              at Expect.That(subject).Should().NotHaveValue(unexpected)
 				              """);
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			MyColors? subject = MyColors.Yellow;
+
+			async Task Act()
+				=> await That(subject).Should().NotHaveValue(null);
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveValueTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveValueTests.cs
@@ -89,7 +89,7 @@ public sealed partial class NullableEnumShould
 		}
 
 		[Fact]
-		public async Task WhenUnexpectedIsNull_ShouldFail()
+		public async Task WhenUnexpectedIsNull_ShouldSucceed()
 		{
 			MyColors? subject = MyColors.Yellow;
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.cs
@@ -2,6 +2,19 @@
 
 public sealed partial class NullableEnumShould
 {
+	public enum EnumLong : long
+	{
+		Int64Max = long.MaxValue,
+		Int64LessOne = long.MaxValue - 1
+	}
+
+	public enum EnumULong : ulong
+	{
+		Int64Max = long.MaxValue,
+		UInt64LessOne = ulong.MaxValue - 1,
+		UInt64Max = ulong.MaxValue
+	}
+
 	[Flags]
 	public enum MyColors
 	{


### PR DESCRIPTION
Fix nullability for enum expectations to allow `null` as expected/unexpected value.