### PR TITLE
fix: Ignore `InnerException` of `AggregateException`

### DIFF
--- a/Source/Testably.Expectations/Core/Helpers/ExceptionHelpers.cs
+++ b/Source/Testably.Expectations/Core/Helpers/ExceptionHelpers.cs
@@ -15,32 +15,31 @@ internal static class ExceptionHelpers
 
 		return message;
 	}
-	
-	
+
 	public static IEnumerable<Exception> GetInnerExpectations(this Exception? actual)
 	{
 		if (actual == null)
 		{
 			yield break;
 		}
-		if (actual.InnerException != null)
-		{
-			yield return actual.InnerException;
-			foreach (var inner in GetInnerExpectations(actual.InnerException))
-			{
-				yield return inner;
-			}
-		}
 
 		if (actual is AggregateException aggregateException)
 		{
-			foreach (var innerException in aggregateException.InnerExceptions)
+			foreach (Exception? innerException in aggregateException.InnerExceptions)
 			{
 				yield return innerException;
-				foreach (var inner in GetInnerExpectations(innerException))
+				foreach (Exception? inner in GetInnerExpectations(innerException))
 				{
 					yield return inner;
 				}
+			}
+		}
+		else if (actual.InnerException != null)
+		{
+			yield return actual.InnerException;
+			foreach (Exception? inner in GetInnerExpectations(actual.InnerException))
+			{
+				yield return inner;
 			}
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.NotThrowTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.NotThrowTests.cs
@@ -5,37 +5,7 @@ public sealed partial class DelegateShould
 	public sealed class NotThrowTests
 	{
 		[Fact]
-		public async Task Fails_For_Code_With_Exceptions()
-		{
-			string expectedMessage = $"""
-			                          Expected action to
-			                          not throw any exception,
-			                          but it did throw a CustomException:
-			                            {nameof(Fails_For_Code_With_Exceptions)}
-			                          at Expect.That(action).Should().NotThrow()
-			                          """;
-			Exception exception = CreateCustomException();
-			Action action = () => throw exception;
-
-			async Task Act()
-				=> await That(action).Should().NotThrow();
-
-			await That(Act).Should().ThrowException()
-				.WithMessage(expectedMessage);
-		}
-
-		[Fact]
-		public async Task Returns_Awaited_Result()
-		{
-			int value = 42;
-			Func<int> action = () => value;
-
-			int result = await That(action).Should().NotThrow();
-			await That(result).Should().Be(value);
-		}
-
-		[Fact]
-		public async Task Succeeds_For_Code_Without_Exceptions()
+		public async Task WhenActionDoesNotThrow_ShouldSucceed()
 		{
 			Action action = () => { };
 
@@ -43,6 +13,36 @@ public sealed partial class DelegateShould
 				=> await That(action).Should().NotThrow();
 
 			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActionThrows_ShouldFail()
+		{
+			Exception exception = new CustomException(nameof(WhenActionThrows_ShouldFail));
+			Action action = () => throw exception;
+
+			async Task Act()
+				=> await That(action).Should().NotThrow();
+
+			await That(Act).Should().ThrowException()
+				.WithMessage($"""
+				              Expected action to
+				              not throw any exception,
+				              but it did throw a CustomException:
+				                {nameof(WhenActionThrows_ShouldFail)}
+				              at Expect.That(action).Should().NotThrow()
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenAwaited_ShouldReturnResultFromDelegate(int value)
+		{
+			Func<int> action = () => value;
+
+			int result = await That(action).Should().NotThrow();
+
+			await That(result).Should().Be(value);
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.OnlyIfTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.OnlyIfTests.cs
@@ -38,7 +38,7 @@ public sealed partial class DelegateShould
 		[Fact]
 		public async Task WhenAwaited_OnlyIfTrue_ShouldReturnThrownException()
 		{
-			Exception exception = CreateCustomException();
+			Exception exception = new CustomException();
 			Action action = () => throw exception;
 
 			CustomException? result =

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowExactlyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowExactlyTests.cs
@@ -4,80 +4,24 @@ public sealed partial class DelegateShould
 {
 	public sealed class ThrowExactlyTests
 	{
-		[Fact]
-		public async Task Fails_For_Code_With_Other_Exceptions()
+		[Theory]
+		[AutoData]
+		public async Task WhenAwaited_ShouldReturnThrownException(string value)
 		{
-			string expectedMessage = $"""
-			                          Expected action to
-			                          throw exactly a CustomException,
-			                          but it did throw an OtherException:
-			                            {nameof(Fails_For_Code_With_Other_Exceptions)}
-			                          at Expect.That(action).Should().ThrowExactly<CustomException>()
-			                          """;
-			Exception exception = CreateOtherException();
-			Action action = () => throw exception;
-
-			async Task<CustomException> Act()
-				=> await That(action).Should().ThrowExactly<CustomException>();
-
-			await That(Act).Should().ThrowException()
-				.WithMessage(expectedMessage);
-		}
-
-		[Fact]
-		public async Task Fails_For_Code_With_Subtype_Exceptions()
-		{
-			string expectedMessage = $"""
-			                          Expected action to
-			                          throw exactly a CustomException,
-			                          but it did throw a SubCustomException:
-			                            {nameof(Fails_For_Code_With_Subtype_Exceptions)}
-			                          at Expect.That(action).Should().ThrowExactly<CustomException>()
-			                          """;
-			Exception exception = CreateSubCustomException();
-			Action action = () => throw exception;
-
-			async Task<CustomException> Act()
-				=> await That(action).Should().ThrowExactly<CustomException>();
-
-			await That(Act).Should().ThrowException()
-				.WithMessage(expectedMessage);
-		}
-
-		[Fact]
-		public async Task Fails_For_Code_Without_Exceptions()
-		{
-			string expectedMessage = """
-			                         Expected action to
-			                         throw exactly a CustomException,
-			                         but it did not
-			                         at Expect.That(action).Should().ThrowExactly<CustomException>()
-			                         """;
-			Action action = () => { };
-
-			async Task<CustomException> Act()
-				=> await That(action).Should().ThrowExactly<CustomException>();
-
-			await That(Act).Should().ThrowException()
-				.WithMessage(expectedMessage);
-		}
-
-		[Fact]
-		public async Task Returns_Exception_When_Awaited()
-		{
-			Exception exception = CreateCustomException();
+			Exception exception = new CustomException { Value = value };
 			Action action = () => throw exception;
 
 			CustomException result =
 				await That(action).Should().ThrowExactly<CustomException>();
 
+			await That(result.Value).Should().Be(value);
 			await That(result).Should().BeSameAs(exception);
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Code_With_Correct_Exception()
+		public async Task WhenCorrectExceptionTypeIsThrown_ShouldSucceed()
 		{
-			Exception exception = CreateCustomException();
+			Exception exception = new CustomException();
 			Action action = () => throw exception;
 
 			async Task<CustomException> Act()
@@ -87,15 +31,60 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
-		public async Task WhenAwaited_ShouldReturnThrownException()
+		public async Task WhenNoExceptionIsThrown_ShouldFail()
 		{
-			Exception exception = CreateCustomException();
+			Action action = () => { };
+
+			async Task<CustomException> Act()
+				=> await That(action).Should().ThrowExactly<CustomException>();
+
+			await That(Act).Should().ThrowException()
+				.WithMessage("""
+				             Expected action to
+				             throw exactly a CustomException,
+				             but it did not
+				             at Expect.That(action).Should().ThrowExactly<CustomException>()
+				             """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenOtherExceptionIsThrown_ShouldFail(string message)
+		{
+			Exception exception = new OtherException(message);
 			Action action = () => throw exception;
 
-			CustomException result =
-				await That(action).Should().ThrowExactly<CustomException>();
+			async Task<CustomException> Act()
+				=> await That(action).Should().ThrowExactly<CustomException>();
 
-			await That(result).Should().BeSameAs(exception);
+			await That(Act).Should().ThrowException()
+				.WithMessage($"""
+				              Expected action to
+				              throw exactly a CustomException,
+				              but it did throw an OtherException:
+				                {message}
+				              at Expect.That(action).Should().ThrowExactly<CustomException>()
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenSubCustomExceptionIsThrown_ShouldFail(string message)
+		{
+			Exception exception = new SubCustomException(message);
+			Action action = () => throw exception;
+
+			async Task<CustomException> Act()
+				=> await That(action).Should().ThrowExactly<CustomException>();
+
+			await That(Act).Should().ThrowException()
+				.WithMessage($"""
+				              Expected action to
+				              throw exactly a CustomException,
+				              but it did throw a SubCustomException:
+				                {message}
+				              at Expect.That(action).Should().ThrowExactly<CustomException>()
+				              """);
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowExceptionTests.cs
@@ -5,27 +5,9 @@ public sealed partial class DelegateShould
 	public sealed class ThrowExceptionTests
 	{
 		[Fact]
-		public async Task Fails_For_Code_Without_Exceptions()
+		public async Task WhenAwaited_ShouldReturnThrownException()
 		{
-			string expectedMessage = """
-			                         Expected action to
-			                         throw an Exception,
-			                         but it did not
-			                         at Expect.That(action).Should().ThrowException()
-			                         """;
-			Action action = () => { };
-
-			async Task<Exception> Act()
-				=> await That(action).Should().ThrowException();
-
-			await That(Act).Should().ThrowException()
-				.WithMessage(expectedMessage);
-		}
-
-		[Fact]
-		public async Task Returns_Exception_When_Awaited()
-		{
-			Exception exception = CreateCustomException();
+			Exception exception = new CustomException();
 			Action action = () => throw exception;
 
 			Exception result = await That(action).Should().ThrowException();
@@ -34,9 +16,9 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
-		public async Task Succeeds_For_Code_With_Exceptions()
+		public async Task WhenExceptionIsThrown_ShouldSucceed()
 		{
-			Exception exception = CreateCustomException();
+			Exception exception = new CustomException();
 			Action action = () => throw exception;
 
 			async Task<Exception> Act()
@@ -46,14 +28,20 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
-		public async Task WhenAwaited_ShouldReturnThrownException()
+		public async Task WhenNoExceptionIsThrown_ShouldFail()
 		{
-			Exception exception = CreateCustomException();
-			Action action = () => throw exception;
+			Action action = () => { };
 
-			Exception result = await That(action).Should().ThrowException();
+			async Task<Exception> Act()
+				=> await That(action).Should().ThrowException();
 
-			await That(result).Should().BeSameAs(exception);
+			await That(Act).Should().ThrowException()
+				.WithMessage("""
+				             Expected action to
+				             throw an Exception,
+				             but it did not
+				             at Expect.That(action).Should().ThrowException()
+				             """);
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.cs
@@ -4,50 +4,21 @@ namespace Testably.Expectations.Tests.ThatTests.Delegates;
 
 public sealed partial class DelegateShould
 {
-	private static CustomException CreateCustomException(
+	private class CustomException(
 		[CallerMemberName] string message = "",
 		Exception? innerException = null)
+		: Exception(message, innerException)
 	{
-		return new CustomException(message, innerException);
+		public string? Value { get; set; }
 	}
 
-	private static OtherException CreateOtherException(
+	private class SubCustomException(
 		[CallerMemberName] string message = "",
 		Exception? innerException = null)
-	{
-		return new OtherException(message, innerException);
-	}
+		: CustomException(message, innerException);
 
-	private static SubCustomException CreateSubCustomException(
+	private class OtherException(
 		[CallerMemberName] string message = "",
 		Exception? innerException = null)
-	{
-		return new SubCustomException(message, innerException);
-	}
-
-	private class CustomException : Exception
-	{
-		public string Value => "Foo!";
-
-		public CustomException(string message, Exception? innerException = null)
-			: base(message, innerException)
-		{
-		}
-	}
-
-	private class SubCustomException : CustomException
-	{
-		public SubCustomException(string message, Exception? innerException = null)
-			: base(message, innerException)
-		{
-		}
-	}
-
-	private class OtherException : Exception
-	{
-		public OtherException(string message, Exception? innerException = null)
-			: base(message, innerException)
-		{
-		}
-	}
+		: Exception(message, innerException);
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithInnerExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithInnerExceptionTests.cs
@@ -7,7 +7,7 @@ public sealed partial class DelegateThrows
 		[Fact]
 		public async Task WhenAwaited_WithExpectations_ShouldReturnThrownException()
 		{
-			Exception exception = new("outer", new Exception("inner"));
+			Exception exception = new OuterException(innerException: new Exception("inner"));
 
 			Exception result = await That(() => throw exception)
 				.Should().ThrowException().WithInnerException(
@@ -19,7 +19,7 @@ public sealed partial class DelegateThrows
 		[Fact]
 		public async Task WhenAwaited_WithoutExpectations_ShouldReturnThrownException()
 		{
-			Exception exception = new("outer", new Exception("inner"));
+			Exception exception = new OuterException(innerException: new Exception("inner"));
 
 			Exception result = await That(() => throw exception)
 				.Should().ThrowException().WithInnerException();
@@ -30,7 +30,7 @@ public sealed partial class DelegateThrows
 		[Fact]
 		public async Task WhenInnerExceptionIsPresent_ShouldSucceed()
 		{
-			Action action = () => throw new Exception("outer", new Exception("inner"));
+			Action action = () => throw new OuterException(innerException: new Exception());
 
 			async Task Act()
 				=> await That(action).Should().ThrowException().WithInnerException();
@@ -41,8 +41,7 @@ public sealed partial class DelegateThrows
 		[Fact]
 		public async Task WhenNoInnerExceptionIsPresent_ShouldFail()
 		{
-			string actual = "actual text";
-			Action action = () => throw new Exception(actual);
+			Action action = () => throw new OuterException();
 
 			async Task Act()
 				=> await That(action).Should().ThrowException().WithInnerException();

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithRecursiveInnerExceptionsTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithRecursiveInnerExceptionsTests.cs
@@ -4,10 +4,36 @@ public sealed partial class DelegateThrows
 {
 	public sealed class WithRecursiveInnerExceptionsTests
 	{
+		[Theory]
+		[InlineData(1, false)]
+		[InlineData(2, true)]
+		public async Task WhenAnyInnerExceptionDoesMatch_ShouldSucceed(int minimum,
+			bool shouldThrow)
+		{
+			Action action = () => throw new OuterException(
+				innerException: new OtherException(
+					innerException: new AggregateException(
+						new OtherException(),
+						new OtherException(
+							innerException: new CustomException()))));
+
+			async Task Act()
+				=> await That(action).Should().ThrowException().WithRecursiveInnerExceptions(
+					e => e.AtLeast(minimum).Be<CustomException>());
+
+			await That(Act).Should().Throw<XunitException>().OnlyIf(shouldThrow)
+				.WithMessage($"""
+				              Expected action to
+				              throw an Exception with recursive inner exceptions which have at least {minimum} items of type CustomException,
+				              but only 1 of 5 items were
+				              at Expect.That(action).Should().ThrowException().WithRecursiveInnerExceptions(e => e.AtLeast(minimum).Be<CustomException>())
+				              """);
+		}
+
 		[Fact]
 		public async Task WhenAwaited_WithExpectations_ShouldReturnThrownException()
 		{
-			Exception exception = new("outer", new Exception("inner"));
+			Exception exception = new OuterException(innerException: new CustomException());
 
 			Exception? result = await That(() => throw exception)
 				.Should().ThrowException().WithRecursiveInnerExceptions(
@@ -19,7 +45,7 @@ public sealed partial class DelegateThrows
 		[Fact]
 		public async Task WhenInnerExceptionDoesNotMatch_ShouldFail()
 		{
-			Action action = () => throw new Exception("", new Exception("inner"));
+			Action action = () => throw new OuterException(innerException: new CustomException());
 
 			async Task Act()
 				=> await That(action).Should().ThrowException().WithRecursiveInnerExceptions(
@@ -37,7 +63,7 @@ public sealed partial class DelegateThrows
 		[Fact]
 		public async Task WhenNoInnerExceptionIsPresent_ShouldNotFailDirectly()
 		{
-			Action action = () => throw new Exception();
+			Action action = () => throw new OuterException();
 
 			async Task Act()
 				=> await That(action).Should().ThrowException().WithRecursiveInnerExceptions(


### PR DESCRIPTION
Ignore `InnerException` of `AggregateException`, as it would otherwise be included twice.

Also add more tests for delegate expectations.