### PR TITLE
fix: incorrect implementation of `BeEmpty` for `IAsyncEnumerable`

### DIFF
--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AllTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AllTests.cs
@@ -1,0 +1,52 @@
+﻿#if NET6_0_OR_GREATER
+using System.Collections.Generic;
+using Testably.Expectations.Tests.TestHelpers;
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace Testably.Expectations.Tests.ThatTests.Collections;
+
+public sealed partial class AsyncEnumerableShould
+{
+	public sealed class AllTests
+	{
+		[Fact]
+		public async Task WhenEnumerableContainsDifferentValues_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().All().Be(1);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have all items equal to 1,
+				             but not all items were equal
+				             at Expect.That(subject).Should().All().Be(1)
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenEnumerableIsEmpty_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+
+			async Task Act()
+				=> await That(subject).Should().All().Be(0);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenEnumerableOnlyContainsEqualValues_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 1, 1, 1]);
+
+			async Task Act()
+				=> await That(subject).Should().All().Be(1);
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BeEmptyTests.cs
@@ -1,0 +1,71 @@
+﻿#if NET6_0_OR_GREATER
+using System.Collections.Generic;
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace Testably.Expectations.Tests.ThatTests.Collections;
+
+public sealed partial class AsyncEnumerableShould
+{
+	public sealed class BeEmptyTests
+	{
+		[Fact]
+		public async Task WhenEnumerableContainsValues_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 2]);
+
+			async Task Act()
+				=> await That(subject).Should().BeEmpty();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be empty,
+				             but found [1, 1, 2]
+				             at Expect.That(subject).Should().BeEmpty()
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenEnumerableIsEmpty_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+
+			async Task Act()
+				=> await That(subject).Should().BeEmpty();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeEmptyTests
+	{
+		[Fact]
+		public async Task WhenEnumerableContainsValues_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 2]);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeEmpty();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenEnumerableIsEmpty_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeEmpty();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be empty,
+				             but it was
+				             at Expect.That(subject).Should().NotBeEmpty()
+				             """);
+		}
+	}
+}
+#endif


### PR DESCRIPTION
BeEmpty was incorrectly copied from `IEnumerable` without adjusting the types