### PR TITLE
fix: disable `nint` and `nuint` as they can't be used as generic type arguments

### DIFF
--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 // ReSharper disable once CheckNamespace
@@ -36,34 +35,6 @@ public static partial class ThatNumberShould
 	///     Start expectations for the current <see cref="uint" /> <paramref name="subject" />.
 	/// </summary>
 	public static IThat<uint?> Should(this IExpectSubject<uint?> subject)
-		=> subject.Should(expectationBuilder => expectationBuilder
-			.AppendMethodStatement(nameof(Should)));
-
-	/// <summary>
-	///     Start expectations for the current <see langword="nint" /> <paramref name="subject" />.
-	/// </summary>
-	public static IThat<nint> Should(this IExpectSubject<nint> subject)
-		=> subject.Should(expectationBuilder => expectationBuilder
-			.AppendMethodStatement(nameof(Should)));
-
-	/// <summary>
-	///     Start expectations for the current <see langword="nint" /> <paramref name="subject" />.
-	/// </summary>
-	public static IThat<nint?> Should(this IExpectSubject<nint?> subject)
-		=> subject.Should(expectationBuilder => expectationBuilder
-			.AppendMethodStatement(nameof(Should)));
-
-	/// <summary>
-	///     Start expectations for the current <see langword="nuint" /> <paramref name="subject" />.
-	/// </summary>
-	public static IThat<nuint> Should(this IExpectSubject<nuint> subject)
-		=> subject.Should(expectationBuilder => expectationBuilder
-			.AppendMethodStatement(nameof(Should)));
-
-	/// <summary>
-	///     Start expectations for the current <see langword="nuint" /> <paramref name="subject" />.
-	/// </summary>
-	public static IThat<nuint?> Should(this IExpectSubject<nuint?> subject)
 		=> subject.Should(expectationBuilder => expectationBuilder
 			.AppendMethodStatement(nameof(Should)));
 
@@ -192,8 +163,7 @@ public static partial class ThatNumberShould
 	public static IThat<decimal?> Should(this IExpectSubject<decimal?> subject)
 		=> subject.Should(expectationBuilder => expectationBuilder
 			.AppendMethodStatement(nameof(Should)));
-	
-	
+
 	private readonly struct GenericConstraint<T>(
 		T expected,
 		string expectation,
@@ -208,7 +178,8 @@ public static partial class ThatNumberShould
 				return new ConstraintResult.Success<T>(actual, ToString());
 			}
 
-			return new ConstraintResult.Failure(ToString(), failureMessageFactory(actual, expected));
+			return new ConstraintResult.Failure(ToString(),
+				failureMessageFactory(actual, expected));
 		}
 
 		public override string ToString()

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -348,15 +348,11 @@ namespace Testably.Expectations
         public static Testably.Expectations.Core.IThat<short> Should(this Testably.Expectations.Core.IExpectSubject<short> subject) { }
         public static Testably.Expectations.Core.IThat<int> Should(this Testably.Expectations.Core.IExpectSubject<int> subject) { }
         public static Testably.Expectations.Core.IThat<long> Should(this Testably.Expectations.Core.IExpectSubject<long> subject) { }
-        public static Testably.Expectations.Core.IThat<System.IntPtr> Should(this Testably.Expectations.Core.IExpectSubject<System.IntPtr> subject) { }
-        public static Testably.Expectations.Core.IThat<System.IntPtr?> Should(this Testably.Expectations.Core.IExpectSubject<System.IntPtr?> subject) { }
         public static Testably.Expectations.Core.IThat<sbyte> Should(this Testably.Expectations.Core.IExpectSubject<sbyte> subject) { }
         public static Testably.Expectations.Core.IThat<float> Should(this Testably.Expectations.Core.IExpectSubject<float> subject) { }
         public static Testably.Expectations.Core.IThat<ushort> Should(this Testably.Expectations.Core.IExpectSubject<ushort> subject) { }
         public static Testably.Expectations.Core.IThat<uint> Should(this Testably.Expectations.Core.IExpectSubject<uint> subject) { }
         public static Testably.Expectations.Core.IThat<ulong> Should(this Testably.Expectations.Core.IExpectSubject<ulong> subject) { }
-        public static Testably.Expectations.Core.IThat<System.UIntPtr> Should(this Testably.Expectations.Core.IExpectSubject<System.UIntPtr> subject) { }
-        public static Testably.Expectations.Core.IThat<System.UIntPtr?> Should(this Testably.Expectations.Core.IExpectSubject<System.UIntPtr?> subject) { }
         public static Testably.Expectations.Core.IThat<byte?> Should(this Testably.Expectations.Core.IExpectSubject<byte?> subject) { }
         public static Testably.Expectations.Core.IThat<decimal?> Should(this Testably.Expectations.Core.IExpectSubject<decimal?> subject) { }
         public static Testably.Expectations.Core.IThat<double?> Should(this Testably.Expectations.Core.IExpectSubject<double?> subject) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -348,15 +348,11 @@ namespace Testably.Expectations
         public static Testably.Expectations.Core.IThat<short> Should(this Testably.Expectations.Core.IExpectSubject<short> subject) { }
         public static Testably.Expectations.Core.IThat<int> Should(this Testably.Expectations.Core.IExpectSubject<int> subject) { }
         public static Testably.Expectations.Core.IThat<long> Should(this Testably.Expectations.Core.IExpectSubject<long> subject) { }
-        public static Testably.Expectations.Core.IThat<System.IntPtr> Should(this Testably.Expectations.Core.IExpectSubject<System.IntPtr> subject) { }
-        public static Testably.Expectations.Core.IThat<System.IntPtr?> Should(this Testably.Expectations.Core.IExpectSubject<System.IntPtr?> subject) { }
         public static Testably.Expectations.Core.IThat<sbyte> Should(this Testably.Expectations.Core.IExpectSubject<sbyte> subject) { }
         public static Testably.Expectations.Core.IThat<float> Should(this Testably.Expectations.Core.IExpectSubject<float> subject) { }
         public static Testably.Expectations.Core.IThat<ushort> Should(this Testably.Expectations.Core.IExpectSubject<ushort> subject) { }
         public static Testably.Expectations.Core.IThat<uint> Should(this Testably.Expectations.Core.IExpectSubject<uint> subject) { }
         public static Testably.Expectations.Core.IThat<ulong> Should(this Testably.Expectations.Core.IExpectSubject<ulong> subject) { }
-        public static Testably.Expectations.Core.IThat<System.UIntPtr> Should(this Testably.Expectations.Core.IExpectSubject<System.UIntPtr> subject) { }
-        public static Testably.Expectations.Core.IThat<System.UIntPtr?> Should(this Testably.Expectations.Core.IExpectSubject<System.UIntPtr?> subject) { }
         public static Testably.Expectations.Core.IThat<byte?> Should(this Testably.Expectations.Core.IExpectSubject<byte?> subject) { }
         public static Testably.Expectations.Core.IThat<decimal?> Should(this Testably.Expectations.Core.IExpectSubject<decimal?> subject) { }
         public static Testably.Expectations.Core.IThat<double?> Should(this Testably.Expectations.Core.IExpectSubject<double?> subject) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -302,15 +302,11 @@ namespace Testably.Expectations
         public static Testably.Expectations.Core.IThat<short> Should(this Testably.Expectations.Core.IExpectSubject<short> subject) { }
         public static Testably.Expectations.Core.IThat<int> Should(this Testably.Expectations.Core.IExpectSubject<int> subject) { }
         public static Testably.Expectations.Core.IThat<long> Should(this Testably.Expectations.Core.IExpectSubject<long> subject) { }
-        public static Testably.Expectations.Core.IThat<System.IntPtr> Should(this Testably.Expectations.Core.IExpectSubject<System.IntPtr> subject) { }
-        public static Testably.Expectations.Core.IThat<System.IntPtr?> Should(this Testably.Expectations.Core.IExpectSubject<System.IntPtr?> subject) { }
         public static Testably.Expectations.Core.IThat<sbyte> Should(this Testably.Expectations.Core.IExpectSubject<sbyte> subject) { }
         public static Testably.Expectations.Core.IThat<float> Should(this Testably.Expectations.Core.IExpectSubject<float> subject) { }
         public static Testably.Expectations.Core.IThat<ushort> Should(this Testably.Expectations.Core.IExpectSubject<ushort> subject) { }
         public static Testably.Expectations.Core.IThat<uint> Should(this Testably.Expectations.Core.IExpectSubject<uint> subject) { }
         public static Testably.Expectations.Core.IThat<ulong> Should(this Testably.Expectations.Core.IExpectSubject<ulong> subject) { }
-        public static Testably.Expectations.Core.IThat<System.UIntPtr> Should(this Testably.Expectations.Core.IExpectSubject<System.UIntPtr> subject) { }
-        public static Testably.Expectations.Core.IThat<System.UIntPtr?> Should(this Testably.Expectations.Core.IExpectSubject<System.UIntPtr?> subject) { }
         public static Testably.Expectations.Core.IThat<byte?> Should(this Testably.Expectations.Core.IExpectSubject<byte?> subject) { }
         public static Testably.Expectations.Core.IThat<decimal?> Should(this Testably.Expectations.Core.IExpectSubject<decimal?> subject) { }
         public static Testably.Expectations.Core.IThat<double?> Should(this Testably.Expectations.Core.IExpectSubject<double?> subject) { }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.cs
@@ -1,5 +1,185 @@
-﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
+﻿using System.Globalization;
+
+namespace Testably.Expectations.Tests.ThatTests.Numbers;
 
 public sealed partial class NumberShould
 {
+	public class ShouldTests
+	{
+		[Theory]
+		[AutoData]
+		public async Task ShouldSupportValues_byte(byte subject, byte expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSupportValues_decimal(decimal subject, decimal expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSupportValues_double(double subject, double expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSupportValues_float(float subject, float expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSupportValues_int(int subject, int expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSupportValues_long(long subject, long expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSupportValues_sbyte(sbyte subject, sbyte expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSupportValues_short(short subject, short expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSupportValues_uint(uint subject, uint expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSupportValues_ulong(ulong subject, ulong expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ShouldSupportValues_ushort(ushort subject, ushort expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+	}
 }


### PR DESCRIPTION
#66 