### PR TITLE
feat: add tolerance for numbers

### DIFF
--- a/Source/Testably.Expectations/Options/NumberTolerance.cs
+++ b/Source/Testably.Expectations/Options/NumberTolerance.cs
@@ -16,7 +16,7 @@ public class NumberTolerance<TNumber>(
 	public TNumber? Tolerance { get; private set; }
 
 	/// <summary>
-	///     Sets the tolerance to apply on the time comparisons.
+	///     Sets the tolerance to apply on the number comparisons.
 	/// </summary>
 	public void SetTolerance(TNumber tolerance)
 	{

--- a/Source/Testably.Expectations/Options/NumberTolerance.cs
+++ b/Source/Testably.Expectations/Options/NumberTolerance.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Testably.Expectations.Formatting;
+
+namespace Testably.Expectations.Options;
+
+/// <summary>
+///     Tolerance for number comparisons.
+/// </summary>
+public class NumberTolerance<TNumber>
+	where TNumber : struct, IComparable<TNumber>
+{
+	/// <summary>
+	///     The tolerance to apply on the number comparisons.
+	/// </summary>
+	public TNumber? Tolerance { get; private set; }
+
+	/// <summary>
+	///     Sets the tolerance to apply on the time comparisons.
+	/// </summary>
+	public NumberTolerance<TNumber> SetTolerance(TNumber tolerance)
+	{
+		Tolerance = tolerance;
+		return this;
+	}
+
+	/// <inheritdoc />
+	public override string ToString()
+	{
+		if (Tolerance == null)
+		{
+			return "";
+		}
+
+		const char plusMinus = '\u00b1';
+		return $" {plusMinus} {Formatter.Format(Tolerance.Value)}";
+	}
+
+	internal bool IsWithinTolerance(TNumber actual, TNumber? expected)
+	{
+		if (expected == null)
+		{
+			return false;
+		}
+
+		if (actual is int actualInt &&
+		    expected is int expectedInt &&
+		    Tolerance is int toleranceInt)
+		{
+			return Math.Abs(actualInt - expectedInt) <= toleranceInt;
+		}
+
+		if (actual is uint actualUint &&
+		    expected is uint expectedUint &&
+		    Tolerance is uint toleranceUint)
+		{
+			uint difference = actualUint > expectedUint
+				? actualUint - expectedUint
+				: expectedUint - actualUint;
+			return difference <= toleranceUint;
+		}
+
+		return expected.Value.CompareTo(actual) == 0;
+	}
+}

--- a/Source/Testably.Expectations/Options/TimeTolerance.cs
+++ b/Source/Testably.Expectations/Options/TimeTolerance.cs
@@ -16,10 +16,15 @@ public class TimeTolerance
 	/// <summary>
 	///     Sets the tolerance to apply on the time comparisons.
 	/// </summary>
-	public TimeTolerance SetTolerance(TimeSpan tolerance)
+	public void SetTolerance(TimeSpan tolerance)
 	{
+		if (tolerance < TimeSpan.Zero)
+		{
+			throw new ArgumentOutOfRangeException(nameof(tolerance),
+				"Tolerance must be non-negative");
+		}
+
 		Tolerance = tolerance;
-		return this;
 	}
 
 	/// <inheritdoc />

--- a/Source/Testably.Expectations/Results/NumberToleranceResult.cs
+++ b/Source/Testably.Expectations/Results/NumberToleranceResult.cs
@@ -39,7 +39,7 @@ public class NumberToleranceResult<TNumber, TResult, TSelf>(
 	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
 
 	/// <summary>
-	///     Specifies a tolerance to apply on the time comparison.
+	///     Specifies a tolerance to apply on the number comparison.
 	/// </summary>
 	public NumberToleranceResult<TNumber, TResult, TSelf> Within(TNumber tolerance,
 		[CallerArgumentExpression("tolerance")]

--- a/Source/Testably.Expectations/Results/NumberToleranceResult.cs
+++ b/Source/Testably.Expectations/Results/NumberToleranceResult.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Testably.Expectations.Core;
+using Testably.Expectations.Options;
+
+namespace Testably.Expectations.Results;
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TNumber" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrResult{TResult,TValue}" />, allows specifying a
+///     tolerance.
+/// </summary>
+public class NumberToleranceResult<TNumber, TResult>(
+	ExpectationBuilder expectationBuilder,
+	TResult returnValue,
+	NumberTolerance<TNumber> options)
+	: NumberToleranceResult<TNumber, TResult,
+		NumberToleranceResult<TNumber, TResult>>(
+		expectationBuilder,
+		returnValue,
+		options)
+	where TNumber : struct, IComparable<TNumber>;
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrResult{TResult,TValue}" />, allows specifying a
+///     tolerance.
+/// </summary>
+public class NumberToleranceResult<TNumber, TResult, TSelf>(
+	ExpectationBuilder expectationBuilder,
+	TResult returnValue,
+	NumberTolerance<TNumber> options)
+	: AndOrResult<TNumber, TResult, TSelf>(expectationBuilder, returnValue)
+	where TSelf : NumberToleranceResult<TNumber, TResult, TSelf>
+	where TNumber : struct, IComparable<TNumber>
+{
+	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
+
+	/// <summary>
+	///     Specifies a tolerance to apply on the time comparison.
+	/// </summary>
+	public NumberToleranceResult<TNumber, TResult, TSelf> Within(TNumber tolerance,
+		[CallerArgumentExpression("tolerance")]
+		string doNotPopulateThisValue = "")
+	{
+		options.SetTolerance(tolerance);
+		_expectationBuilder.AppendMethodStatement(nameof(Within), doNotPopulateThisValue);
+		return this;
+	}
+}

--- a/Source/Testably.Expectations/Results/TimeToleranceResult.cs
+++ b/Source/Testably.Expectations/Results/TimeToleranceResult.cs
@@ -34,7 +34,7 @@ public class TimeToleranceResult<TResult, TValue, TSelf>(
 	: AndOrResult<TResult, TValue, TSelf>(expectationBuilder, returnValue)
 	where TSelf : TimeToleranceResult<TResult, TValue, TSelf>
 {
-	private readonly ExpectationBuilder _expectationBuilder1 = expectationBuilder;
+	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
 
 	/// <summary>
 	///     Specifies a tolerance to apply on the time comparison.
@@ -43,13 +43,8 @@ public class TimeToleranceResult<TResult, TValue, TSelf>(
 		[CallerArgumentExpression("tolerance")]
 		string doNotPopulateThisValue = "")
 	{
-		if (tolerance < TimeSpan.Zero)
-		{
-			throw new ArgumentOutOfRangeException(nameof(tolerance), "Tolerance must be non-negative");
-		}
-
 		options.SetTolerance(tolerance);
-		_expectationBuilder1.AppendMethodStatement(nameof(Within), doNotPopulateThisValue);
+		_expectationBuilder.AppendMethodStatement(nameof(Within), doNotPopulateThisValue);
 		return this;
 	}
 }

--- a/Source/Testably.Expectations/That/Guids/ThatGuidShould.Be.cs
+++ b/Source/Testably.Expectations/That/Guids/ThatGuidShould.Be.cs
@@ -13,7 +13,7 @@ public static partial class ThatGuidShould
 	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
 	public static AndOrResult<Guid, IThat<Guid>> Be(this IThat<Guid> source,
-		Guid expected,
+		Guid? expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ValueConstraint(
@@ -26,7 +26,7 @@ public static partial class ThatGuidShould
 	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static AndOrResult<Guid, IThat<Guid>> NotBe(this IThat<Guid> source,
-		Guid unexpected,
+		Guid? unexpected,
 		[CallerArgumentExpression("unexpected")]
 		string doNotPopulateThisValue = "")
 		=> new(source.ExpectationBuilder

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.Be.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.Be.cs
@@ -14,15 +14,182 @@ public static partial class ThatNumberShould
 	/// <summary>
 	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static NumberToleranceResult<TNumber, IThat<TNumber>> Be<TNumber>(
-		this IThat<TNumber> source,
-		TNumber? expected,
+	public static NumberToleranceResult<short, IThat<short>> Be(
+		this IThat<short> source,
+		short? expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		where TNumber : struct, IComparable<TNumber>
 	{
-		NumberTolerance<TNumber> options = new ();
-		return new NumberToleranceResult<TNumber, IThat<TNumber>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueConstraint<TNumber>(expected, options))
+		NumberTolerance<short> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<short, IThat<short>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueWithToleranceConstraint<short>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<ushort, IThat<ushort>> Be(
+		this IThat<ushort> source,
+		ushort? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<ushort> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<ushort, IThat<ushort>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueWithToleranceConstraint<ushort>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<int, IThat<int>> Be(
+		this IThat<int> source,
+		int? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<int> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<int, IThat<int>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueWithToleranceConstraint<int>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<uint, IThat<uint>> Be(
+		this IThat<uint> source,
+		uint? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<uint> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<uint, IThat<uint>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueWithToleranceConstraint<uint>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<long, IThat<long>> Be(
+		this IThat<long> source,
+		long? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<long> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<long, IThat<long>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueWithToleranceConstraint<long>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<ulong, IThat<ulong>> Be(
+		this IThat<ulong> source,
+		ulong? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<ulong> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<ulong, IThat<ulong>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueWithToleranceConstraint<ulong>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<byte, IThat<byte>> Be(
+		this IThat<byte> source,
+		byte? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<byte> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<byte, IThat<byte>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueWithToleranceConstraint<byte>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<sbyte, IThat<sbyte>> Be(
+		this IThat<sbyte> source,
+		sbyte? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<sbyte> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<sbyte, IThat<sbyte>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueWithToleranceConstraint<sbyte>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<decimal, IThat<decimal>> Be(
+		this IThat<decimal> source,
+		decimal? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<decimal> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<decimal, IThat<decimal>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueWithToleranceConstraint<decimal>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<float, IThat<float>> Be(
+		this IThat<float> source,
+		float? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<float> options = new(
+			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<float, IThat<float>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueWithToleranceConstraint<float>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<double, IThat<double>> Be(
+		this IThat<double> source,
+		double? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<double> options = new(
+			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<double, IThat<double>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueWithToleranceConstraint<double>(expected, options))
 				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
 			source,
 			options);
@@ -36,13 +203,10 @@ public static partial class ThatNumberShould
 		TNumber? expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		where TNumber : struct, IComparable<TNumber>
-	{
-		NumberTolerance<TNumber> options = new ();
-		return new AndOrResult<TNumber?, IThat<TNumber?>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueConstraint<TNumber>(expected, options))
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new IsValueConstraint<TNumber>(expected))
 				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
 			source);
-	}
 
 	/// <summary>
 	///     Verifies that the subject is not equal to the <paramref name="expected" /> value.
@@ -57,7 +221,26 @@ public static partial class ThatNumberShould
 				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
 			source);
 
-	private readonly struct IsValueConstraint<TNumber>(TNumber? expected,
+	private readonly struct IsValueConstraint<TNumber>(TNumber? expected)
+		: IValueConstraint<TNumber>
+		where TNumber : struct, IComparable<TNumber>
+	{
+		public ConstraintResult IsMetBy(TNumber actual)
+		{
+			if (expected?.CompareTo(actual) == 0)
+			{
+				return new ConstraintResult.Success<TNumber>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> $"be {Formatter.Format(expected)}";
+	}
+
+	private readonly struct IsValueWithToleranceConstraint<TNumber>(
+		TNumber? expected,
 		NumberTolerance<TNumber> options)
 		: IValueConstraint<TNumber>
 		where TNumber : struct, IComparable<TNumber>

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.Be.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.Be.cs
@@ -14,105 +14,6 @@ public static partial class ThatNumberShould
 	/// <summary>
 	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static NumberToleranceResult<short, IThat<short>> Be(
-		this IThat<short> source,
-		short? expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-	{
-		NumberTolerance<short> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
-		return new NumberToleranceResult<short, IThat<short>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueWithToleranceConstraint<short>(expected, options))
-				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
-	/// </summary>
-	public static NumberToleranceResult<ushort, IThat<ushort>> Be(
-		this IThat<ushort> source,
-		ushort? expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-	{
-		NumberTolerance<ushort> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
-		return new NumberToleranceResult<ushort, IThat<ushort>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueWithToleranceConstraint<ushort>(expected, options))
-				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
-			source,
-			options);
-	}
-	/// <summary>
-	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
-	/// </summary>
-	public static NumberToleranceResult<int, IThat<int>> Be(
-		this IThat<int> source,
-		int? expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-	{
-		NumberTolerance<int> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
-		return new NumberToleranceResult<int, IThat<int>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueWithToleranceConstraint<int>(expected, options))
-				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
-	/// </summary>
-	public static NumberToleranceResult<uint, IThat<uint>> Be(
-		this IThat<uint> source,
-		uint? expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-	{
-		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
-		return new NumberToleranceResult<uint, IThat<uint>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueWithToleranceConstraint<uint>(expected, options))
-				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
-			source,
-			options);
-	}
-	/// <summary>
-	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
-	/// </summary>
-	public static NumberToleranceResult<long, IThat<long>> Be(
-		this IThat<long> source,
-		long? expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-	{
-		NumberTolerance<long> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
-		return new NumberToleranceResult<long, IThat<long>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueWithToleranceConstraint<long>(expected, options))
-				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
-	/// </summary>
-	public static NumberToleranceResult<ulong, IThat<ulong>> Be(
-		this IThat<ulong> source,
-		ulong? expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-	{
-		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
-		return new NumberToleranceResult<ulong, IThat<ulong>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueWithToleranceConstraint<ulong>(expected, options))
-				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
-			source,
-			options);
-	}
-	/// <summary>
-	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
-	/// </summary>
 	public static NumberToleranceResult<byte, IThat<byte>> Be(
 		this IThat<byte> source,
 		byte? expected,
@@ -121,7 +22,7 @@ public static partial class ThatNumberShould
 		NumberTolerance<byte> options = new(
 			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
 		return new NumberToleranceResult<byte, IThat<byte>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueWithToleranceConstraint<byte>(expected, options))
+				.AddConstraint(new IsValueConstraint<byte>(expected, options))
 				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
 			source,
 			options);
@@ -138,7 +39,7 @@ public static partial class ThatNumberShould
 		NumberTolerance<sbyte> options = new(
 			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueWithToleranceConstraint<sbyte>(expected, options))
+				.AddConstraint(new IsValueConstraint<sbyte>(expected, options))
 				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
 			source,
 			options);
@@ -147,15 +48,100 @@ public static partial class ThatNumberShould
 	/// <summary>
 	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static NumberToleranceResult<decimal, IThat<decimal>> Be(
-		this IThat<decimal> source,
-		decimal? expected,
+	public static NumberToleranceResult<short, IThat<short>> Be(
+		this IThat<short> source,
+		short? expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		NumberTolerance<decimal> options = new(
+		NumberTolerance<short> options = new(
 			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
-		return new NumberToleranceResult<decimal, IThat<decimal>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueWithToleranceConstraint<decimal>(expected, options))
+		return new NumberToleranceResult<short, IThat<short>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueConstraint<short>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<ushort, IThat<ushort>> Be(
+		this IThat<ushort> source,
+		ushort? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<ushort> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<ushort, IThat<ushort>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueConstraint<ushort>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<int, IThat<int>> Be(
+		this IThat<int> source,
+		int? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<int> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<int, IThat<int>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueConstraint<int>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<uint, IThat<uint>> Be(
+		this IThat<uint> source,
+		uint? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<uint> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<uint, IThat<uint>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueConstraint<uint>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<long, IThat<long>> Be(
+		this IThat<long> source,
+		long? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<long> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<long, IThat<long>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueConstraint<long>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<ulong, IThat<ulong>> Be(
+		this IThat<ulong> source,
+		ulong? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<ulong> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<ulong, IThat<ulong>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueConstraint<ulong>(expected, options))
 				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
 			source,
 			options);
@@ -172,7 +158,7 @@ public static partial class ThatNumberShould
 		NumberTolerance<float> options = new(
 			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
 		return new NumberToleranceResult<float, IThat<float>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueWithToleranceConstraint<float>(expected, options))
+				.AddConstraint(new IsValueConstraint<float>(expected, options))
 				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
 			source,
 			options);
@@ -189,7 +175,7 @@ public static partial class ThatNumberShould
 		NumberTolerance<double> options = new(
 			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
 		return new NumberToleranceResult<double, IThat<double>>(source.ExpectationBuilder
-				.AddConstraint(new IsValueWithToleranceConstraint<double>(expected, options))
+				.AddConstraint(new IsValueConstraint<double>(expected, options))
 				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
 			source,
 			options);
@@ -198,48 +184,219 @@ public static partial class ThatNumberShould
 	/// <summary>
 	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrResult<TNumber?, IThat<TNumber?>> Be<TNumber>(
-		this IThat<TNumber?> source,
-		TNumber? expected,
+	public static NumberToleranceResult<decimal, IThat<decimal>> Be(
+		this IThat<decimal> source,
+		decimal? expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		where TNumber : struct, IComparable<TNumber>
-		=> new(source.ExpectationBuilder
-				.AddConstraint(new IsValueConstraint<TNumber>(expected))
-				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
-			source);
-
-	/// <summary>
-	///     Verifies that the subject is not equal to the <paramref name="expected" /> value.
-	/// </summary>
-	public static AndOrResult<TNumber, IThat<TNumber>> NotBe<TNumber>(
-		this IThat<TNumber> source,
-		TNumber? expected,
-		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-		where TNumber : struct, IComparable<TNumber>
-		=> new(source.ExpectationBuilder
-				.AddConstraint(new IsNotValueConstraint<TNumber>(expected))
-				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
-			source);
-
-	private readonly struct IsValueConstraint<TNumber>(TNumber? expected)
-		: IValueConstraint<TNumber>
-		where TNumber : struct, IComparable<TNumber>
 	{
-		public ConstraintResult IsMetBy(TNumber actual)
-		{
-			if (expected?.CompareTo(actual) == 0)
-			{
-				return new ConstraintResult.Success<TNumber>(actual, ToString());
-			}
-
-			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
-		}
-
-		public override string ToString()
-			=> $"be {Formatter.Format(expected)}";
+		NumberTolerance<decimal> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<decimal, IThat<decimal>>(source.ExpectationBuilder
+				.AddConstraint(new IsValueConstraint<decimal>(expected, options))
+				.AppendMethodStatement(nameof(Be), doNotPopulateThisValue),
+			source,
+			options);
 	}
 
-	private readonly struct IsValueWithToleranceConstraint<TNumber>(
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<byte, IThat<byte>> NotBe(
+		this IThat<byte> source,
+		byte? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<byte> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<byte, IThat<byte>>(source.ExpectationBuilder
+				.AddConstraint(new IsNotValueConstraint<byte>(unexpected, options))
+				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<sbyte, IThat<sbyte>> NotBe(
+		this IThat<sbyte> source,
+		sbyte? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<sbyte> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<sbyte, IThat<sbyte>>(source.ExpectationBuilder
+				.AddConstraint(new IsNotValueConstraint<sbyte>(unexpected, options))
+				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<short, IThat<short>> NotBe(
+		this IThat<short> source,
+		short? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<short> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<short, IThat<short>>(source.ExpectationBuilder
+				.AddConstraint(new IsNotValueConstraint<short>(unexpected, options))
+				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<ushort, IThat<ushort>> NotBe(
+		this IThat<ushort> source,
+		ushort? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<ushort> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<ushort, IThat<ushort>>(source.ExpectationBuilder
+				.AddConstraint(new IsNotValueConstraint<ushort>(unexpected, options))
+				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<int, IThat<int>> NotBe(
+		this IThat<int> source,
+		int? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<int> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<int, IThat<int>>(source.ExpectationBuilder
+				.AddConstraint(new IsNotValueConstraint<int>(unexpected, options))
+				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<uint, IThat<uint>> NotBe(
+		this IThat<uint> source,
+		uint? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<uint> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<uint, IThat<uint>>(source.ExpectationBuilder
+				.AddConstraint(new IsNotValueConstraint<uint>(unexpected, options))
+				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<long, IThat<long>> NotBe(
+		this IThat<long> source,
+		long? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<long> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<long, IThat<long>>(source.ExpectationBuilder
+				.AddConstraint(new IsNotValueConstraint<long>(unexpected, options))
+				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<ulong, IThat<ulong>> NotBe(
+		this IThat<ulong> source,
+		ulong? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<ulong> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<ulong, IThat<ulong>>(source.ExpectationBuilder
+				.AddConstraint(new IsNotValueConstraint<ulong>(unexpected, options))
+				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<float, IThat<float>> NotBe(
+		this IThat<float> source,
+		float? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<float> options = new(
+			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<float, IThat<float>>(source.ExpectationBuilder
+				.AddConstraint(new IsNotValueConstraint<float>(unexpected, options))
+				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<double, IThat<double>> NotBe(
+		this IThat<double> source,
+		double? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<double> options = new(
+			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<double, IThat<double>>(source.ExpectationBuilder
+				.AddConstraint(new IsNotValueConstraint<double>(unexpected, options))
+				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<decimal, IThat<decimal>> NotBe(
+		this IThat<decimal> source,
+		decimal? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+	{
+		NumberTolerance<decimal> options = new(
+			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+		return new NumberToleranceResult<decimal, IThat<decimal>>(source.ExpectationBuilder
+				.AddConstraint(new IsNotValueConstraint<decimal>(unexpected, options))
+				.AppendMethodStatement(nameof(NotBe), doNotPopulateThisValue),
+			source,
+			options);
+	}
+
+	private readonly struct IsValueConstraint<TNumber>(
 		TNumber? expected,
 		NumberTolerance<TNumber> options)
 		: IValueConstraint<TNumber>
@@ -259,13 +416,15 @@ public static partial class ThatNumberShould
 			=> $"be {Formatter.Format(expected)}{options}";
 	}
 
-	private readonly struct IsNotValueConstraint<TNumber>(TNumber? expected)
+	private readonly struct IsNotValueConstraint<TNumber>(
+		TNumber? unexpected,
+		NumberTolerance<TNumber> options)
 		: IValueConstraint<TNumber>
 		where TNumber : struct, IComparable<TNumber>
 	{
 		public ConstraintResult IsMetBy(TNumber actual)
 		{
-			if (expected?.CompareTo(actual) != 0)
+			if (!options.IsWithinTolerance(actual, unexpected))
 			{
 				return new ConstraintResult.Success<TNumber>(actual, ToString());
 			}
@@ -274,6 +433,6 @@ public static partial class ThatNumberShould
 		}
 
 		public override string ToString()
-			=> $"not be {Formatter.Format(expected)}";
+			=> $"not be {Formatter.Format(unexpected)}{options}";
 	}
 }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -243,9 +243,9 @@ namespace Testably.Expectations
     }
     public static class ThatGuidShould
     {
-        public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> Be(this Testably.Expectations.Core.IThat<System.Guid> source, System.Guid expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> Be(this Testably.Expectations.Core.IThat<System.Guid> source, System.Guid? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> BeEmpty(this Testably.Expectations.Core.IThat<System.Guid> source) { }
-        public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> NotBe(this Testably.Expectations.Core.IThat<System.Guid> source, System.Guid unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> NotBe(this Testably.Expectations.Core.IThat<System.Guid> source, System.Guid? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> NotBeEmpty(this Testably.Expectations.Core.IThat<System.Guid> source) { }
         public static Testably.Expectations.Core.IThat<System.Guid> Should(this Testably.Expectations.Core.IExpectSubject<System.Guid> subject) { }
     }
@@ -324,18 +324,34 @@ namespace Testably.Expectations
     }
     public static class ThatNumberShould
     {
-        public static Testably.Expectations.Results.AndOrResult<TNumber, Testably.Expectations.Core.IThat<TNumber>> Be<TNumber>(this Testably.Expectations.Core.IThat<TNumber> source, TNumber? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-            where TNumber :  struct, System.IComparable<TNumber> { }
-        public static Testably.Expectations.Results.AndOrResult<TNumber?, Testably.Expectations.Core.IThat<TNumber?>> Be<TNumber>(this Testably.Expectations.Core.IThat<TNumber?> source, TNumber? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-            where TNumber :  struct, System.IComparable<TNumber> { }
+        public static Testably.Expectations.Results.NumberToleranceResult<byte, Testably.Expectations.Core.IThat<byte>> Be(this Testably.Expectations.Core.IThat<byte> source, byte? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<decimal, Testably.Expectations.Core.IThat<decimal>> Be(this Testably.Expectations.Core.IThat<decimal> source, decimal? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<double, Testably.Expectations.Core.IThat<double>> Be(this Testably.Expectations.Core.IThat<double> source, double? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<short, Testably.Expectations.Core.IThat<short>> Be(this Testably.Expectations.Core.IThat<short> source, short? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<int, Testably.Expectations.Core.IThat<int>> Be(this Testably.Expectations.Core.IThat<int> source, int? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<long, Testably.Expectations.Core.IThat<long>> Be(this Testably.Expectations.Core.IThat<long> source, long? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<sbyte, Testably.Expectations.Core.IThat<sbyte>> Be(this Testably.Expectations.Core.IThat<sbyte> source, sbyte? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<float, Testably.Expectations.Core.IThat<float>> Be(this Testably.Expectations.Core.IThat<float> source, float? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<ushort, Testably.Expectations.Core.IThat<ushort>> Be(this Testably.Expectations.Core.IThat<ushort> source, ushort? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<uint, Testably.Expectations.Core.IThat<uint>> Be(this Testably.Expectations.Core.IThat<uint> source, uint? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<ulong, Testably.Expectations.Core.IThat<ulong>> Be(this Testably.Expectations.Core.IThat<ulong> source, ulong? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> BeFinite(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrResult<float, Testably.Expectations.Core.IThat<float>> BeFinite(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> BeInfinite(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrResult<float, Testably.Expectations.Core.IThat<float>> BeInfinite(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> BeNaN(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrResult<float, Testably.Expectations.Core.IThat<float>> BeNaN(this Testably.Expectations.Core.IThat<float> source) { }
-        public static Testably.Expectations.Results.AndOrResult<TNumber, Testably.Expectations.Core.IThat<TNumber>> NotBe<TNumber>(this Testably.Expectations.Core.IThat<TNumber> source, TNumber? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-            where TNumber :  struct, System.IComparable<TNumber> { }
+        public static Testably.Expectations.Results.NumberToleranceResult<byte, Testably.Expectations.Core.IThat<byte>> NotBe(this Testably.Expectations.Core.IThat<byte> source, byte? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<decimal, Testably.Expectations.Core.IThat<decimal>> NotBe(this Testably.Expectations.Core.IThat<decimal> source, decimal? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<double, Testably.Expectations.Core.IThat<double>> NotBe(this Testably.Expectations.Core.IThat<double> source, double? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<short, Testably.Expectations.Core.IThat<short>> NotBe(this Testably.Expectations.Core.IThat<short> source, short? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<int, Testably.Expectations.Core.IThat<int>> NotBe(this Testably.Expectations.Core.IThat<int> source, int? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<long, Testably.Expectations.Core.IThat<long>> NotBe(this Testably.Expectations.Core.IThat<long> source, long? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<sbyte, Testably.Expectations.Core.IThat<sbyte>> NotBe(this Testably.Expectations.Core.IThat<sbyte> source, sbyte? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<float, Testably.Expectations.Core.IThat<float>> NotBe(this Testably.Expectations.Core.IThat<float> source, float? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<ushort, Testably.Expectations.Core.IThat<ushort>> NotBe(this Testably.Expectations.Core.IThat<ushort> source, ushort? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<uint, Testably.Expectations.Core.IThat<uint>> NotBe(this Testably.Expectations.Core.IThat<uint> source, uint? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<ulong, Testably.Expectations.Core.IThat<ulong>> NotBe(this Testably.Expectations.Core.IThat<ulong> source, ulong? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> NotBeFinite(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrResult<float, Testably.Expectations.Core.IThat<float>> NotBeFinite(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> NotBeInfinite(this Testably.Expectations.Core.IThat<double> source) { }
@@ -608,6 +624,14 @@ namespace Testably.Expectations.Options
         public Testably.Expectations.Options.EquivalencyOptions IgnoringMember(string memberToIgnore) { }
         public override string ToString() { }
     }
+    public class NumberTolerance<TNumber>
+        where TNumber :  struct, System.IComparable<TNumber>
+    {
+        public NumberTolerance(System.Func<TNumber, TNumber, TNumber?, bool> isWithinTolerance) { }
+        public TNumber? Tolerance { get; }
+        public void SetTolerance(TNumber tolerance) { }
+        public override string ToString() { }
+    }
     public class ObjectEqualityOptions
     {
         public ObjectEqualityOptions() { }
@@ -654,7 +678,7 @@ namespace Testably.Expectations.Options
     {
         public TimeTolerance() { }
         public System.TimeSpan? Tolerance { get; }
-        public Testably.Expectations.Options.TimeTolerance SetTolerance(System.TimeSpan tolerance) { }
+        public void SetTolerance(System.TimeSpan tolerance) { }
         public override string ToString() { }
     }
 }
@@ -720,6 +744,18 @@ namespace Testably.Expectations.Results
         public TSelf Because(string reason, [System.Runtime.CompilerServices.CallerArgumentExpression("reason")] string doNotPopulateThisValue = "") { }
         [System.Diagnostics.StackTraceHidden]
         public System.Runtime.CompilerServices.TaskAwaiter<TResult> GetAwaiter() { }
+    }
+    public class NumberToleranceResult<TNumber, TResult> : Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult, Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult>>
+        where TNumber :  struct, System.IComparable<TNumber>
+    {
+        public NumberToleranceResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder, TResult returnValue, Testably.Expectations.Options.NumberTolerance<TNumber> options) { }
+    }
+    public class NumberToleranceResult<TNumber, TResult, TSelf> : Testably.Expectations.Results.AndOrResult<TNumber, TResult, TSelf>
+        where TNumber :  struct, System.IComparable<TNumber>
+        where TSelf : Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult, TSelf>
+    {
+        public NumberToleranceResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder, TResult returnValue, Testably.Expectations.Options.NumberTolerance<TNumber> options) { }
+        public Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult, TSelf> Within(TNumber tolerance, [System.Runtime.CompilerServices.CallerArgumentExpression("tolerance")] string doNotPopulateThisValue = "") { }
     }
     public class ObjectEqualityResult<TResult, TValue> : Testably.Expectations.Results.ObjectEqualityResult<TResult, TValue, Testably.Expectations.Results.ObjectEqualityResult<TResult, TValue>>
     {

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -243,9 +243,9 @@ namespace Testably.Expectations
     }
     public static class ThatGuidShould
     {
-        public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> Be(this Testably.Expectations.Core.IThat<System.Guid> source, System.Guid expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> Be(this Testably.Expectations.Core.IThat<System.Guid> source, System.Guid? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> BeEmpty(this Testably.Expectations.Core.IThat<System.Guid> source) { }
-        public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> NotBe(this Testably.Expectations.Core.IThat<System.Guid> source, System.Guid unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> NotBe(this Testably.Expectations.Core.IThat<System.Guid> source, System.Guid? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> NotBeEmpty(this Testably.Expectations.Core.IThat<System.Guid> source) { }
         public static Testably.Expectations.Core.IThat<System.Guid> Should(this Testably.Expectations.Core.IExpectSubject<System.Guid> subject) { }
     }
@@ -324,18 +324,34 @@ namespace Testably.Expectations
     }
     public static class ThatNumberShould
     {
-        public static Testably.Expectations.Results.AndOrResult<TNumber, Testably.Expectations.Core.IThat<TNumber>> Be<TNumber>(this Testably.Expectations.Core.IThat<TNumber> source, TNumber? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-            where TNumber :  struct, System.IComparable<TNumber> { }
-        public static Testably.Expectations.Results.AndOrResult<TNumber?, Testably.Expectations.Core.IThat<TNumber?>> Be<TNumber>(this Testably.Expectations.Core.IThat<TNumber?> source, TNumber? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-            where TNumber :  struct, System.IComparable<TNumber> { }
+        public static Testably.Expectations.Results.NumberToleranceResult<byte, Testably.Expectations.Core.IThat<byte>> Be(this Testably.Expectations.Core.IThat<byte> source, byte? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<decimal, Testably.Expectations.Core.IThat<decimal>> Be(this Testably.Expectations.Core.IThat<decimal> source, decimal? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<double, Testably.Expectations.Core.IThat<double>> Be(this Testably.Expectations.Core.IThat<double> source, double? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<short, Testably.Expectations.Core.IThat<short>> Be(this Testably.Expectations.Core.IThat<short> source, short? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<int, Testably.Expectations.Core.IThat<int>> Be(this Testably.Expectations.Core.IThat<int> source, int? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<long, Testably.Expectations.Core.IThat<long>> Be(this Testably.Expectations.Core.IThat<long> source, long? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<sbyte, Testably.Expectations.Core.IThat<sbyte>> Be(this Testably.Expectations.Core.IThat<sbyte> source, sbyte? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<float, Testably.Expectations.Core.IThat<float>> Be(this Testably.Expectations.Core.IThat<float> source, float? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<ushort, Testably.Expectations.Core.IThat<ushort>> Be(this Testably.Expectations.Core.IThat<ushort> source, ushort? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<uint, Testably.Expectations.Core.IThat<uint>> Be(this Testably.Expectations.Core.IThat<uint> source, uint? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<ulong, Testably.Expectations.Core.IThat<ulong>> Be(this Testably.Expectations.Core.IThat<ulong> source, ulong? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> BeFinite(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrResult<float, Testably.Expectations.Core.IThat<float>> BeFinite(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> BeInfinite(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrResult<float, Testably.Expectations.Core.IThat<float>> BeInfinite(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> BeNaN(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrResult<float, Testably.Expectations.Core.IThat<float>> BeNaN(this Testably.Expectations.Core.IThat<float> source) { }
-        public static Testably.Expectations.Results.AndOrResult<TNumber, Testably.Expectations.Core.IThat<TNumber>> NotBe<TNumber>(this Testably.Expectations.Core.IThat<TNumber> source, TNumber? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-            where TNumber :  struct, System.IComparable<TNumber> { }
+        public static Testably.Expectations.Results.NumberToleranceResult<byte, Testably.Expectations.Core.IThat<byte>> NotBe(this Testably.Expectations.Core.IThat<byte> source, byte? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<decimal, Testably.Expectations.Core.IThat<decimal>> NotBe(this Testably.Expectations.Core.IThat<decimal> source, decimal? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<double, Testably.Expectations.Core.IThat<double>> NotBe(this Testably.Expectations.Core.IThat<double> source, double? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<short, Testably.Expectations.Core.IThat<short>> NotBe(this Testably.Expectations.Core.IThat<short> source, short? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<int, Testably.Expectations.Core.IThat<int>> NotBe(this Testably.Expectations.Core.IThat<int> source, int? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<long, Testably.Expectations.Core.IThat<long>> NotBe(this Testably.Expectations.Core.IThat<long> source, long? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<sbyte, Testably.Expectations.Core.IThat<sbyte>> NotBe(this Testably.Expectations.Core.IThat<sbyte> source, sbyte? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<float, Testably.Expectations.Core.IThat<float>> NotBe(this Testably.Expectations.Core.IThat<float> source, float? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<ushort, Testably.Expectations.Core.IThat<ushort>> NotBe(this Testably.Expectations.Core.IThat<ushort> source, ushort? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<uint, Testably.Expectations.Core.IThat<uint>> NotBe(this Testably.Expectations.Core.IThat<uint> source, uint? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<ulong, Testably.Expectations.Core.IThat<ulong>> NotBe(this Testably.Expectations.Core.IThat<ulong> source, ulong? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> NotBeFinite(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrResult<float, Testably.Expectations.Core.IThat<float>> NotBeFinite(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> NotBeInfinite(this Testably.Expectations.Core.IThat<double> source) { }
@@ -608,6 +624,14 @@ namespace Testably.Expectations.Options
         public Testably.Expectations.Options.EquivalencyOptions IgnoringMember(string memberToIgnore) { }
         public override string ToString() { }
     }
+    public class NumberTolerance<TNumber>
+        where TNumber :  struct, System.IComparable<TNumber>
+    {
+        public NumberTolerance(System.Func<TNumber, TNumber, TNumber?, bool> isWithinTolerance) { }
+        public TNumber? Tolerance { get; }
+        public void SetTolerance(TNumber tolerance) { }
+        public override string ToString() { }
+    }
     public class ObjectEqualityOptions
     {
         public ObjectEqualityOptions() { }
@@ -654,7 +678,7 @@ namespace Testably.Expectations.Options
     {
         public TimeTolerance() { }
         public System.TimeSpan? Tolerance { get; }
-        public Testably.Expectations.Options.TimeTolerance SetTolerance(System.TimeSpan tolerance) { }
+        public void SetTolerance(System.TimeSpan tolerance) { }
         public override string ToString() { }
     }
 }
@@ -720,6 +744,18 @@ namespace Testably.Expectations.Results
         public TSelf Because(string reason, [System.Runtime.CompilerServices.CallerArgumentExpression("reason")] string doNotPopulateThisValue = "") { }
         [System.Diagnostics.StackTraceHidden]
         public System.Runtime.CompilerServices.TaskAwaiter<TResult> GetAwaiter() { }
+    }
+    public class NumberToleranceResult<TNumber, TResult> : Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult, Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult>>
+        where TNumber :  struct, System.IComparable<TNumber>
+    {
+        public NumberToleranceResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder, TResult returnValue, Testably.Expectations.Options.NumberTolerance<TNumber> options) { }
+    }
+    public class NumberToleranceResult<TNumber, TResult, TSelf> : Testably.Expectations.Results.AndOrResult<TNumber, TResult, TSelf>
+        where TNumber :  struct, System.IComparable<TNumber>
+        where TSelf : Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult, TSelf>
+    {
+        public NumberToleranceResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder, TResult returnValue, Testably.Expectations.Options.NumberTolerance<TNumber> options) { }
+        public Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult, TSelf> Within(TNumber tolerance, [System.Runtime.CompilerServices.CallerArgumentExpression("tolerance")] string doNotPopulateThisValue = "") { }
     }
     public class ObjectEqualityResult<TResult, TValue> : Testably.Expectations.Results.ObjectEqualityResult<TResult, TValue, Testably.Expectations.Results.ObjectEqualityResult<TResult, TValue>>
     {

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -209,9 +209,9 @@ namespace Testably.Expectations
     }
     public static class ThatGuidShould
     {
-        public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> Be(this Testably.Expectations.Core.IThat<System.Guid> source, System.Guid expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> Be(this Testably.Expectations.Core.IThat<System.Guid> source, System.Guid? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> BeEmpty(this Testably.Expectations.Core.IThat<System.Guid> source) { }
-        public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> NotBe(this Testably.Expectations.Core.IThat<System.Guid> source, System.Guid unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> NotBe(this Testably.Expectations.Core.IThat<System.Guid> source, System.Guid? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrResult<System.Guid, Testably.Expectations.Core.IThat<System.Guid>> NotBeEmpty(this Testably.Expectations.Core.IThat<System.Guid> source) { }
         public static Testably.Expectations.Core.IThat<System.Guid> Should(this Testably.Expectations.Core.IExpectSubject<System.Guid> subject) { }
     }
@@ -278,18 +278,34 @@ namespace Testably.Expectations
     }
     public static class ThatNumberShould
     {
-        public static Testably.Expectations.Results.AndOrResult<TNumber, Testably.Expectations.Core.IThat<TNumber>> Be<TNumber>(this Testably.Expectations.Core.IThat<TNumber> source, TNumber? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-            where TNumber :  struct, System.IComparable<TNumber> { }
-        public static Testably.Expectations.Results.AndOrResult<TNumber?, Testably.Expectations.Core.IThat<TNumber?>> Be<TNumber>(this Testably.Expectations.Core.IThat<TNumber?> source, TNumber? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-            where TNumber :  struct, System.IComparable<TNumber> { }
+        public static Testably.Expectations.Results.NumberToleranceResult<byte, Testably.Expectations.Core.IThat<byte>> Be(this Testably.Expectations.Core.IThat<byte> source, byte? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<decimal, Testably.Expectations.Core.IThat<decimal>> Be(this Testably.Expectations.Core.IThat<decimal> source, decimal? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<double, Testably.Expectations.Core.IThat<double>> Be(this Testably.Expectations.Core.IThat<double> source, double? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<short, Testably.Expectations.Core.IThat<short>> Be(this Testably.Expectations.Core.IThat<short> source, short? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<int, Testably.Expectations.Core.IThat<int>> Be(this Testably.Expectations.Core.IThat<int> source, int? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<long, Testably.Expectations.Core.IThat<long>> Be(this Testably.Expectations.Core.IThat<long> source, long? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<sbyte, Testably.Expectations.Core.IThat<sbyte>> Be(this Testably.Expectations.Core.IThat<sbyte> source, sbyte? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<float, Testably.Expectations.Core.IThat<float>> Be(this Testably.Expectations.Core.IThat<float> source, float? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<ushort, Testably.Expectations.Core.IThat<ushort>> Be(this Testably.Expectations.Core.IThat<ushort> source, ushort? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<uint, Testably.Expectations.Core.IThat<uint>> Be(this Testably.Expectations.Core.IThat<uint> source, uint? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<ulong, Testably.Expectations.Core.IThat<ulong>> Be(this Testably.Expectations.Core.IThat<ulong> source, ulong? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> BeFinite(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrResult<float, Testably.Expectations.Core.IThat<float>> BeFinite(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> BeInfinite(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrResult<float, Testably.Expectations.Core.IThat<float>> BeInfinite(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> BeNaN(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrResult<float, Testably.Expectations.Core.IThat<float>> BeNaN(this Testably.Expectations.Core.IThat<float> source) { }
-        public static Testably.Expectations.Results.AndOrResult<TNumber, Testably.Expectations.Core.IThat<TNumber>> NotBe<TNumber>(this Testably.Expectations.Core.IThat<TNumber> source, TNumber? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
-            where TNumber :  struct, System.IComparable<TNumber> { }
+        public static Testably.Expectations.Results.NumberToleranceResult<byte, Testably.Expectations.Core.IThat<byte>> NotBe(this Testably.Expectations.Core.IThat<byte> source, byte? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<decimal, Testably.Expectations.Core.IThat<decimal>> NotBe(this Testably.Expectations.Core.IThat<decimal> source, decimal? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<double, Testably.Expectations.Core.IThat<double>> NotBe(this Testably.Expectations.Core.IThat<double> source, double? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<short, Testably.Expectations.Core.IThat<short>> NotBe(this Testably.Expectations.Core.IThat<short> source, short? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<int, Testably.Expectations.Core.IThat<int>> NotBe(this Testably.Expectations.Core.IThat<int> source, int? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<long, Testably.Expectations.Core.IThat<long>> NotBe(this Testably.Expectations.Core.IThat<long> source, long? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<sbyte, Testably.Expectations.Core.IThat<sbyte>> NotBe(this Testably.Expectations.Core.IThat<sbyte> source, sbyte? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<float, Testably.Expectations.Core.IThat<float>> NotBe(this Testably.Expectations.Core.IThat<float> source, float? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<ushort, Testably.Expectations.Core.IThat<ushort>> NotBe(this Testably.Expectations.Core.IThat<ushort> source, ushort? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<uint, Testably.Expectations.Core.IThat<uint>> NotBe(this Testably.Expectations.Core.IThat<uint> source, uint? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.NumberToleranceResult<ulong, Testably.Expectations.Core.IThat<ulong>> NotBe(this Testably.Expectations.Core.IThat<ulong> source, ulong? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> NotBeFinite(this Testably.Expectations.Core.IThat<double> source) { }
         public static Testably.Expectations.Results.AndOrResult<float, Testably.Expectations.Core.IThat<float>> NotBeFinite(this Testably.Expectations.Core.IThat<float> source) { }
         public static Testably.Expectations.Results.AndOrResult<double, Testably.Expectations.Core.IThat<double>> NotBeInfinite(this Testably.Expectations.Core.IThat<double> source) { }
@@ -546,6 +562,14 @@ namespace Testably.Expectations.Options
         public Testably.Expectations.Options.EquivalencyOptions IgnoringMember(string memberToIgnore) { }
         public override string ToString() { }
     }
+    public class NumberTolerance<TNumber>
+        where TNumber :  struct, System.IComparable<TNumber>
+    {
+        public NumberTolerance(System.Func<TNumber, TNumber, TNumber?, bool> isWithinTolerance) { }
+        public TNumber? Tolerance { get; }
+        public void SetTolerance(TNumber tolerance) { }
+        public override string ToString() { }
+    }
     public class ObjectEqualityOptions
     {
         public ObjectEqualityOptions() { }
@@ -592,7 +616,7 @@ namespace Testably.Expectations.Options
     {
         public TimeTolerance() { }
         public System.TimeSpan? Tolerance { get; }
-        public Testably.Expectations.Options.TimeTolerance SetTolerance(System.TimeSpan tolerance) { }
+        public void SetTolerance(System.TimeSpan tolerance) { }
         public override string ToString() { }
     }
 }
@@ -658,6 +682,18 @@ namespace Testably.Expectations.Results
         public TSelf Because(string reason, [System.Runtime.CompilerServices.CallerArgumentExpression("reason")] string doNotPopulateThisValue = "") { }
         [System.Diagnostics.StackTraceHidden]
         public System.Runtime.CompilerServices.TaskAwaiter<TResult> GetAwaiter() { }
+    }
+    public class NumberToleranceResult<TNumber, TResult> : Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult, Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult>>
+        where TNumber :  struct, System.IComparable<TNumber>
+    {
+        public NumberToleranceResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder, TResult returnValue, Testably.Expectations.Options.NumberTolerance<TNumber> options) { }
+    }
+    public class NumberToleranceResult<TNumber, TResult, TSelf> : Testably.Expectations.Results.AndOrResult<TNumber, TResult, TSelf>
+        where TNumber :  struct, System.IComparable<TNumber>
+        where TSelf : Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult, TSelf>
+    {
+        public NumberToleranceResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder, TResult returnValue, Testably.Expectations.Options.NumberTolerance<TNumber> options) { }
+        public Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult, TSelf> Within(TNumber tolerance, [System.Runtime.CompilerServices.CallerArgumentExpression("tolerance")] string doNotPopulateThisValue = "") { }
     }
     public class ObjectEqualityResult<TResult, TValue> : Testably.Expectations.Results.ObjectEqualityResult<TResult, TValue, Testably.Expectations.Results.ObjectEqualityResult<TResult, TValue>>
     {

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.Be.WithinTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.Be.WithinTests.cs
@@ -7,7 +7,172 @@ public sealed partial class NumberShould
 		public sealed class WithinTests
 		{
 			[Fact]
-			public async Task WhenInsideTolerance_ShouldSucceed()
+			public async Task ForByte_WhenInsideTolerance_ShouldSucceed()
+			{
+				byte subject = 12;
+				byte expected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForByte_WhenOutsideTolerance_ShouldFail()
+			{
+				byte subject = 12;
+				byte expected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be 10 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().Be(expected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForDecimal_WhenInsideTolerance_ShouldSucceed()
+			{
+				decimal subject = new(12.2);
+				decimal expected = new(12.1);
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(new decimal(0.1));
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForDecimal_WhenOutsideTolerance_ShouldFail()
+			{
+				decimal subject = new(12.3);
+				decimal expected = new(12.1);
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(new decimal(0.1));
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be 12.1 ± 0.1,
+					             but found 12.3
+					             at Expect.That(subject).Should().Be(expected).Within(new decimal(0.1))
+					             """);
+			}
+
+			[Fact]
+			public async Task
+				ForDecimal_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				decimal subject = new(12.2);
+				decimal expected = new(12.1);
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(new decimal(-0.1));
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForDouble_WhenInsideTolerance_ShouldSucceed()
+			{
+				double subject = 12.2;
+				double expected = 12.1;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(0.1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForDouble_WhenOutsideTolerance_ShouldFail()
+			{
+				double subject = 12.3;
+				double expected = 12.1;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(0.1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be 12.1 ± 0.1,
+					             but found 12.3
+					             at Expect.That(subject).Should().Be(expected).Within(0.1)
+					             """);
+			}
+
+			[Fact]
+			public async Task
+				ForDouble_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				double subject = 12.2;
+				double expected = 12.1;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(-0.1);
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForFloat_WhenInsideTolerance_ShouldSucceed()
+			{
+				float subject = 12.2F;
+				float expected = 12.1F;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(0.1F);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForFloat_WhenOutsideTolerance_ShouldFail()
+			{
+				float subject = 12.3F;
+				float expected = 12.1F;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(0.1F);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be 12.1 ± 0.1,
+					             but found 12.3
+					             at Expect.That(subject).Should().Be(expected).Within(0.1F)
+					             """);
+			}
+
+			[Fact]
+			public async Task
+				ForFloat_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				float subject = 12.2F;
+				float expected = 12.1F;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(-0.1F);
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForInt_WhenInsideTolerance_ShouldSucceed()
 			{
 				int subject = 12;
 				int expected = 11;
@@ -19,10 +184,250 @@ public sealed partial class NumberShould
 			}
 
 			[Fact]
-			public async Task WhenOutsideTolerance_ShouldFail()
+			public async Task ForInt_WhenOutsideTolerance_ShouldFail()
 			{
 				int subject = 12;
 				int expected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be 10 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().Be(expected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task
+				ForInt_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				int subject = 12;
+				int expected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(-1);
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForLong_WhenInsideTolerance_ShouldSucceed()
+			{
+				long subject = 12;
+				long expected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForLong_WhenOutsideTolerance_ShouldFail()
+			{
+				long subject = 12;
+				long expected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be 10 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().Be(expected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task
+				ForLong_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				long subject = 12;
+				long expected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(-1);
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForSbyte_WhenInsideTolerance_ShouldSucceed()
+			{
+				sbyte subject = 12;
+				sbyte expected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForSbyte_WhenOutsideTolerance_ShouldFail()
+			{
+				sbyte subject = 12;
+				sbyte expected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be 10 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().Be(expected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task
+				ForSbyte_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				sbyte subject = 12;
+				sbyte expected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(-1);
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForShort_WhenInsideTolerance_ShouldSucceed()
+			{
+				short subject = 12;
+				short expected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForShort_WhenOutsideTolerance_ShouldFail()
+			{
+				short subject = 12;
+				short expected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be 10 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().Be(expected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task
+				ForShort_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				short subject = 12;
+				short expected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(-1);
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForUint_WhenInsideTolerance_ShouldSucceed()
+			{
+				uint subject = 12;
+				uint expected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForUint_WhenOutsideTolerance_ShouldFail()
+			{
+				uint subject = 12;
+				uint expected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be 10 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().Be(expected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForUlong_WhenInsideTolerance_ShouldSucceed()
+			{
+				ulong subject = 12;
+				ulong expected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForUlong_WhenOutsideTolerance_ShouldFail()
+			{
+				ulong subject = 12;
+				ulong expected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be 10 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().Be(expected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForUshort_WhenInsideTolerance_ShouldSucceed()
+			{
+				ushort subject = 12;
+				ushort expected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForUshort_WhenOutsideTolerance_ShouldFail()
+			{
+				ushort subject = 12;
+				ushort expected = 10;
 
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.Be.WithinTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.Be.WithinTests.cs
@@ -442,4 +442,445 @@ public sealed partial class NumberShould
 			}
 		}
 	}
+
+	public sealed class NotBe
+	{
+		public sealed class WithinTests
+		{
+			[Fact]
+			public async Task ForByte_WhenInsideTolerance_ShouldFail()
+			{
+				byte subject = 12;
+				byte unexpected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be 11 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForByte_WhenOutsideTolerance_ShouldSucceed()
+			{
+				byte subject = 12;
+				byte unexpected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForDecimal_WhenInsideTolerance_ShouldFail()
+			{
+				decimal subject = new(12.2);
+				decimal unexpected = new(12.1);
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(new decimal(0.1));
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be 12.1 ± 0.1,
+					             but found 12.2
+					             at Expect.That(subject).Should().NotBe(unexpected).Within(new decimal(0.1))
+					             """);
+			}
+
+			[Fact]
+			public async Task ForDecimal_WhenOutsideTolerance_ShouldSucceed()
+			{
+				decimal subject = new(12.3);
+				decimal unexpected = new(12.1);
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(new decimal(0.1));
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task
+				ForDecimal_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				decimal subject = new(12.2);
+				decimal unexpected = new(12.1);
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(new decimal(-0.1));
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForDouble_WhenInsideTolerance_ShouldFail()
+			{
+				double subject = 12.2;
+				double unexpected = 12.1;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(0.1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be 12.1 ± 0.1,
+					             but found 12.2
+					             at Expect.That(subject).Should().NotBe(unexpected).Within(0.1)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForDouble_WhenOutsideTolerance_ShouldSucceed()
+			{
+				double subject = 12.3;
+				double unexpected = 12.1;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(0.1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task
+				ForDouble_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				double subject = 12.2;
+				double unexpected = 12.1;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(-0.1);
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForFloat_WhenInsideTolerance_ShouldFail()
+			{
+				float subject = 12.2F;
+				float unexpected = 12.1F;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(0.1F);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be 12.1 ± 0.1,
+					             but found 12.2
+					             at Expect.That(subject).Should().NotBe(unexpected).Within(0.1F)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForFloat_WhenOutsideTolerance_ShouldSucceed()
+			{
+				float subject = 12.3F;
+				float unexpected = 12.1F;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(0.1F);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task
+				ForFloat_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				float subject = 12.2F;
+				float unexpected = 12.1F;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(-0.1F);
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForInt_WhenInsideTolerance_ShouldFail()
+			{
+				int subject = 12;
+				int unexpected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be 11 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForInt_WhenOutsideTolerance_ShouldSucceed()
+			{
+				int subject = 12;
+				int unexpected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task
+				ForInt_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				int subject = 12;
+				int unexpected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(-1);
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForLong_WhenInsideTolerance_ShouldFail()
+			{
+				long subject = 12;
+				long unexpected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be 11 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForLong_WhenOutsideTolerance_ShouldSucceed()
+			{
+				long subject = 12;
+				long unexpected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task
+				ForLong_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				long subject = 12;
+				long unexpected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(-1);
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForSbyte_WhenInsideTolerance_ShouldFail()
+			{
+				sbyte subject = 12;
+				sbyte unexpected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be 11 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForSbyte_WhenOutsideTolerance_ShouldSucceed()
+			{
+				sbyte subject = 12;
+				sbyte unexpected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task
+				ForSbyte_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				sbyte subject = 12;
+				sbyte unexpected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(-1);
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForShort_WhenInsideTolerance_ShouldFail()
+			{
+				short subject = 12;
+				short unexpected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be 11 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForShort_WhenOutsideTolerance_ShouldSucceed()
+			{
+				short subject = 12;
+				short unexpected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task
+				ForShort_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+			{
+				short subject = 12;
+				short unexpected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(-1);
+
+				await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+					.WithParamName("tolerance").And
+					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task ForUint_WhenInsideTolerance_ShouldFail()
+			{
+				uint subject = 12;
+				uint unexpected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be 11 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForUint_WhenOutsideTolerance_ShouldSucceed()
+			{
+				uint subject = 12;
+				uint unexpected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForUlong_WhenInsideTolerance_ShouldFail()
+			{
+				ulong subject = 12;
+				ulong unexpected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be 11 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForUlong_WhenOutsideTolerance_ShouldSucceed()
+			{
+				ulong subject = 12;
+				ulong unexpected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task ForUshort_WhenInsideTolerance_ShouldFail()
+			{
+				ushort subject = 12;
+				ushort unexpected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be 11 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					             """);
+			}
+
+			[Fact]
+			public async Task ForUshort_WhenOutsideTolerance_ShouldSucceed()
+			{
+				ushort subject = 12;
+				ushort unexpected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().NotBe(unexpected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+		}
+	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.Be.WithinTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.Be.WithinTests.cs
@@ -1,0 +1,40 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
+
+public sealed partial class NumberShould
+{
+	public sealed class Be
+	{
+		public sealed class WithinTests
+		{
+			[Fact]
+			public async Task WhenInsideTolerance_ShouldSucceed()
+			{
+				int subject = 12;
+				int expected = 11;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task WhenOutsideTolerance_ShouldFail()
+			{
+				int subject = 12;
+				int expected = 10;
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).Within(1);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be 10 ± 1,
+					             but found 12
+					             at Expect.That(subject).Should().Be(expected).Within(1)
+					             """);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #72 by allowing specifying a tolerance `.Within(tolerance)` on number `Be` and `NotBe` expectations.