### PR TITLE
feat: support cancellation of expectations

### DIFF
--- a/Source/Testably.Expectations/Core/Constraints/IAsyncConstraint.cs
+++ b/Source/Testably.Expectations/Core/Constraints/IAsyncConstraint.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace Testably.Expectations.Core.Constraints;
 
@@ -10,5 +11,5 @@ public interface IAsyncConstraint<in TValue> : IConstraint
 	/// <summary>
 	///     Checks if the <paramref name="actual" /> value meets the expectation.
 	/// </summary>
-	public Task<ConstraintResult> IsMetBy(TValue actual);
+	public Task<ConstraintResult> IsMetBy(TValue actual, CancellationToken cancellationToken);
 }

--- a/Source/Testably.Expectations/Core/Constraints/IAsyncContextConstraint.cs
+++ b/Source/Testably.Expectations/Core/Constraints/IAsyncContextConstraint.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Testably.Expectations.Core.EvaluationContext;
 
 namespace Testably.Expectations.Core.Constraints;
@@ -11,5 +12,5 @@ public interface IAsyncContextConstraint<in TValue> : IConstraint
 	/// <summary>
 	///     Checks if the <paramref name="actual" /> value meets the expectation using the <see cref="IEvaluationContext" />.
 	/// </summary>
-	public Task<ConstraintResult> IsMetBy(TValue actual, IEvaluationContext context);
+	public Task<ConstraintResult> IsMetBy(TValue actual, IEvaluationContext context, CancellationToken cancellationToken);
 }

--- a/Source/Testably.Expectations/Core/EvaluationContext/EvaluationContextExtensions.cs
+++ b/Source/Testably.Expectations/Core/EvaluationContext/EvaluationContextExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Testably.Expectations.Core.EvaluationContext;
@@ -94,7 +93,8 @@ internal static class EvaluationContextExtensions
 			return existingValue;
 		}
 
-		IAsyncEnumerable<TItem> materializedEnumerable = MaterializingAsyncEnumerable<TItem>.Wrap(collection);
+		IAsyncEnumerable<TItem> materializedEnumerable =
+			MaterializingAsyncEnumerable<TItem>.Wrap(collection);
 		// ReSharper disable once PossibleMultipleEnumeration
 		evaluationContext.Store(MaterializedAsyncEnumerableKey, materializedEnumerable);
 		// ReSharper disable once PossibleMultipleEnumeration
@@ -113,7 +113,8 @@ internal static class EvaluationContextExtensions
 
 		#region IAsyncEnumerable<T> Members
 
-		public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+		public async IAsyncEnumerator<T> GetAsyncEnumerator(
+			CancellationToken cancellationToken = default)
 		{
 			foreach (T materializedItem in _materializedItems)
 			{
@@ -126,6 +127,7 @@ internal static class EvaluationContextExtensions
 				{
 					break;
 				}
+
 				T item = _enumerator.Current;
 				_materializedItems.Add(item);
 				yield return item;

--- a/Source/Testably.Expectations/Core/EvaluationContext/EvaluationContextExtensions.cs
+++ b/Source/Testably.Expectations/Core/EvaluationContext/EvaluationContextExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Testably.Expectations.Core.EvaluationContext;
@@ -110,13 +111,9 @@ internal static class EvaluationContextExtensions
 			_enumerator = enumerable.GetAsyncEnumerator();
 		}
 
-		#region IEnumerable<T> Members
+		#region IAsyncEnumerable<T> Members
 
-		/// <inheritdoc />
-		public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken())
-			=> GetAsyncEnumerator();
-
-		private async IAsyncEnumerator<T> GetAsyncEnumerator()
+		public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
 		{
 			foreach (T materializedItem in _materializedItems)
 			{
@@ -125,6 +122,10 @@ internal static class EvaluationContextExtensions
 
 			while (await _enumerator.MoveNextAsync())
 			{
+				if (cancellationToken.IsCancellationRequested)
+				{
+					break;
+				}
 				T item = _enumerator.Current;
 				_materializedItems.Add(item);
 				yield return item;

--- a/Source/Testably.Expectations/Core/ExpectationBuilder.cs
+++ b/Source/Testably.Expectations/Core/ExpectationBuilder.cs
@@ -151,7 +151,8 @@ public abstract class ExpectationBuilder
 	}
 
 	internal abstract Task<ConstraintResult> IsMet(
-		Node rootNode, EvaluationContext.EvaluationContext context,
+		Node rootNode,
+		EvaluationContext.EvaluationContext context,
 		CancellationToken cancellationToken);
 
 	internal void Or(Action<StringBuilder> expressionBuilder,
@@ -207,16 +208,18 @@ internal class ExpectationBuilder<TValue> : ExpectationBuilder
 	/// </summary>
 	private readonly IValueSource<TValue> _subjectSource;
 
-	internal ExpectationBuilder(IValueSource<TValue> subjectSource, string subjectExpression) :
-		base(
-			subjectExpression)
+	internal ExpectationBuilder(
+		IValueSource<TValue> subjectSource,
+		string subjectExpression)
+		: base(subjectExpression)
 	{
 		_subjectSource = subjectSource;
 	}
 
 	/// <inheritdoc />
 	internal override async Task<ConstraintResult> IsMet(
-		Node rootNode, EvaluationContext.EvaluationContext context,
+		Node rootNode,
+		EvaluationContext.EvaluationContext context,
 		CancellationToken cancellationToken)
 	{
 		TValue? data = await _subjectSource.GetValue();

--- a/Source/Testably.Expectations/Core/Nodes/AndNode.cs
+++ b/Source/Testably.Expectations/Core/Nodes/AndNode.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.EvaluationContext;
 using Testably.Expectations.Core.Helpers;
@@ -21,16 +22,17 @@ internal class AndNode : CombinationNode
 	/// <inheritdoc />
 	public override async Task<ConstraintResult> IsMetBy<TValue>(
 		TValue? value,
-		IEvaluationContext context)
+		IEvaluationContext context,
+		CancellationToken cancellationToken)
 		where TValue : default
 	{
-		ConstraintResult leftResult = await Left.IsMetBy(value, context);
+		ConstraintResult leftResult = await Left.IsMetBy(value, context, cancellationToken);
 		if (leftResult.IgnoreFurtherProcessing)
 		{
 			return leftResult;
 		}
 
-		ConstraintResult rightResult = await Right.IsMetBy(value, context);
+		ConstraintResult rightResult = await Right.IsMetBy(value, context, cancellationToken);
 
 		string combinedExpectation =
 			$"{leftResult.ExpectationText}{_textSeparator}{rightResult.ExpectationText}";

--- a/Source/Testably.Expectations/Core/Nodes/CastNode.cs
+++ b/Source/Testably.Expectations/Core/Nodes/CastNode.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.EvaluationContext;
 
@@ -18,14 +19,15 @@ internal class CastNode<T1, T2> : ManipulationNode
 	/// <inheritdoc />
 	public override async Task<ConstraintResult> IsMetBy<TValue>(
 		TValue? value,
-		IEvaluationContext context)
+		IEvaluationContext context,
+		CancellationToken cancellationToken)
 		where TValue : default
 	{
-		ConstraintResult? result = await TryMeet(CastConstraint, value, context, Reason);
+		ConstraintResult? result = await TryMeet(CastConstraint, value, Reason, context, cancellationToken);
 		if (!result.IgnoreFurtherProcessing && Inner != None &&
 		    result is ConstraintResult.Success<T2> success)
 		{
-			return (await Inner.IsMetBy(success.Value, context))
+			return (await Inner.IsMetBy(success.Value, context, cancellationToken))
 				.UpdateExpectationText(e => $"{result.ExpectationText} {e.ExpectationText}");
 		}
 

--- a/Source/Testably.Expectations/Core/Nodes/DeferredNode.cs
+++ b/Source/Testably.Expectations/Core/Nodes/DeferredNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.EvaluationContext;
@@ -18,7 +19,8 @@ internal class DeferredNode<TTarget> : Node
 	/// <inheritdoc />
 	public override async Task<ConstraintResult> IsMetBy<TValue>(
 		TValue? value,
-		IEvaluationContext context)
+		IEvaluationContext context,
+		CancellationToken cancellationToken)
 		where TValue : default
 	{
 		if (value is not TTarget matchingActualValue)

--- a/Source/Testably.Expectations/Core/Nodes/ExpectationNode.cs
+++ b/Source/Testably.Expectations/Core/Nodes/ExpectationNode.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.EvaluationContext;
 
@@ -16,9 +17,10 @@ internal class ExpectationNode : Node
 	/// <inheritdoc />
 	public override Task<ConstraintResult> IsMetBy<TValue>(
 		TValue? value,
-		IEvaluationContext context)
+		IEvaluationContext context,
+		CancellationToken cancellationToken)
 		where TValue : default
-		=> TryMeet(Constraint, value, context, Reason);
+		=> TryMeet(Constraint, value, Reason, context, cancellationToken);
 
 	/// <inheritdoc />
 	public override string ToString()

--- a/Source/Testably.Expectations/Core/Nodes/OrNode.cs
+++ b/Source/Testably.Expectations/Core/Nodes/OrNode.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.EvaluationContext;
 using Testably.Expectations.Core.Helpers;
@@ -21,16 +22,17 @@ internal class OrNode : CombinationNode
 	/// <inheritdoc />
 	public override async Task<ConstraintResult> IsMetBy<TValue>(
 		TValue? value,
-		IEvaluationContext context)
+		IEvaluationContext context,
+		CancellationToken cancellationToken)
 		where TValue : default
 	{
-		ConstraintResult leftResult = await Left.IsMetBy(value, context);
+		ConstraintResult leftResult = await Left.IsMetBy(value, context, cancellationToken);
 		if (leftResult.IgnoreFurtherProcessing)
 		{
 			return leftResult;
 		}
 
-		ConstraintResult rightResult = await Right.IsMetBy(value, context);
+		ConstraintResult rightResult = await Right.IsMetBy(value, context, cancellationToken);
 
 		string combinedExpectation =
 			$"{leftResult.ExpectationText}{_textSeparator}{rightResult.ExpectationText}";

--- a/Source/Testably.Expectations/Core/Nodes/WhichNode.cs
+++ b/Source/Testably.Expectations/Core/Nodes/WhichNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.EvaluationContext;
@@ -22,7 +23,8 @@ internal class WhichNode<TSource, TProperty> : ManipulationNode
 	/// <inheritdoc />
 	public override async Task<ConstraintResult> IsMetBy<TValue>(
 		TValue? value,
-		IEvaluationContext context)
+		IEvaluationContext context,
+		CancellationToken cancellationToken)
 		where TValue : default
 	{
 		if (_propertyAccessor is PropertyAccessor<TSource, TProperty> propertyAccessor)
@@ -37,7 +39,7 @@ internal class WhichNode<TSource, TProperty> : ManipulationNode
 				typedValue,
 				out TProperty? matchingValue))
 			{
-				ConstraintResult result = (await Inner.IsMetBy(matchingValue, context))
+				ConstraintResult result = (await Inner.IsMetBy(matchingValue, context, cancellationToken))
 					.UpdateExpectationText(r
 						=> _expectationTextGenerator(_propertyAccessor, r.ExpectationText));
 				return result.UseValue(value);

--- a/Source/Testably.Expectations/Results/ExpectationResult.cs
+++ b/Source/Testably.Expectations/Results/ExpectationResult.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
@@ -31,6 +32,19 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder)
 	{
 		Task result = GetResult();
 		return result.GetAwaiter();
+	}
+
+	/// <summary>
+	///     Sets the <see cref="CancellationToken" /> to be passed to expectations.
+	/// </summary>
+	public ExpectationResult WithCancellation(CancellationToken cancellationToken,
+		[CallerArgumentExpression("cancellationToken")]
+		string doNotPopulateThisValue = "")
+	{
+		expectationBuilder
+			.AppendMethodStatement(nameof(WithCancellation), doNotPopulateThisValue)
+			.AddCancellation(cancellationToken);
+		return this;
 	}
 
 	private async Task GetResult()
@@ -87,6 +101,19 @@ public class ExpectationResult<TResult, TSelf>(ExpectationBuilder expectationBui
 	{
 		Task<TResult> result = GetResult();
 		return result.GetAwaiter();
+	}
+
+	/// <summary>
+	///     Sets the <see cref="CancellationToken" /> to be passed to expectations.
+	/// </summary>
+	public TSelf WithCancellation(CancellationToken cancellationToken,
+		[CallerArgumentExpression("cancellationToken")]
+		string doNotPopulateThisValue = "")
+	{
+		expectationBuilder
+			.AppendMethodStatement(nameof(WithCancellation), doNotPopulateThisValue)
+			.AddCancellation(cancellationToken);
+		return (TSelf)this;
 	}
 
 	[StackTraceHidden]

--- a/Source/Testably.Expectations/That/Collections/CollectionEvaluatorResult.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionEvaluatorResult.cs
@@ -5,4 +5,4 @@ namespace Testably.Expectations;
 /// <summary>
 ///     The result when checking the condition in an <see cref="ICollectionEvaluator{TItem}" />.
 /// </summary>
-public record struct CollectionEvaluatorResult(bool IsSuccess, string Error);
+public record struct CollectionEvaluatorResult(bool? IsSuccess, string Error);

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.All.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.All.cs
@@ -13,7 +13,8 @@ public abstract partial class CollectionQuantifier
 	private sealed class AllQuantifier : CollectionQuantifier
 	{
 		/// <inheritdoc />
-		public override string ToString(bool includeItems) => $"all{(includeItems ? " items" : "")}";
+		public override string ToString(bool includeItems)
+			=> $"all{(includeItems ? " items" : "")}";
 
 		/// <inheritdoc />
 		protected override bool ContinueEvaluation(

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.Between.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.Between.cs
@@ -14,7 +14,8 @@ public abstract partial class CollectionQuantifier
 	private sealed class BetweenQuantifier(int minimum, int maximum) : CollectionQuantifier
 	{
 		/// <inheritdoc />
-		public override string ToString(bool includeItems) => $"between {minimum} and {maximum}{(includeItems ? " items" : "")}";
+		public override string ToString(bool includeItems)
+			=> $"between {minimum} and {maximum}{(includeItems ? " items" : "")}";
 
 		/// <inheritdoc />
 		protected override bool ContinueEvaluation(

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.cs
@@ -138,11 +138,17 @@ public abstract partial class CollectionQuantifier
 				}
 			}
 
+			if (cancellationToken.IsCancellationRequested)
+			{
+				return new CollectionEvaluatorResult(null,
+					"could not verify, because it was cancelled early");
+			}
+
 			return !quantifier.ContinueEvaluation(
 				matchingCount, notMatchingCount, matchingCount + notMatchingCount,
 				out CollectionEvaluatorResult? finalResult)
 				? finalResult.Value
-				: new CollectionEvaluatorResult(false, "could not decide");
+				: new CollectionEvaluatorResult(false, "could not verify");
 		}
 
 		#endregion

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Testably.Expectations.Core.EvaluationContext;
 // ReSharper disable once CheckNamespace
@@ -64,7 +65,8 @@ public abstract partial class CollectionQuantifier
 		/// <inheritdoc cref="ICollectionEvaluator{TItem}.CheckCondition{TExpected}" />
 		public Task<CollectionEvaluatorResult> CheckCondition<TExpected>(
 			TExpected expected,
-			Func<TItem, TExpected, bool> predicate)
+			Func<TItem, TExpected, bool> predicate,
+			CancellationToken cancellationToken)
 		{
 			int matchingCount = 0;
 			int notMatchingCount = 0;
@@ -110,13 +112,14 @@ public abstract partial class CollectionQuantifier
 		/// <inheritdoc cref="ICollectionEvaluator{TItem}.CheckCondition{TExpected}" />
 		public async Task<CollectionEvaluatorResult> CheckCondition<TExpected>(
 			TExpected expected,
-			Func<TItem, TExpected, bool> predicate)
+			Func<TItem, TExpected, bool> predicate,
+			CancellationToken cancellationToken)
 		{
 			int matchingCount = 0;
 			int notMatchingCount = 0;
 			int? totalCount = null;
 
-			await foreach (TItem item in asyncEnumerable)
+			await foreach (TItem item in asyncEnumerable.WithCancellation(cancellationToken))
 			{
 				bool isMatch = predicate(item, expected);
 				if (isMatch)

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.cs
@@ -74,6 +74,11 @@ public abstract partial class CollectionQuantifier
 
 			foreach (TItem item in enumerable)
 			{
+				if (cancellationToken.IsCancellationRequested)
+				{
+					break;
+				}
+				
 				bool isMatch = predicate(item, expected);
 				if (isMatch)
 				{
@@ -91,11 +96,18 @@ public abstract partial class CollectionQuantifier
 				}
 			}
 
+			if (cancellationToken.IsCancellationRequested)
+			{
+				return Task.FromResult(
+					new CollectionEvaluatorResult(null,
+						"could not verify, because it was cancelled early"));
+			}
+
 			return Task.FromResult(!quantifier.ContinueEvaluation(
 				matchingCount, notMatchingCount, matchingCount + notMatchingCount,
 				out CollectionEvaluatorResult? finalResult)
 				? finalResult.Value
-				: new CollectionEvaluatorResult(false, "could not decide"));
+				: new CollectionEvaluatorResult(false, "could not verify"));
 		}
 
 		#endregion

--- a/Source/Testably.Expectations/That/Collections/ICollectionEvaluator.cs
+++ b/Source/Testably.Expectations/That/Collections/ICollectionEvaluator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 // ReSharper disable once CheckNamespace
 
@@ -15,5 +16,6 @@ public interface ICollectionEvaluator<out TItem>
 	/// </summary>
 	Task<CollectionEvaluatorResult> CheckCondition<TExpected>(
 		TExpected expected,
-		Func<TItem, TExpected, bool> predicate);
+		Func<TItem, TExpected, bool> predicate,
+		CancellationToken cancellationToken);
 }

--- a/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.Be.cs
+++ b/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.Be.cs
@@ -82,13 +82,12 @@ public class QuantifiedCollectionResult
 				.CheckCondition(default(TItem), (a, _) => a is TExpected, cancellationToken)
 				.ConfigureAwait(false);
 
-			if (result.IsSuccess)
+			return result.IsSuccess switch
 			{
-				return new ConstraintResult.Success<TCollection>(actual, ToString());
-			}
-
-			return new ConstraintResult.Failure(ToString(),
-				$"{result.Error} items were");
+				true => new ConstraintResult.Success<TCollection>(actual, ToString()),
+				false => new ConstraintResult.Failure(ToString(), $"{result.Error} items were"),
+				_ => new ConstraintResult.Failure(ToString(), result.Error)
+			};
 		}
 
 		public override string ToString()

--- a/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.Be.cs
+++ b/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.Be.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
@@ -72,12 +72,14 @@ public class QuantifiedCollectionResult
 		Func<TCollection, IEvaluationContext, ICollectionEvaluator<TItem>> evaluatorFactory)
 		: IAsyncContextConstraint<TCollection>
 	{
-		public async Task<ConstraintResult> IsMetBy(TCollection actual,
-			IEvaluationContext context)
+		public async Task<ConstraintResult> IsMetBy(
+			TCollection actual,
+			IEvaluationContext context,
+			CancellationToken cancellationToken)
 		{
 			ICollectionEvaluator<TItem> evaluator = evaluatorFactory(actual, context);
 			CollectionEvaluatorResult result = await evaluator
-				.CheckCondition(default(TItem), (a, _) => a is TExpected)
+				.CheckCondition(default(TItem), (a, _) => a is TExpected, cancellationToken)
 				.ConfigureAwait(false);
 
 			if (result.IsSuccess)

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.All.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.All.cs
@@ -12,7 +12,7 @@ public static partial class ThatAsyncEnumerableShould
 	/// </summary>
 	public static QuantifiedCollectionResult.Async
 		<IThat<IAsyncEnumerable<TItem>>, TItem, IAsyncEnumerable<TItem>> All<TItem>(
-		this IThat<IAsyncEnumerable<TItem>> source)
+			this IThat<IAsyncEnumerable<TItem>> source)
 		=> new(source,
 			source.ExpectationBuilder.AppendMethodStatement(nameof(All)),
 			CollectionQuantifier.All);

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.AtLeast.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.AtLeast.cs
@@ -13,8 +13,8 @@ public static partial class ThatAsyncEnumerableShould
 	/// </summary>
 	public static QuantifiedCollectionResult.Async
 		<IThat<IAsyncEnumerable<TItem>>, TItem, IAsyncEnumerable<TItem>> AtLeast<TItem>(
-		this IThat<IAsyncEnumerable<TItem>> source,
-		int minimum, [CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
+			this IThat<IAsyncEnumerable<TItem>> source,
+			int minimum, [CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
 		=> new(source,
 			source.ExpectationBuilder.AppendMethodStatement(nameof(AtLeast),
 				doNotPopulateThisValue),

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.AtMost.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.AtMost.cs
@@ -13,8 +13,8 @@ public static partial class ThatAsyncEnumerableShould
 	/// </summary>
 	public static QuantifiedCollectionResult.Async
 		<IThat<IAsyncEnumerable<TItem>>, TItem, IAsyncEnumerable<TItem>> AtMost<TItem>(
-		this IThat<IAsyncEnumerable<TItem>> source,
-		int maximum, [CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "")
+			this IThat<IAsyncEnumerable<TItem>> source,
+			int maximum, [CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "")
 		=> new(source,
 			source.ExpectationBuilder.AppendMethodStatement(nameof(AtMost), doNotPopulateThisValue),
 			CollectionQuantifier.AtMost(maximum));

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.BeEmpty.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.BeEmpty.cs
@@ -63,6 +63,12 @@ public static partial class ThatAsyncEnumerableShould
 					$"found {Formatter.Format(items)}");
 			}
 
+			if (cancellationToken.IsCancellationRequested)
+			{
+				return new ConstraintResult.Failure(ToString(),
+					"could not evaluate it, because it was already cancelled");
+			}
+
 			return new ConstraintResult.Success<IAsyncEnumerable<TItem>>(materializedEnumerable,
 				ToString());
 		}

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.BeEmpty.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.BeEmpty.cs
@@ -1,5 +1,6 @@
 ﻿#if NET6_0_OR_GREATER
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
@@ -34,16 +35,18 @@ public static partial class ThatAsyncEnumerableShould
 				.AppendMethodStatement(nameof(NotBeEmpty)),
 			source);
 
-	private readonly struct
-		IsEmptyValueConstraint<TItem> : IAsyncContextConstraint<IAsyncEnumerable<TItem>>
+	private readonly struct IsEmptyValueConstraint<TItem>
+		: IAsyncContextConstraint<IAsyncEnumerable<TItem>>
 	{
 		public async Task<ConstraintResult> IsMetBy(
-			IAsyncEnumerable<TItem> actual, IEvaluationContext context)
+			IAsyncEnumerable<TItem> actual,
+			IEvaluationContext context,
+			CancellationToken cancellationToken)
 		{
 			IAsyncEnumerable<TItem> materializedEnumerable =
 				context.UseMaterializedAsyncEnumerable<TItem, IAsyncEnumerable<TItem>>(actual);
 			await using IAsyncEnumerator<TItem> enumerator =
-				materializedEnumerable.GetAsyncEnumerator();
+				materializedEnumerable.GetAsyncEnumerator(cancellationToken);
 			if (await enumerator.MoveNextAsync())
 			{
 				List<TItem> items = new(11) { enumerator.Current };
@@ -68,16 +71,18 @@ public static partial class ThatAsyncEnumerableShould
 			=> "be empty";
 	}
 
-	private readonly struct
-		IsNotEmptyConstraint<TItem> : IAsyncContextConstraint<IAsyncEnumerable<TItem>>
+	private readonly struct IsNotEmptyConstraint<TItem>
+		: IAsyncContextConstraint<IAsyncEnumerable<TItem>>
 	{
 		public async Task<ConstraintResult> IsMetBy(
-			IAsyncEnumerable<TItem> actual, IEvaluationContext context)
+			IAsyncEnumerable<TItem> actual,
+			IEvaluationContext context,
+			CancellationToken cancellationToken)
 		{
 			IAsyncEnumerable<TItem> materializedEnumerable =
 				context.UseMaterializedAsyncEnumerable<TItem, IAsyncEnumerable<TItem>>(actual);
 			await using IAsyncEnumerator<TItem> enumerator =
-				materializedEnumerable.GetAsyncEnumerator();
+				materializedEnumerable.GetAsyncEnumerator(cancellationToken);
 			if (await enumerator.MoveNextAsync())
 			{
 				return new ConstraintResult.Success<IAsyncEnumerable<TItem>>(materializedEnumerable,

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.Between.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.Between.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
-using Testably.Expectations.Results;
 
 // ReSharper disable once CheckNamespace
 namespace Testably.Expectations;

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.None.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.None.cs
@@ -12,7 +12,7 @@ public static partial class ThatAsyncEnumerableShould
 	/// </summary>
 	public static QuantifiedCollectionResult.Async
 		<IThat<IAsyncEnumerable<TItem>>, TItem, IAsyncEnumerable<TItem>> None<TItem>(
-		this IThat<IAsyncEnumerable<TItem>> source)
+			this IThat<IAsyncEnumerable<TItem>> source)
 		=> new(source,
 			source.ExpectationBuilder.AppendMethodStatement(nameof(None)),
 			CollectionQuantifier.None);

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtMost.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtMost.cs
@@ -12,11 +12,12 @@ public static partial class ThatEnumerableShould
 	/// </summary>
 	public static QuantifiedCollectionResult.Sync
 		<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>> AtMost<TItem>(
-		this IThat<IEnumerable<TItem>> source,
-		int maximum, [CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "")
+			this IThat<IEnumerable<TItem>> source,
+			int maximum, [CallerArgumentExpression("maximum")] string doNotPopulateThisValue = "")
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(AtMost), doNotPopulateThisValue);
-		return new QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
+		return new QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem,
+			IEnumerable<TItem>>(
 			source,
 			source.ExpectationBuilder,
 			CollectionQuantifier.AtMost(maximum));

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.BeEmpty.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.BeEmpty.cs
@@ -15,8 +15,7 @@ public static partial class ThatEnumerableShould
 	///     Verifies that the actual enumerable is empty.
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
-		BeEmpty<TItem>(
-			this IThat<IEnumerable<TItem>> source)
+		BeEmpty<TItem>(this IThat<IEnumerable<TItem>> source)
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new IsEmptyValueConstraint<TItem>())
 				.AppendMethodStatement(nameof(BeEmpty)),

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.Between.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.Between.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
-using Testably.Expectations.Results;
 
 // ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
@@ -19,11 +18,14 @@ public static partial class ThatEnumerableShould
 			[CallerArgumentExpression("minimum")] string doNotPopulateThisValue = "")
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(Between), doNotPopulateThisValue);
-		return new BetweenResult<QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>>(
+		return new BetweenResult<QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem,
+			IEnumerable<TItem>>>(
 			source.ExpectationBuilder,
-			maximum => new QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
-				source,
-				source.ExpectationBuilder,
-				CollectionQuantifier.Between(minimum, maximum)));
+			maximum
+				=> new QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem,
+					IEnumerable<TItem>>(
+					source,
+					source.ExpectationBuilder,
+					CollectionQuantifier.Between(minimum, maximum)));
 	}
 }

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.None.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.None.cs
@@ -9,11 +9,14 @@ public static partial class ThatEnumerableShould
 	/// <summary>
 	///     Verifies that no items in the enumerable...
 	/// </summary>
-	public static QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>> None<TItem>(
-		this IThat<IEnumerable<TItem>> source)
+	public static
+		QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>
+		None<TItem>(
+			this IThat<IEnumerable<TItem>> source)
 	{
 		source.ExpectationBuilder.AppendMethodStatement(nameof(None));
-		return new QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem, IEnumerable<TItem>>(
+		return new QuantifiedCollectionResult.Sync<IThat<IEnumerable<TItem>>, TItem,
+			IEnumerable<TItem>>(
 			source,
 			source.ExpectationBuilder,
 			CollectionQuantifier.None);

--- a/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Be.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Be.cs
@@ -72,12 +72,13 @@ public static partial class ThatQuantifiedCollectionResultShould
 				.CheckCondition(expected, (a, e) => a?.Equals(e) == true, cancellationToken)
 				.ConfigureAwait(false);
 
-			if (result.IsSuccess)
+			return result.IsSuccess switch
 			{
-				return new ConstraintResult.Success<TCollection>(actual, ToString());
-			}
-
-			return new ConstraintResult.Failure(ToString(), $"{result.Error} items were equal");
+				true => new ConstraintResult.Success<TCollection>(actual, ToString()),
+				false => new ConstraintResult.Failure(ToString(),
+					$"{result.Error} items were equal"),
+				_ => new ConstraintResult.Failure(ToString(), result.Error)
+			};
 		}
 
 		public override string ToString()

--- a/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Be.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Be.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
@@ -61,11 +62,14 @@ public static partial class ThatQuantifiedCollectionResultShould
 		Func<TCollection, IEvaluationContext, ICollectionEvaluator<TItem>> evaluatorFactory)
 		: IAsyncContextConstraint<TCollection>
 	{
-		public async Task<ConstraintResult> IsMetBy(TCollection actual, IEvaluationContext context)
+		public async Task<ConstraintResult> IsMetBy(
+			TCollection actual,
+			IEvaluationContext context,
+			CancellationToken cancellationToken)
 		{
 			ICollectionEvaluator<TItem> evaluator = evaluatorFactory(actual, context);
 			CollectionEvaluatorResult result = await evaluator
-				.CheckCondition(expected, (a, e) => a?.Equals(e) == true)
+				.CheckCondition(expected, (a, e) => a?.Equals(e) == true, cancellationToken)
 				.ConfigureAwait(false);
 
 			if (result.IsSuccess)

--- a/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.BeEquivalentTo.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.BeEquivalentTo.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
@@ -79,16 +80,22 @@ public static partial class ThatQuantifiedCollectionResultShould
 		Func<TCollection, IEvaluationContext, ICollectionEvaluator<TItem>> evaluatorFactory)
 		: IAsyncContextConstraint<TCollection>
 	{
-		public async Task<ConstraintResult> IsMetBy(TCollection actual, IEvaluationContext context)
+		public async Task<ConstraintResult> IsMetBy(
+			TCollection actual,
+			IEvaluationContext context,
+			CancellationToken cancellationToken)
 		{
 			string[] memberToIgnore = [.. options.MembersToIgnore];
 			ICollectionEvaluator<TItem> evaluator = evaluatorFactory(actual, context);
 			CollectionEvaluatorResult result = await evaluator
-				.CheckCondition(expected, (a, e) => !Compare.CheckEquivalent(a, e,
-					new CompareOptions
-					{
-						MembersToIgnore = memberToIgnore,
-					}).Any())
+				.CheckCondition(
+					expected,
+					(a, e) => !Compare.CheckEquivalent(a, e,
+						new CompareOptions
+						{
+							MembersToIgnore = memberToIgnore,
+						}).Any(),
+					cancellationToken)
 				.ConfigureAwait(false);
 
 			if (result.IsSuccess)

--- a/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.BeEquivalentTo.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.BeEquivalentTo.cs
@@ -98,13 +98,13 @@ public static partial class ThatQuantifiedCollectionResultShould
 					cancellationToken)
 				.ConfigureAwait(false);
 
-			if (result.IsSuccess)
+			return result.IsSuccess switch
 			{
-				return new ConstraintResult.Success<TCollection>(actual, ToString());
-			}
-
-			return new ConstraintResult.Failure(ToString(),
-				$"{result.Error} items were equivalent");
+				true => new ConstraintResult.Success<TCollection>(actual, ToString()),
+				false => new ConstraintResult.Failure(ToString(),
+					$"{result.Error} items were equivalent"),
+				_ => new ConstraintResult.Failure(ToString(), result.Error)
+			};
 		}
 
 		public override string ToString()

--- a/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Satisfy.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Satisfy.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.EvaluationContext;
-using Testably.Expectations.Core.Helpers;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
@@ -114,11 +113,14 @@ public static partial class ThatQuantifiedCollectionResultShould
 		Func<TCollection, IEvaluationContext, ICollectionEvaluator<TItem>> evaluatorFactory)
 		: IAsyncContextConstraint<TCollection>
 	{
-		public async Task<ConstraintResult> IsMetBy(TCollection actual, IEvaluationContext context)
+		public async Task<ConstraintResult> IsMetBy(
+			TCollection actual,
+			IEvaluationContext context,
+			CancellationToken cancellationToken)
 		{
 			ICollectionEvaluator<TItem> evaluator = evaluatorFactory(actual, context);
 			CollectionEvaluatorResult result = await evaluator
-				.CheckCondition(predicate, (a, p) => p(a))
+				.CheckCondition(predicate, (a, p) => p(a), cancellationToken)
 				.ConfigureAwait(false);
 
 			if (result.IsSuccess)

--- a/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Satisfy.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Satisfy.cs
@@ -123,12 +123,12 @@ public static partial class ThatQuantifiedCollectionResultShould
 				.CheckCondition(predicate, (a, p) => p(a), cancellationToken)
 				.ConfigureAwait(false);
 
-			if (result.IsSuccess)
+			return result.IsSuccess switch
 			{
-				return new ConstraintResult.Success<TCollection>(actual, ToString());
-			}
-
-			return new ConstraintResult.Failure(ToString(), $"{result.Error} did");
+				true => new ConstraintResult.Success<TCollection>(actual, ToString()),
+				false => new ConstraintResult.Failure(ToString(), $"{result.Error} did"),
+				_ => new ConstraintResult.Failure(ToString(), result.Error),
+			};
 		}
 
 		public override string ToString()

--- a/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveContent.cs
+++ b/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveContent.cs
@@ -1,6 +1,7 @@
 ﻿#if NET6_0_OR_GREATER
 using System.Net.Http;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
@@ -29,7 +30,9 @@ public static partial class ThatHttpResponseMessageShould
 	private readonly struct HasContentConstraint(StringMatcher expected)
 		: IAsyncConstraint<HttpResponseMessage>
 	{
-		public async Task<ConstraintResult> IsMetBy(HttpResponseMessage? actual)
+		public async Task<ConstraintResult> IsMetBy(
+			HttpResponseMessage? actual,
+			CancellationToken cancellationToken)
 		{
 			if (actual == null)
 			{
@@ -37,7 +40,7 @@ public static partial class ThatHttpResponseMessageShould
 					"found <null>");
 			}
 
-			string message = await actual.Content.ReadAsStringAsync();
+			string message = await actual.Content.ReadAsStringAsync(cancellationToken);
 			if (expected.Matches(message))
 			{
 				return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());

--- a/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveStatusCode.cs
+++ b/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveStatusCode.cs
@@ -3,6 +3,7 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
@@ -46,7 +47,9 @@ public static partial class ThatHttpResponseMessageShould
 	private readonly struct HasStatusCodeConstraint(HttpStatusCode expected)
 		: IAsyncConstraint<HttpResponseMessage>
 	{
-		public async Task<ConstraintResult> IsMetBy(HttpResponseMessage? actual)
+		public async Task<ConstraintResult> IsMetBy(
+			HttpResponseMessage? actual,
+			CancellationToken cancellationToken)
 		{
 			if (actual == null)
 			{
@@ -59,7 +62,8 @@ public static partial class ThatHttpResponseMessageShould
 				return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());
 			}
 
-			string formattedResponse = await HttpResponseMessageFormatter.Format(actual, "  ");
+			string formattedResponse =
+				await HttpResponseMessageFormatter.Format(actual, "  ", cancellationToken);
 			return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
 				$"found {Formatter.Format(actual.StatusCode)}:{Environment.NewLine}{formattedResponse}");
 		}

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -9,9 +9,9 @@ namespace Testably.Expectations
     }
     public struct CollectionEvaluatorResult : System.IEquatable<Testably.Expectations.CollectionEvaluatorResult>
     {
-        public CollectionEvaluatorResult(bool IsSuccess, string Error) { }
+        public CollectionEvaluatorResult(bool? IsSuccess, string Error) { }
         public string Error { get; set; }
-        public bool IsSuccess { get; set; }
+        public bool? IsSuccess { get; set; }
     }
     public abstract class CollectionQuantifier
     {
@@ -55,7 +55,7 @@ namespace Testably.Expectations
     }
     public interface ICollectionEvaluator<out TItem>
     {
-        System.Threading.Tasks.Task<Testably.Expectations.CollectionEvaluatorResult> CheckCondition<TExpected>(TExpected expected, System.Func<TItem, TExpected, bool> predicate);
+        System.Threading.Tasks.Task<Testably.Expectations.CollectionEvaluatorResult> CheckCondition<TExpected>(TExpected expected, System.Func<TItem, TExpected, bool> predicate, System.Threading.CancellationToken cancellationToken);
     }
     public class QuantifiedCollectionResult
     {
@@ -503,11 +503,11 @@ namespace Testably.Expectations.Core.Constraints
     }
     public interface IAsyncConstraint<in TValue> : Testably.Expectations.Core.Constraints.IConstraint
     {
-        System.Threading.Tasks.Task<Testably.Expectations.Core.Constraints.ConstraintResult> IsMetBy(TValue actual);
+        System.Threading.Tasks.Task<Testably.Expectations.Core.Constraints.ConstraintResult> IsMetBy(TValue actual, System.Threading.CancellationToken cancellationToken);
     }
     public interface IAsyncContextConstraint<in TValue> : Testably.Expectations.Core.Constraints.IConstraint
     {
-        System.Threading.Tasks.Task<Testably.Expectations.Core.Constraints.ConstraintResult> IsMetBy(TValue actual, Testably.Expectations.Core.EvaluationContext.IEvaluationContext context);
+        System.Threading.Tasks.Task<Testably.Expectations.Core.Constraints.ConstraintResult> IsMetBy(TValue actual, Testably.Expectations.Core.EvaluationContext.IEvaluationContext context, System.Threading.CancellationToken cancellationToken);
     }
     public interface ICastConstraint<in TValue, TProperty> : Testably.Expectations.Core.Constraints.IConstraint, Testably.Expectations.Core.Constraints.IValueConstraint<TValue> { }
     public interface IConstraint { }
@@ -731,6 +731,7 @@ namespace Testably.Expectations.Results
         public ExpectationResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }
         public Testably.Expectations.Results.ExpectationResult Because(string reason) { }
         public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
+        public Testably.Expectations.Results.ExpectationResult WithCancellation(System.Threading.CancellationToken cancellationToken, [System.Runtime.CompilerServices.CallerArgumentExpression("cancellationToken")] string doNotPopulateThisValue = "") { }
     }
     public class ExpectationResult<TResult> : Testably.Expectations.Results.ExpectationResult<TResult, Testably.Expectations.Results.ExpectationResult<TResult>>
     {
@@ -744,6 +745,7 @@ namespace Testably.Expectations.Results
         public TSelf Because(string reason, [System.Runtime.CompilerServices.CallerArgumentExpression("reason")] string doNotPopulateThisValue = "") { }
         [System.Diagnostics.StackTraceHidden]
         public System.Runtime.CompilerServices.TaskAwaiter<TResult> GetAwaiter() { }
+        public TSelf WithCancellation(System.Threading.CancellationToken cancellationToken, [System.Runtime.CompilerServices.CallerArgumentExpression("cancellationToken")] string doNotPopulateThisValue = "") { }
     }
     public class NumberToleranceResult<TNumber, TResult> : Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult, Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult>>
         where TNumber :  struct, System.IComparable<TNumber>

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -9,9 +9,9 @@ namespace Testably.Expectations
     }
     public struct CollectionEvaluatorResult : System.IEquatable<Testably.Expectations.CollectionEvaluatorResult>
     {
-        public CollectionEvaluatorResult(bool IsSuccess, string Error) { }
+        public CollectionEvaluatorResult(bool? IsSuccess, string Error) { }
         public string Error { get; set; }
-        public bool IsSuccess { get; set; }
+        public bool? IsSuccess { get; set; }
     }
     public abstract class CollectionQuantifier
     {
@@ -55,7 +55,7 @@ namespace Testably.Expectations
     }
     public interface ICollectionEvaluator<out TItem>
     {
-        System.Threading.Tasks.Task<Testably.Expectations.CollectionEvaluatorResult> CheckCondition<TExpected>(TExpected expected, System.Func<TItem, TExpected, bool> predicate);
+        System.Threading.Tasks.Task<Testably.Expectations.CollectionEvaluatorResult> CheckCondition<TExpected>(TExpected expected, System.Func<TItem, TExpected, bool> predicate, System.Threading.CancellationToken cancellationToken);
     }
     public class QuantifiedCollectionResult
     {
@@ -503,11 +503,11 @@ namespace Testably.Expectations.Core.Constraints
     }
     public interface IAsyncConstraint<in TValue> : Testably.Expectations.Core.Constraints.IConstraint
     {
-        System.Threading.Tasks.Task<Testably.Expectations.Core.Constraints.ConstraintResult> IsMetBy(TValue actual);
+        System.Threading.Tasks.Task<Testably.Expectations.Core.Constraints.ConstraintResult> IsMetBy(TValue actual, System.Threading.CancellationToken cancellationToken);
     }
     public interface IAsyncContextConstraint<in TValue> : Testably.Expectations.Core.Constraints.IConstraint
     {
-        System.Threading.Tasks.Task<Testably.Expectations.Core.Constraints.ConstraintResult> IsMetBy(TValue actual, Testably.Expectations.Core.EvaluationContext.IEvaluationContext context);
+        System.Threading.Tasks.Task<Testably.Expectations.Core.Constraints.ConstraintResult> IsMetBy(TValue actual, Testably.Expectations.Core.EvaluationContext.IEvaluationContext context, System.Threading.CancellationToken cancellationToken);
     }
     public interface ICastConstraint<in TValue, TProperty> : Testably.Expectations.Core.Constraints.IConstraint, Testably.Expectations.Core.Constraints.IValueConstraint<TValue> { }
     public interface IConstraint { }
@@ -731,6 +731,7 @@ namespace Testably.Expectations.Results
         public ExpectationResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }
         public Testably.Expectations.Results.ExpectationResult Because(string reason) { }
         public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
+        public Testably.Expectations.Results.ExpectationResult WithCancellation(System.Threading.CancellationToken cancellationToken, [System.Runtime.CompilerServices.CallerArgumentExpression("cancellationToken")] string doNotPopulateThisValue = "") { }
     }
     public class ExpectationResult<TResult> : Testably.Expectations.Results.ExpectationResult<TResult, Testably.Expectations.Results.ExpectationResult<TResult>>
     {
@@ -744,6 +745,7 @@ namespace Testably.Expectations.Results
         public TSelf Because(string reason, [System.Runtime.CompilerServices.CallerArgumentExpression("reason")] string doNotPopulateThisValue = "") { }
         [System.Diagnostics.StackTraceHidden]
         public System.Runtime.CompilerServices.TaskAwaiter<TResult> GetAwaiter() { }
+        public TSelf WithCancellation(System.Threading.CancellationToken cancellationToken, [System.Runtime.CompilerServices.CallerArgumentExpression("cancellationToken")] string doNotPopulateThisValue = "") { }
     }
     public class NumberToleranceResult<TNumber, TResult> : Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult, Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult>>
         where TNumber :  struct, System.IComparable<TNumber>

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -9,9 +9,9 @@ namespace Testably.Expectations
     }
     public struct CollectionEvaluatorResult : System.IEquatable<Testably.Expectations.CollectionEvaluatorResult>
     {
-        public CollectionEvaluatorResult(bool IsSuccess, string Error) { }
+        public CollectionEvaluatorResult(bool? IsSuccess, string Error) { }
         public string Error { get; set; }
-        public bool IsSuccess { get; set; }
+        public bool? IsSuccess { get; set; }
     }
     public abstract class CollectionQuantifier
     {
@@ -51,7 +51,7 @@ namespace Testably.Expectations
     }
     public interface ICollectionEvaluator<out TItem>
     {
-        System.Threading.Tasks.Task<Testably.Expectations.CollectionEvaluatorResult> CheckCondition<TExpected>(TExpected expected, System.Func<TItem, TExpected, bool> predicate);
+        System.Threading.Tasks.Task<Testably.Expectations.CollectionEvaluatorResult> CheckCondition<TExpected>(TExpected expected, System.Func<TItem, TExpected, bool> predicate, System.Threading.CancellationToken cancellationToken);
     }
     public class QuantifiedCollectionResult
     {
@@ -441,11 +441,11 @@ namespace Testably.Expectations.Core.Constraints
     }
     public interface IAsyncConstraint<in TValue> : Testably.Expectations.Core.Constraints.IConstraint
     {
-        System.Threading.Tasks.Task<Testably.Expectations.Core.Constraints.ConstraintResult> IsMetBy(TValue actual);
+        System.Threading.Tasks.Task<Testably.Expectations.Core.Constraints.ConstraintResult> IsMetBy(TValue actual, System.Threading.CancellationToken cancellationToken);
     }
     public interface IAsyncContextConstraint<in TValue> : Testably.Expectations.Core.Constraints.IConstraint
     {
-        System.Threading.Tasks.Task<Testably.Expectations.Core.Constraints.ConstraintResult> IsMetBy(TValue actual, Testably.Expectations.Core.EvaluationContext.IEvaluationContext context);
+        System.Threading.Tasks.Task<Testably.Expectations.Core.Constraints.ConstraintResult> IsMetBy(TValue actual, Testably.Expectations.Core.EvaluationContext.IEvaluationContext context, System.Threading.CancellationToken cancellationToken);
     }
     public interface ICastConstraint<in TValue, TProperty> : Testably.Expectations.Core.Constraints.IConstraint, Testably.Expectations.Core.Constraints.IValueConstraint<TValue> { }
     public interface IConstraint { }
@@ -669,6 +669,7 @@ namespace Testably.Expectations.Results
         public ExpectationResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }
         public Testably.Expectations.Results.ExpectationResult Because(string reason) { }
         public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
+        public Testably.Expectations.Results.ExpectationResult WithCancellation(System.Threading.CancellationToken cancellationToken, [System.Runtime.CompilerServices.CallerArgumentExpression("cancellationToken")] string doNotPopulateThisValue = "") { }
     }
     public class ExpectationResult<TResult> : Testably.Expectations.Results.ExpectationResult<TResult, Testably.Expectations.Results.ExpectationResult<TResult>>
     {
@@ -682,6 +683,7 @@ namespace Testably.Expectations.Results
         public TSelf Because(string reason, [System.Runtime.CompilerServices.CallerArgumentExpression("reason")] string doNotPopulateThisValue = "") { }
         [System.Diagnostics.StackTraceHidden]
         public System.Runtime.CompilerServices.TaskAwaiter<TResult> GetAwaiter() { }
+        public TSelf WithCancellation(System.Threading.CancellationToken cancellationToken, [System.Runtime.CompilerServices.CallerArgumentExpression("cancellationToken")] string doNotPopulateThisValue = "") { }
     }
     public class NumberToleranceResult<TNumber, TResult> : Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult, Testably.Expectations.Results.NumberToleranceResult<TNumber, TResult>>
         where TNumber :  struct, System.IComparable<TNumber>

--- a/Tests/Testably.Expectations.Tests/TestHelpers/Factory.cs
+++ b/Tests/Testably.Expectations.Tests/TestHelpers/Factory.cs
@@ -1,9 +1,28 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace Testably.Expectations.Tests.TestHelpers;
 
 internal static class Factory
 {
+#if NET6_0_OR_GREATER
+	/// <summary>
+	///     Returns an infinite <see cref="IAsyncEnumerable{T}" /> of fibonacci numbers.
+	/// </summary>
+	public static async IAsyncEnumerable<int> GetAsyncFibonacciNumbers(
+		[EnumeratorCancellation] CancellationToken cancellationToken = default)
+	{
+		int a = 0, b = 1;
+
+		do
+		{
+			await Task.Yield();
+			yield return b;
+			(a, b) = (b, a + b);
+		} while (!cancellationToken.IsCancellationRequested);
+	}
+#endif
 	/// <summary>
 	///     Returns an infinite <see cref="IEnumerable{T}" /> of fibonacci numbers.
 	/// </summary>

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AllTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AllTests.cs
@@ -1,5 +1,6 @@
 ﻿#if NET6_0_OR_GREATER
 using System.Collections.Generic;
+using System.Threading;
 using Testably.Expectations.Tests.TestHelpers;
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -9,6 +10,54 @@ public sealed partial class AsyncEnumerableShould
 {
 	public sealed class AllTests
 	{
+		[Fact]
+		public async Task ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IAsyncEnumerable<int> subject = GetCancellingEnumerable(6, cts, CancellationToken.None);
+
+			async Task Act()
+				=> await That(subject).Should().All().Satisfy(x => x < 6).WithCancellation(token);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             all satisfy "x => x < 6",
+				             but could not verify, because it was cancelled early
+				             at Expect.That(subject).Should().All().Satisfy(x => x < 6).WithCancellation(token)
+				             """);
+		}
+
+		[Fact]
+		public async Task DoesNotEnumerateTwice()
+		{
+			ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
+
+			async Task Act()
+				=> await That(subject).Should().All().Satisfy(_ => true)
+					.And.All().Satisfy(_ => true);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task DoesNotMaterializeEnumerable()
+		{
+			IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
+
+			async Task Act()
+				=> await That(subject).Should().All().Be(1);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have all items equal to 1,
+				             but not all items were equal
+				             at Expect.That(subject).Should().All().Be(1)
+				             """);
+		}
+
 		[Fact]
 		public async Task WhenEnumerableContainsDifferentValues_ShouldFail()
 		{

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AllTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AllTests.cs
@@ -15,7 +15,7 @@ public sealed partial class AsyncEnumerableShould
 		{
 			using CancellationTokenSource cts = new();
 			CancellationToken token = cts.Token;
-			IAsyncEnumerable<int> subject = GetCancellingEnumerable(6, cts, CancellationToken.None);
+			IAsyncEnumerable<int> subject = GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 			async Task Act()
 				=> await That(subject).Should().All().Satisfy(x => x < 6).WithCancellation(token);

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AtLeastTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AtLeastTests.cs
@@ -15,7 +15,7 @@ public sealed partial class AsyncEnumerableShould
 		{
 			using CancellationTokenSource cts = new();
 			CancellationToken token = cts.Token;
-			IAsyncEnumerable<int> subject = GetCancellingEnumerable(6, cts, CancellationToken.None);
+			IAsyncEnumerable<int> subject = GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 			async Task Act()
 				=> await That(subject).Should().AtLeast(6).Satisfy(x => x < 6)

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AtLeastTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AtLeastTests.cs
@@ -1,5 +1,6 @@
 ﻿#if NET6_0_OR_GREATER
 using System.Collections.Generic;
+using System.Threading;
 using Testably.Expectations.Tests.TestHelpers;
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -10,6 +11,43 @@ public sealed partial class AsyncEnumerableShould
 	public sealed class AtLeastTests
 	{
 		[Fact]
+		public async Task ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IAsyncEnumerable<int> subject = GetCancellingEnumerable(6, cts, CancellationToken.None);
+
+			async Task Act()
+				=> await That(subject).Should().AtLeast(6).Satisfy(x => x < 6)
+					.WithCancellation(token);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task DoesNotEnumerateTwice()
+		{
+			ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
+
+			async Task Act()
+				=> await That(subject).Should().AtLeast(0).Be(1)
+					.And.AtLeast(0).Be(1);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task DoesNotMaterializeEnumerable()
+		{
+			IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
+
+			async Task Act()
+				=> await That(subject).Should().AtLeast(2).Be(1);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
 		public async Task WhenEnumerableContainsEnoughEqualItems_ShouldSucceed()
 		{
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
@@ -19,6 +57,7 @@ public sealed partial class AsyncEnumerableShould
 
 			await That(Act).Should().NotThrow();
 		}
+
 		[Fact]
 		public async Task WhenEnumerableContainsTooFewEqualItems_ShouldFail()
 		{
@@ -35,6 +74,7 @@ public sealed partial class AsyncEnumerableShould
 				             at Expect.That(subject).Should().AtLeast(5).Be(1)
 				             """);
 		}
+
 		[Fact]
 		public async Task WhenEnumerableContainsTooFewEquivalentItems_ShouldFail()
 		{

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AtMostTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AtMostTests.cs
@@ -1,5 +1,6 @@
 ﻿#if NET6_0_OR_GREATER
 using System.Collections.Generic;
+using System.Threading;
 using Testably.Expectations.Tests.TestHelpers;
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -10,9 +11,29 @@ public sealed partial class AsyncEnumerableShould
 	public sealed class AtMostTests
 	{
 		[Fact]
+		public async Task ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IAsyncEnumerable<int> subject = GetCancellingEnumerable(6, cts, CancellationToken.None);
+
+			async Task Act()
+				=> await That(subject).Should().AtMost(8).Satisfy(x => x < 6)
+					.WithCancellation(token);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             at most 8 satisfy "x => x < 6",
+				             but could not verify, because it was cancelled early
+				             at Expect.That(subject).Should().AtMost(8).Satisfy(x => x < 6).WithCancellation(token)
+				             """);
+		}
+
+		[Fact]
 		public async Task DoesNotEnumerateTwice()
 		{
-			ThrowWhenIteratingTwiceEnumerable subject = new();
+			ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 			async Task Act()
 				=> await That(subject).Should().AtMost(3).Be(1)
@@ -24,7 +45,7 @@ public sealed partial class AsyncEnumerableShould
 		[Fact]
 		public async Task DoesNotMaterializeEnumerable()
 		{
-			IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+			IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 			async Task Act()
 				=> await That(subject).Should().AtMost(1).Be(1);

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AtMostTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AtMostTests.cs
@@ -15,7 +15,7 @@ public sealed partial class AsyncEnumerableShould
 		{
 			using CancellationTokenSource cts = new();
 			CancellationToken token = cts.Token;
-			IAsyncEnumerable<int> subject = GetCancellingEnumerable(6, cts, CancellationToken.None);
+			IAsyncEnumerable<int> subject = GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 			async Task Act()
 				=> await That(subject).Should().AtMost(8).Satisfy(x => x < 6)

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BeEmptyTests.cs
@@ -34,7 +34,7 @@ public sealed partial class AsyncEnumerableShould
 		{
 			using CancellationTokenSource cts = new();
 			CancellationToken token = cts.Token;
-			IAsyncEnumerable<int> subject = GetCancellingEnumerable(5, cts, CancellationToken.None);
+			IAsyncEnumerable<int> subject = GetCancellingAsyncEnumerable(5, cts, CancellationToken.None);
 
 			async Task Act()
 				=> await That(subject).Should().BeEmpty().WithCancellation(token);
@@ -54,7 +54,7 @@ public sealed partial class AsyncEnumerableShould
 			using CancellationTokenSource cts = new();
 			CancellationToken token = cts.Token;
 			IAsyncEnumerable<int>
-				subject = GetCancellingEnumerable(16, cts, CancellationToken.None);
+				subject = GetCancellingAsyncEnumerable(16, cts, CancellationToken.None);
 
 			async Task Act()
 				=> await That(subject).Should().BeEmpty();

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BeEmptyTests.cs
@@ -34,7 +34,8 @@ public sealed partial class AsyncEnumerableShould
 		{
 			using CancellationTokenSource cts = new();
 			CancellationToken token = cts.Token;
-			IAsyncEnumerable<int> subject = GetCancellingAsyncEnumerable(5, cts, CancellationToken.None);
+			IAsyncEnumerable<int> subject =
+				GetCancellingAsyncEnumerable(5, cts, CancellationToken.None);
 
 			async Task Act()
 				=> await That(subject).Should().BeEmpty().WithCancellation(token);
@@ -52,9 +53,8 @@ public sealed partial class AsyncEnumerableShould
 		public async Task ShouldDisplayUpToTenItems()
 		{
 			using CancellationTokenSource cts = new();
-			CancellationToken token = cts.Token;
-			IAsyncEnumerable<int>
-				subject = GetCancellingAsyncEnumerable(16, cts, CancellationToken.None);
+			IAsyncEnumerable<int> subject =
+				GetCancellingAsyncEnumerable(16, cts, CancellationToken.None);
 
 			async Task Act()
 				=> await That(subject).Should().BeEmpty();

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BetweenTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BetweenTests.cs
@@ -1,5 +1,6 @@
 ﻿#if NET6_0_OR_GREATER
 using System.Collections.Generic;
+using System.Threading;
 using Testably.Expectations.Tests.TestHelpers;
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -10,9 +11,29 @@ public sealed partial class AsyncEnumerableShould
 	public sealed class BetweenTests
 	{
 		[Fact]
+		public async Task ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IAsyncEnumerable<int> subject = GetCancellingEnumerable(6, cts, CancellationToken.None);
+
+			async Task Act()
+				=> await That(subject).Should().Between(6).And(8).Satisfy(x => x < 6)
+					.WithCancellation(token);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             between 6 and 8 satisfy "x => x < 6",
+				             but could not verify, because it was cancelled early
+				             at Expect.That(subject).Should().Between(6).And(8).Satisfy(x => x < 6).WithCancellation(token)
+				             """);
+		}
+
+		[Fact]
 		public async Task DoesNotEnumerateTwice()
 		{
-			ThrowWhenIteratingTwiceEnumerable subject = new();
+			ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 			async Task Act()
 				=> await That(subject).Should().Between(0).And(2).Be(1)
@@ -24,7 +45,7 @@ public sealed partial class AsyncEnumerableShould
 		[Fact]
 		public async Task DoesNotMaterializeEnumerable()
 		{
-			IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+			IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 			async Task Act()
 				=> await That(subject).Should().Between(0).And(1).Be(1);

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BetweenTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BetweenTests.cs
@@ -15,7 +15,7 @@ public sealed partial class AsyncEnumerableShould
 		{
 			using CancellationTokenSource cts = new();
 			CancellationToken token = cts.Token;
-			IAsyncEnumerable<int> subject = GetCancellingEnumerable(6, cts, CancellationToken.None);
+			IAsyncEnumerable<int> subject = GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 			async Task Act()
 				=> await That(subject).Should().Between(6).And(8).Satisfy(x => x < 6)

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.NoneTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.NoneTests.cs
@@ -1,5 +1,6 @@
 ﻿#if NET6_0_OR_GREATER
 using System.Collections.Generic;
+using System.Threading;
 using Testably.Expectations.Tests.TestHelpers;
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -10,9 +11,29 @@ public sealed partial class AsyncEnumerableShould
 	public sealed class NoneTests
 	{
 		[Fact]
+		public async Task ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IAsyncEnumerable<int> subject = GetCancellingEnumerable(6, cts, CancellationToken.None);
+
+			async Task Act()
+				=> await That(subject).Should().None().Satisfy(x => x < 0)
+					.WithCancellation(token);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             none satisfy "x => x < 0",
+				             but could not verify, because it was cancelled early
+				             at Expect.That(subject).Should().None().Satisfy(x => x < 0).WithCancellation(token)
+				             """);
+		}
+
+		[Fact]
 		public async Task DoesNotEnumerateTwice()
 		{
-			ThrowWhenIteratingTwiceEnumerable subject = new();
+			ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 			async Task Act()
 				=> await That(subject).Should().None().Be(15)
@@ -24,7 +45,7 @@ public sealed partial class AsyncEnumerableShould
 		[Fact]
 		public async Task DoesNotMaterializeEnumerable()
 		{
-			IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+			IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 			async Task Act()
 				=> await That(subject).Should().None().Be(5);

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.NoneTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.NoneTests.cs
@@ -15,7 +15,7 @@ public sealed partial class AsyncEnumerableShould
 		{
 			using CancellationTokenSource cts = new();
 			CancellationToken token = cts.Token;
-			IAsyncEnumerable<int> subject = GetCancellingEnumerable(6, cts, CancellationToken.None);
+			IAsyncEnumerable<int> subject = GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 			async Task Act()
 				=> await That(subject).Should().None().Satisfy(x => x < 0)

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.cs
@@ -34,9 +34,9 @@ public partial class AsyncEnumerableShould
 
 	/// <summary>
 	///     Returns an <see cref="IAsyncEnumerable{T}" /> with incrementing numbers, starting with 0, which cancels the
-	///     <paramref name="cancellationToken" /> after <paramref name="cancelAfter" /> iteration.
+	///     <paramref name="cancellationTokenSource" /> after <paramref name="cancelAfter" /> iteration.
 	/// </summary>
-	private static async IAsyncEnumerable<int> GetCancellingEnumerable(
+	private static async IAsyncEnumerable<int> GetCancellingAsyncEnumerable(
 		int cancelAfter,
 		CancellationTokenSource cancellationTokenSource,
 		[EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.AllTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.AllTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using Testably.Expectations.Tests.TestHelpers;
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -8,6 +9,25 @@ public sealed partial class EnumerableShould
 {
 	public sealed class AllTests
 	{
+		[Fact]
+		public async Task ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IEnumerable<int> subject = GetCancellingEnumerable(6, cts);
+
+			async Task Act()
+				=> await That(subject).Should().All().Satisfy(x => x < 6).WithCancellation(token);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             all satisfy "x => x < 6",
+				             but could not verify, because it was cancelled early
+				             at Expect.That(subject).Should().All().Satisfy(x => x < 6).WithCancellation(token)
+				             """);
+		}
+
 		[Fact]
 		public async Task DoesNotEnumerateTwice()
 		{

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.AtLeastTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.AtLeastTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using Testably.Expectations.Tests.TestHelpers;
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -8,6 +9,20 @@ public sealed partial class EnumerableShould
 {
 	public sealed class AtLeastTests
 	{
+		[Fact]
+		public async Task ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IEnumerable<int> subject = GetCancellingEnumerable(6, cts);
+
+			async Task Act()
+				=> await That(subject).Should().AtLeast(6).Satisfy(x => x < 6)
+					.WithCancellation(token);
+
+			await That(Act).Should().NotThrow();
+		}
+
 		[Fact]
 		public async Task DoesNotEnumerateTwice()
 		{

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.AtMostTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.AtMostTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using Testably.Expectations.Tests.TestHelpers;
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -8,6 +9,26 @@ public sealed partial class EnumerableShould
 {
 	public sealed class AtMostTests
 	{
+		[Fact]
+		public async Task ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IEnumerable<int> subject = GetCancellingEnumerable(6, cts);
+
+			async Task Act()
+				=> await That(subject).Should().AtMost(8).Satisfy(x => x < 6)
+					.WithCancellation(token);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             at most 8 satisfy "x => x < 6",
+				             but could not verify, because it was cancelled early
+				             at Expect.That(subject).Should().AtMost(8).Satisfy(x => x < 6).WithCancellation(token)
+				             """);
+		}
+
 		[Fact]
 		public async Task DoesNotEnumerateTwice()
 		{

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.cs
@@ -20,10 +20,11 @@ public partial class EnumerableShould
 	/// </summary>
 	private static IEnumerable<int> GetCancellingEnumerable(
 		int cancelAfter,
-		CancellationTokenSource cancellationTokenSource)
+		CancellationTokenSource cancellationTokenSource,
+		int limit = 10_000)
 	{
 		int index = 0;
-		while (true)
+		while (index < limit)
 		{
 			if (index == cancelAfter)
 			{

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Testably.Expectations.Tests.ThatTests.Collections;
 
@@ -10,6 +11,26 @@ public partial class EnumerableShould
 		foreach (int item in items)
 		{
 			yield return item;
+		}
+	}
+
+	/// <summary>
+	///     Returns an <see cref="IEnumerable{T}" /> with incrementing numbers, starting with 0, which cancels the
+	///     <paramref name="cancellationTokenSource" /> after <paramref name="cancelAfter" /> iteration.
+	/// </summary>
+	private static IEnumerable<int> GetCancellingEnumerable(
+		int cancelAfter,
+		CancellationTokenSource cancellationTokenSource)
+	{
+		int index = 0;
+		while (true)
+		{
+			if (index == cancelAfter)
+			{
+				cancellationTokenSource.Cancel();
+			}
+
+			yield return index++;
 		}
 	}
 


### PR DESCRIPTION
Implements #70 :
Add an overload `.WithCancellation(CancellationToken)` which will forward the cancellation token to all async constraints (e.g. `IAsyncEnumerable`.
Also add tests, that `IAsyncEnumerable` constraints take the `CancellationToken` into account.