### PR TITLE
refactor: add `DebuggerDisplay` attribute instead of `ToString()`

### DIFF
--- a/Source/Testably.Expectations/Core/ExpectationBuilder.cs
+++ b/Source/Testably.Expectations/Core/ExpectationBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ namespace Testably.Expectations.Core;
 /// <summary>
 ///     The builder for collecting all expectations.
 /// </summary>
+[DebuggerDisplay("{_tree}")]
 public abstract class ExpectationBuilder
 {
 	/// <summary>
@@ -120,12 +122,6 @@ public abstract class ExpectationBuilder
 				expectationTextGenerator));
 			return this;
 		});
-	}
-
-	/// <inheritdoc />
-	public override string ToString()
-	{
-		return _tree.ToString();
 	}
 
 	/// <summary>

--- a/Source/Testably.Expectations/Expect.cs
+++ b/Source/Testably.Expectations/Expect.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Testably.Expectations.Core;
@@ -107,6 +108,7 @@ public static class Expect
 				doNotPopulateThisValue));
 #endif
 
+	[DebuggerDisplay("Expect.ThatSubject<{typeof(T)}>: {ExpectationBuilder}")]
 	internal readonly struct ThatSubject<T>(ExpectationBuilder expectationBuilder)
 		: IExpectSubject<T>, IThat<T>
 	{

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -530,6 +530,7 @@ namespace Testably.Expectations.Core.EvaluationContext
 }
 namespace Testably.Expectations.Core
 {
+    [System.Diagnostics.DebuggerDisplay("{_tree}")]
     public abstract class ExpectationBuilder
     {
         protected ExpectationBuilder(string subjectExpression) { }
@@ -541,7 +542,6 @@ namespace Testably.Expectations.Core
         public void AddReason(string reason) { }
         public Testably.Expectations.Core.ExpectationBuilder AppendStatement(string value) { }
         public Testably.Expectations.Core.ExpectationBuilder.PropertyExpectationBuilder<TSource, TTarget> ForProperty<TSource, TTarget>(Testably.Expectations.Core.PropertyAccessor<TSource, TTarget?> propertyAccessor, System.Func<Testably.Expectations.Core.PropertyAccessor, string, string>? expectationTextGenerator = null) { }
-        public override string ToString() { }
         public class PropertyExpectationBuilder<TSource, TProperty>
         {
             public Testably.Expectations.Core.ExpectationBuilder AddExpectations(System.Action<Testably.Expectations.Core.ExpectationBuilder> expectation) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -530,6 +530,7 @@ namespace Testably.Expectations.Core.EvaluationContext
 }
 namespace Testably.Expectations.Core
 {
+    [System.Diagnostics.DebuggerDisplay("{_tree}")]
     public abstract class ExpectationBuilder
     {
         protected ExpectationBuilder(string subjectExpression) { }
@@ -541,7 +542,6 @@ namespace Testably.Expectations.Core
         public void AddReason(string reason) { }
         public Testably.Expectations.Core.ExpectationBuilder AppendStatement(string value) { }
         public Testably.Expectations.Core.ExpectationBuilder.PropertyExpectationBuilder<TSource, TTarget> ForProperty<TSource, TTarget>(Testably.Expectations.Core.PropertyAccessor<TSource, TTarget?> propertyAccessor, System.Func<Testably.Expectations.Core.PropertyAccessor, string, string>? expectationTextGenerator = null) { }
-        public override string ToString() { }
         public class PropertyExpectationBuilder<TSource, TProperty>
         {
             public Testably.Expectations.Core.ExpectationBuilder AddExpectations(System.Action<Testably.Expectations.Core.ExpectationBuilder> expectation) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -468,6 +468,7 @@ namespace Testably.Expectations.Core.EvaluationContext
 }
 namespace Testably.Expectations.Core
 {
+    [System.Diagnostics.DebuggerDisplay("{_tree}")]
     public abstract class ExpectationBuilder
     {
         protected ExpectationBuilder(string subjectExpression) { }
@@ -479,7 +480,6 @@ namespace Testably.Expectations.Core
         public void AddReason(string reason) { }
         public Testably.Expectations.Core.ExpectationBuilder AppendStatement(string value) { }
         public Testably.Expectations.Core.ExpectationBuilder.PropertyExpectationBuilder<TSource, TTarget> ForProperty<TSource, TTarget>(Testably.Expectations.Core.PropertyAccessor<TSource, TTarget?> propertyAccessor, System.Func<Testably.Expectations.Core.PropertyAccessor, string, string>? expectationTextGenerator = null) { }
-        public override string ToString() { }
         public class PropertyExpectationBuilder<TSource, TProperty>
         {
             public Testably.Expectations.Core.ExpectationBuilder AddExpectations(System.Action<Testably.Expectations.Core.ExpectationBuilder> expectation) { }


### PR DESCRIPTION
Use [`DebuggerDisplay`](https://learn.microsoft.com/en-us/visualstudio/debugger/using-the-debuggerdisplay-attribute) attribute instead of `ToString()` overload