### PR TITLE
fix: indentation of `DefaultFormatter` when using multiple lines.

### DIFF
--- a/Source/Testably.Expectations/Formatting/DefaultFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/DefaultFormatter.cs
@@ -16,16 +16,14 @@ internal class DefaultFormatter : IValueFormatter
 		if (value.GetType() == typeof(object))
 		{
 			stringBuilder.Append($"System.Object (HashCode={value.GetHashCode()})");
-			return true;
 		}
-
-		if (HasCompilerGeneratedToStringImplementation(value))
+		else if (HasCompilerGeneratedToStringImplementation(value))
 		{
 			WriteTypeAndMemberValues(value, stringBuilder, options);
 		}
 		else if (options.UseLineBreaks)
 		{
-			stringBuilder.AppendLine(value.ToString());
+			stringBuilder.AppendLine(value.ToString().Indent(indentFirstLine: false));
 		}
 		else
 		{
@@ -116,6 +114,10 @@ internal class DefaultFormatter : IValueFormatter
 		}
 
 		stringBuilder.Append($"{new string(' ', indentation)}{member.Name} = ");
+		if (options.UseLineBreaks)
+		{
+			formattedValue = formattedValue.Indent("  ", false);	
+		}
 		stringBuilder.Append(formattedValue);
 	}
 
@@ -139,11 +141,11 @@ internal class DefaultFormatter : IValueFormatter
 		MemberInfo[] members = GetMembers(type);
 		if (members.Length == 0)
 		{
-			stringBuilder.Append("{ }");
+			stringBuilder.Append(" { }");
 		}
 		else
 		{
-			stringBuilder.Append('{');
+			stringBuilder.Append(" {");
 			stringBuilder.Append(options.UseLineBreaks ? Environment.NewLine : " ");
 			WriteMemberValues(obj, members, stringBuilder, options.UseLineBreaks ? 2 : 0, options);
 			stringBuilder.Append(options.UseLineBreaks ? Environment.NewLine : " ");

--- a/Tests/Testably.Expectations.Tests/ThatTests/GenericShould.BeSameAsTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/GenericShould.BeSameAsTests.cs
@@ -28,10 +28,10 @@ public sealed partial class GenericShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
 				             Expected subject to
-				             refer to expected Other{
+				             refer to expected Other {
 				               Value = 1
 				             },
-				             but found Other{
+				             but found Other {
 				               Value = 1
 				             }
 				             at Expect.That(subject).Should().BeSameAs(expected)
@@ -51,7 +51,7 @@ public sealed partial class GenericShould
 				.WithMessage("""
 				             Expected subject to
 				             refer to expected <null>,
-				             but found Other{
+				             but found Other {
 				               Value = 1
 				             }
 				             at Expect.That(subject).Should().BeSameAs(expected)
@@ -82,7 +82,7 @@ public sealed partial class GenericShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
 				             Expected subject to
-				             refer to expected Other{
+				             refer to expected Other {
 				               Value = 1
 				             },
 				             but found <null>
@@ -105,7 +105,7 @@ public sealed partial class GenericShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
 				             Expected subject to
-				             not refer to expected Other{
+				             not refer to expected Other {
 				               Value = 1
 				             },
 				             but it did

--- a/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.Be.UsingTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.Be.UsingTests.cs
@@ -21,7 +21,7 @@ public sealed partial class ObjectShould
 					.WithMessage("""
 					             Expected subject to
 					             be equal to expected using MyComparer,
-					             but found OuterClass{
+					             but found OuterClass {
 					               Inner = <null>,
 					               Value = "Foo"
 					             }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.BeTests.cs
@@ -28,7 +28,7 @@ public sealed partial class ObjectShould
 				.WithMessage($$"""
 				               Expected subject to
 				               be type OtherClass, because we want to test the failure,
-				               but found MyClass{
+				               but found MyClass {
 				                 Value = {{value}}
 				               }
 				               at Expect.That(subject).Should().Be<OtherClass>().Because("we want to test the failure")
@@ -60,7 +60,7 @@ public sealed partial class ObjectShould
 				.WithMessage($$"""
 				               Expected subject to
 				               be type MyClass, because {{reason}},
-				               but found MyBaseClass{
+				               but found MyBaseClass {
 				                 Value = {{value}}
 				               }
 				               at Expect.That(subject).Should().Be<MyClass>().Because(reason)


### PR DESCRIPTION
The `DefaultFormatter` did not apply the correct (nested) indentation.