### PR TITLE
feat: add expectation combinations via `Expect.ThatAll`

### DIFF
--- a/Source/Testably.Expectations/Core/ExpectationBuilder.cs
+++ b/Source/Testably.Expectations/Core/ExpectationBuilder.cs
@@ -35,7 +35,6 @@ public abstract class ExpectationBuilder
 	protected ExpectationBuilder(string subjectExpression)
 	{
 		Subject = subjectExpression;
-		// TODO VAB: Remove from FailureMessageBuilder???
 		_failureMessageBuilder = new FailureMessageBuilder(subjectExpression);
 	}
 

--- a/Source/Testably.Expectations/Core/ExpectationBuilder.cs
+++ b/Source/Testably.Expectations/Core/ExpectationBuilder.cs
@@ -21,6 +21,7 @@ public abstract class ExpectationBuilder
 	///     The builder for the failure message.
 	/// </summary>
 	internal IFailureMessageBuilder FailureMessageBuilder => _failureMessageBuilder;
+	internal string Subject { get; }
 
 	private CancellationToken? _cancellationToken;
 
@@ -33,6 +34,8 @@ public abstract class ExpectationBuilder
 	/// </summary>
 	protected ExpectationBuilder(string subjectExpression)
 	{
+		Subject = subjectExpression;
+		// TODO VAB: Remove from FailureMessageBuilder???
 		_failureMessageBuilder = new FailureMessageBuilder(subjectExpression);
 	}
 

--- a/Source/Testably.Expectations/Core/Helpers/FailureMessageBuilder.cs
+++ b/Source/Testably.Expectations/Core/Helpers/FailureMessageBuilder.cs
@@ -6,26 +6,24 @@ namespace Testably.Expectations.Core.Helpers;
 internal class FailureMessageBuilder : IFailureMessageBuilder
 {
 	public StringBuilder ExpressionBuilder { get; }
-	private readonly string _subject;
 
-	public FailureMessageBuilder(string subject)
+	public FailureMessageBuilder(string subjectExpression)
 	{
-		_subject = subject;
 		ExpressionBuilder = new StringBuilder();
 		ExpressionBuilder
 			.Append(nameof(Expect))
 			.Append('.')
 			.Append(nameof(Expect.That))
 			.Append('(')
-			.Append(_subject)
+			.Append(subjectExpression)
 			.Append(')');
 	}
 
 	#region IFailureMessageBuilder Members
 
-	public string FromFailure(ConstraintResult.Failure failure)
+	public string FromFailure(string subject, ConstraintResult.Failure failure)
 		=> $"""
-		    Expected {_subject} to
+		    Expected {subject} to
 		    {failure.ExpectationText},
 		    but {failure.ResultText}
 		    at {ExpressionBuilder}

--- a/Source/Testably.Expectations/Core/IFailureMessageBuilder.cs
+++ b/Source/Testably.Expectations/Core/IFailureMessageBuilder.cs
@@ -10,5 +10,5 @@ internal interface IFailureMessageBuilder
 	/// <summary>
 	///     Creates the exception message from the <paramref name="failure" />.
 	/// </summary>
-	string FromFailure(ConstraintResult.Failure failure);
+	string FromFailure(string subject, ConstraintResult.Failure failure);
 }

--- a/Source/Testably.Expectations/Expect.cs
+++ b/Source/Testably.Expectations/Expect.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Sources;
+using Testably.Expectations.Results;
 
 namespace Testably.Expectations;
 
@@ -107,6 +108,18 @@ public static class Expect
 					async () => await @delegate),
 				doNotPopulateThisValue));
 #endif
+	
+	/// <summary>
+	///     Verifies that any of the provided <paramref name="expectations"/> are met.
+	/// </summary>
+	public static Expectation.Any ThatAny(params Expectation[] expectations)
+		=> new(expectations);
+
+	/// <summary>
+	///     Verifies that all provided <paramref name="expectations"/> are met.
+	/// </summary>
+	public static Expectation.All ThatAll(params Expectation[] expectations)
+		=> new(expectations);
 
 	[DebuggerDisplay("Expect.ThatSubject<{typeof(T)}>: {ExpectationBuilder}")]
 	internal readonly struct ThatSubject<T>(ExpectationBuilder expectationBuilder)

--- a/Source/Testably.Expectations/Expect.cs
+++ b/Source/Testably.Expectations/Expect.cs
@@ -108,17 +108,17 @@ public static class Expect
 					async () => await @delegate),
 				doNotPopulateThisValue));
 #endif
-	
+
 	/// <summary>
-	///     Verifies that any of the provided <paramref name="expectations"/> are met.
+	///     Verifies that any of the provided <paramref name="expectations" /> are met.
 	/// </summary>
-	public static Expectation.Any ThatAny(params Expectation[] expectations)
+	public static Expectation.Combination.Any ThatAny(params Expectation[] expectations)
 		=> new(expectations);
 
 	/// <summary>
-	///     Verifies that all provided <paramref name="expectations"/> are met.
+	///     Verifies that all provided <paramref name="expectations" /> are met.
 	/// </summary>
-	public static Expectation.All ThatAll(params Expectation[] expectations)
+	public static Expectation.Combination.All ThatAll(params Expectation[] expectations)
 		=> new(expectations);
 
 	[DebuggerDisplay("Expect.ThatSubject<{typeof(T)}>: {ExpectationBuilder}")]

--- a/Source/Testably.Expectations/Results/Expectation.cs
+++ b/Source/Testably.Expectations/Results/Expectation.cs
@@ -33,7 +33,10 @@ public abstract class Expectation
 	{
 		private readonly Expectation[] _expectations;
 
-		internal Combination(Expectation[] expectations)
+		/// <summary>
+		///     Combination of multiple expectations.
+		/// </summary>
+		protected Combination(Expectation[] expectations)
 		{
 			if (expectations.Length == 0)
 			{
@@ -54,6 +57,17 @@ public abstract class Expectation
 			Task result = GetResultOrThrow();
 			return result.GetAwaiter();
 		}
+
+		/// <summary>
+		///     Returns the subject line of the <see cref="Expectation.Combination" />.
+		/// </summary>
+		protected abstract string GetSubjectLine();
+
+		/// <summary>
+		///     Specifies, if the combination should be treated as
+		///     <see cref="ConstraintResult.Success" /> or <see cref="ConstraintResult.Failure" />
+		/// </summary>
+		protected abstract bool IsSuccess(int failureCount, int totalCount);
 
 		/// <inheritdoc />
 		internal override async Task<Result> GetResult(int index)
@@ -109,17 +123,6 @@ public abstract class Expectation
 				new ConstraintResult.Success(expectationText));
 		}
 
-		/// <summary>
-		///     Returns the subject line of the <see cref="Expectation.Combination" />.
-		/// </summary>
-		internal abstract string GetSubjectLine();
-
-		/// <summary>
-		///     Specifies, if the combination should be treated as
-		///     <see cref="ConstraintResult.Success" /> or <see cref="ConstraintResult.Failure" />
-		/// </summary>
-		internal abstract bool IsSuccess(int failureCount, int totalCount);
-
 		private string CreateFailureMessage(ConstraintResult.Failure failure)
 		{
 			return $"""
@@ -145,11 +148,11 @@ public abstract class Expectation
 		public class All(Expectation[] expectations) : Combination(expectations)
 		{
 			/// <inheritdoc />
-			internal override string GetSubjectLine()
+			protected override string GetSubjectLine()
 				=> "Expected all of the following to succeed:";
 
 			/// <inheritdoc />
-			internal override bool IsSuccess(int failureCount, int totalCount)
+			protected override bool IsSuccess(int failureCount, int totalCount)
 				=> failureCount == 0;
 		}
 
@@ -159,11 +162,11 @@ public abstract class Expectation
 		public class Any(Expectation[] expectations) : Combination(expectations)
 		{
 			/// <inheritdoc />
-			internal override string GetSubjectLine()
+			protected override string GetSubjectLine()
 				=> "Expected any of the following to succeed:";
 
 			/// <inheritdoc />
-			internal override bool IsSuccess(int failureCount, int totalCount)
+			protected override bool IsSuccess(int failureCount, int totalCount)
 				=> failureCount < totalCount;
 		}
 	}

--- a/Source/Testably.Expectations/Results/Expectation.cs
+++ b/Source/Testably.Expectations/Results/Expectation.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Core.Helpers;
+
+namespace Testably.Expectations.Results;
+
+/// <summary>
+///     The result of an expectation without an underlying value.
+/// </summary>
+[StackTraceHidden]
+public abstract class Expectation
+{
+	internal abstract Task<ConstraintResult> GetResult();
+
+	internal abstract string GetSubject();
+
+	public class All : Expectation
+	{
+		private readonly Expectation[] _expectations;
+
+		internal All(Expectation[] expectations)
+		{
+			if (expectations.Length == 0)
+			{
+				throw new ArgumentException("You must provide at least one expectation.",
+					paramName: nameof(expectations));
+			}
+
+			_expectations = expectations;
+		}
+
+		/// <summary>
+		///     By awaiting the result, the expectations are verified.
+		///     <para />
+		///     Will throw an exception, when the expectations are not met.
+		/// </summary>
+		public TaskAwaiter GetAwaiter()
+		{
+			Task result = GetResultOrThrow();
+			return result.GetAwaiter();
+		}
+
+		/// <inheritdoc />
+		internal override async Task<ConstraintResult> GetResult()
+		{
+			Dictionary<int, string> expectationTexts = new();
+			Dictionary<int, string>? failureTexts = new();
+			int index = 0;
+			foreach (Expectation? expectation in _expectations)
+			{
+				index++;
+				ConstraintResult? result = await expectation.GetResult();
+				expectationTexts.Add(index,
+					$"Expected {expectation.GetSubject()} to {result.ExpectationText}");
+				if (result is ConstraintResult.Failure failure)
+				{
+					failureTexts.Add(index, failure.ResultText);
+				}
+			}
+
+			string expectationText = string.Join(Environment.NewLine, expectationTexts
+				.Select(expectation
+					=> $" [{expectation.Key:00}] {expectation.Value.Indent("      ", indentFirstLine: false)}"));
+
+			if (failureTexts.Count > 0)
+			{
+				return new ConstraintResult.Failure(expectationText, string.Join(
+					Environment.NewLine, failureTexts
+						.Select(failure
+							=> $" [{failure.Key:00}] {failure.Value.Indent("      ", indentFirstLine: false)}")));
+			}
+
+			return new ConstraintResult.Success(expectationText);
+		}
+
+		/// <inheritdoc />
+		internal override string GetSubject()
+			=> "";
+
+		private string CreateFailureMessage(ConstraintResult.Failure failure)
+		{
+			return $"""
+			        Expected all of the following to succeed:
+			        {failure.ExpectationText}
+			        but
+			        {failure.ResultText}
+			        """;
+		}
+
+		private async Task GetResultOrThrow()
+		{
+			ConstraintResult result = await GetResult();
+
+			if (result is ConstraintResult.Failure failure)
+			{
+				Fail.Test(CreateFailureMessage(failure));
+			}
+		}
+	}
+
+	public class Any : Expectation
+	{
+		private readonly Expectation[] _expectations;
+
+		internal Any(Expectation[] expectations)
+		{
+			if (expectations.Length == 0)
+			{
+				throw new ArgumentException("You must provide at least one expectation.",
+					paramName: nameof(expectations));
+			}
+
+			_expectations = expectations;
+		}
+
+		/// <summary>
+		///     By awaiting the result, the expectations are verified.
+		///     <para />
+		///     Will throw an exception, when the expectations are not met.
+		/// </summary>
+		public TaskAwaiter GetAwaiter()
+		{
+			Task result = GetResultOrThrow();
+			return result.GetAwaiter();
+		}
+
+		/// <inheritdoc />
+		internal override async Task<ConstraintResult> GetResult()
+		{
+			Dictionary<int, string> expectationTexts = new();
+			Dictionary<int, string>? failureTexts = new();
+			int index = 0;
+			foreach (Expectation? expectation in _expectations)
+			{
+				index++;
+				ConstraintResult? result = await expectation.GetResult();
+				expectationTexts.Add(index,
+					$"Expected {expectation.GetSubject()} to {result.ExpectationText}");
+				if (result is ConstraintResult.Failure failure)
+				{
+					failureTexts.Add(index, failure.ResultText);
+				}
+			}
+
+			string expectationText = string.Join(Environment.NewLine, expectationTexts
+				.Select(expectation
+					=> $" [{expectation.Key:00}] {expectation.Value.Indent("      ", indentFirstLine: false)}"));
+
+			if (failureTexts.Count == expectationTexts.Count)
+			{
+				return new ConstraintResult.Failure(expectationText, string.Join(
+					Environment.NewLine, failureTexts
+						.Select(failure
+							=> $" [{failure.Key:00}] {failure.Value.Indent("      ", indentFirstLine: false)}")));
+			}
+
+			return new ConstraintResult.Success(expectationText);
+		}
+
+		/// <inheritdoc />
+		internal override string GetSubject()
+			=> "";
+
+		private string CreateFailureMessage(ConstraintResult.Failure failure)
+		{
+			return $"""
+			        Expected any of the following to succeed:
+			        {failure.ExpectationText}
+			        but
+			        {failure.ResultText}
+			        """;
+		}
+
+		private async Task GetResultOrThrow()
+		{
+			ConstraintResult result = await GetResult();
+
+			if (result is ConstraintResult.Failure failure)
+			{
+				Fail.Test(CreateFailureMessage(failure));
+			}
+		}
+	}
+}

--- a/Source/Testably.Expectations/Results/Expectation.cs
+++ b/Source/Testably.Expectations/Results/Expectation.cs
@@ -9,8 +9,11 @@ using Testably.Expectations.Core.Helpers;
 namespace Testably.Expectations.Results;
 
 /// <summary>
-///     The result of an expectation without an underlying value.
+///     Base class for expectation results.
 /// </summary>
+/// <remarks>
+///     Create instances by using the static methods on the <see cref="Expect" /> class.
+/// </remarks>
 [StackTraceHidden]
 public abstract class Expectation
 {

--- a/Source/Testably.Expectations/Results/ExpectationResult.cs
+++ b/Source/Testably.Expectations/Results/ExpectationResult.cs
@@ -61,7 +61,8 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder) : Expectat
 
 		if (result is ConstraintResult.Failure failure)
 		{
-			Fail.Test(expectationBuilder.FailureMessageBuilder.FromFailure(failure));
+			Fail.Test(expectationBuilder.FailureMessageBuilder.FromFailure(
+				expectationBuilder.Subject, failure));
 		}
 		else if (result is ConstraintResult.Success)
 		{
@@ -139,7 +140,8 @@ public class ExpectationResult<TResult, TSelf>(ExpectationBuilder expectationBui
 
 		if (result is ConstraintResult.Failure failure)
 		{
-			Fail.Test(expectationBuilder.FailureMessageBuilder.FromFailure(failure));
+			Fail.Test(expectationBuilder.FailureMessageBuilder.FromFailure(
+				expectationBuilder.Subject, failure));
 		}
 		else if (result is ConstraintResult.Success<TResult> matchingSuccess)
 		{

--- a/Source/Testably.Expectations/Results/ExpectationResult.cs
+++ b/Source/Testably.Expectations/Results/ExpectationResult.cs
@@ -48,16 +48,13 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder) : Expectat
 	}
 
 	/// <inheritdoc />
-	internal override Task<ConstraintResult> GetResult()
-		=> expectationBuilder.IsMet();
-
-	/// <inheritdoc />
-	internal override string GetSubject()
-		=> expectationBuilder.Subject;
+	internal override async Task<Result> GetResult(int index)
+		=> new(++index, $" [{index:00}] Expected {expectationBuilder.Subject} to",
+			await expectationBuilder.IsMet());
 
 	private async Task GetResultOrThrow()
 	{
-		ConstraintResult result = await GetResult();
+		ConstraintResult result = await expectationBuilder.IsMet();
 
 		if (result is ConstraintResult.Failure failure)
 		{
@@ -126,17 +123,14 @@ public class ExpectationResult<TResult, TSelf>(ExpectationBuilder expectationBui
 	}
 
 	/// <inheritdoc />
-	internal override Task<ConstraintResult> GetResult()
-		=> expectationBuilder.IsMet();
-
-	/// <inheritdoc />
-	internal override string GetSubject()
-		=> expectationBuilder.Subject;
+	internal override async Task<Result> GetResult(int index)
+		=> new(++index, $" [{index:00}] Expected {expectationBuilder.Subject} to",
+			await expectationBuilder.IsMet());
 
 	[StackTraceHidden]
 	private async Task<TResult> GetResultOrThrow()
 	{
-		ConstraintResult result = await GetResult();
+		ConstraintResult result = await expectationBuilder.IsMet();
 
 		if (result is ConstraintResult.Failure failure)
 		{

--- a/Source/Testably.Expectations/Results/ExpectationResult.cs
+++ b/Source/Testably.Expectations/Results/ExpectationResult.cs
@@ -11,7 +11,7 @@ namespace Testably.Expectations.Results;
 ///     The result of an expectation without an underlying value.
 /// </summary>
 [StackTraceHidden]
-public class ExpectationResult(ExpectationBuilder expectationBuilder)
+public class ExpectationResult(ExpectationBuilder expectationBuilder) : Expectation
 {
 	/// <summary>
 	///     Provide a <paramref name="reason" /> explaining why the constraint is needed.<br />
@@ -30,7 +30,7 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder)
 	/// </summary>
 	public TaskAwaiter GetAwaiter()
 	{
-		Task result = GetResult();
+		Task result = GetResultOrThrow();
 		return result.GetAwaiter();
 	}
 
@@ -47,9 +47,17 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder)
 		return this;
 	}
 
-	private async Task GetResult()
+	/// <inheritdoc />
+	internal override Task<ConstraintResult> GetResult()
+		=> expectationBuilder.IsMet();
+
+	/// <inheritdoc />
+	internal override string GetSubject()
+		=> expectationBuilder.Subject;
+
+	private async Task GetResultOrThrow()
 	{
-		ConstraintResult result = await expectationBuilder.IsMet();
+		ConstraintResult result = await GetResult();
 
 		if (result is ConstraintResult.Failure failure)
 		{
@@ -74,7 +82,7 @@ public class ExpectationResult<TResult>(ExpectationBuilder expectationBuilder)
 ///     The result of an expectation with an underlying value of type <typeparamref name="TResult" />.
 /// </summary>
 [StackTraceHidden]
-public class ExpectationResult<TResult, TSelf>(ExpectationBuilder expectationBuilder)
+public class ExpectationResult<TResult, TSelf>(ExpectationBuilder expectationBuilder) : Expectation
 	where TSelf : ExpectationResult<TResult, TSelf>
 {
 	/// <summary>
@@ -99,7 +107,7 @@ public class ExpectationResult<TResult, TSelf>(ExpectationBuilder expectationBui
 	[StackTraceHidden]
 	public TaskAwaiter<TResult> GetAwaiter()
 	{
-		Task<TResult> result = GetResult();
+		Task<TResult> result = GetResultOrThrow();
 		return result.GetAwaiter();
 	}
 
@@ -116,10 +124,18 @@ public class ExpectationResult<TResult, TSelf>(ExpectationBuilder expectationBui
 		return (TSelf)this;
 	}
 
+	/// <inheritdoc />
+	internal override Task<ConstraintResult> GetResult()
+		=> expectationBuilder.IsMet();
+
+	/// <inheritdoc />
+	internal override string GetSubject()
+		=> expectationBuilder.Subject;
+
 	[StackTraceHidden]
-	private async Task<TResult> GetResult()
+	private async Task<TResult> GetResultOrThrow()
 	{
-		ConstraintResult result = await expectationBuilder.IsMet();
+		ConstraintResult result = await GetResult();
 
 		if (result is ConstraintResult.Failure failure)
 		{

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -738,14 +738,21 @@ namespace Testably.Expectations.Results
         protected Expectation() { }
         public abstract class Combination : Testably.Expectations.Results.Expectation
         {
+            protected Combination(Testably.Expectations.Results.Expectation[] expectations) { }
             public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
+            protected abstract string GetSubjectLine();
+            protected abstract bool IsSuccess(int failureCount, int totalCount);
             public class All : Testably.Expectations.Results.Expectation.Combination
             {
                 public All(Testably.Expectations.Results.Expectation[] expectations) { }
+                protected override string GetSubjectLine() { }
+                protected override bool IsSuccess(int failureCount, int totalCount) { }
             }
             public class Any : Testably.Expectations.Results.Expectation.Combination
             {
                 public Any(Testably.Expectations.Results.Expectation[] expectations) { }
+                protected override string GetSubjectLine() { }
+                protected override bool IsSuccess(int failureCount, int totalCount) { }
             }
         }
     }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -40,6 +40,8 @@ namespace Testably.Expectations
         public static Testably.Expectations.Core.IExpectSubject<Testably.Expectations.ThatDelegate.WithValue<TValue>> That<TValue>(System.Threading.Tasks.Task<TValue> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Core.IExpectSubject<Testably.Expectations.ThatDelegate.WithValue<TValue>> That<TValue>(System.Threading.Tasks.ValueTask<TValue> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Core.IExpectSubject<T> That<T>(T? subject, [System.Runtime.CompilerServices.CallerArgumentExpression("subject")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.Expectation.Combination.All ThatAll(params Testably.Expectations.Results.Expectation[] expectations) { }
+        public static Testably.Expectations.Results.Expectation.Combination.Any ThatAny(params Testably.Expectations.Results.Expectation[] expectations) { }
     }
     [System.Diagnostics.StackTraceHidden]
     public static class Fail
@@ -731,7 +733,24 @@ namespace Testably.Expectations.Results
         public TSelf Once() { }
     }
     [System.Diagnostics.StackTraceHidden]
-    public class ExpectationResult
+    public abstract class Expectation
+    {
+        protected Expectation() { }
+        public abstract class Combination : Testably.Expectations.Results.Expectation
+        {
+            public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
+            public class All : Testably.Expectations.Results.Expectation.Combination
+            {
+                public All(Testably.Expectations.Results.Expectation[] expectations) { }
+            }
+            public class Any : Testably.Expectations.Results.Expectation.Combination
+            {
+                public Any(Testably.Expectations.Results.Expectation[] expectations) { }
+            }
+        }
+    }
+    [System.Diagnostics.StackTraceHidden]
+    public class ExpectationResult : Testably.Expectations.Results.Expectation
     {
         public ExpectationResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }
         public Testably.Expectations.Results.ExpectationResult Because(string reason) { }
@@ -743,7 +762,7 @@ namespace Testably.Expectations.Results
         public ExpectationResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }
     }
     [System.Diagnostics.StackTraceHidden]
-    public class ExpectationResult<TResult, TSelf>
+    public class ExpectationResult<TResult, TSelf> : Testably.Expectations.Results.Expectation
         where TSelf : Testably.Expectations.Results.ExpectationResult<TResult, TSelf>
     {
         public ExpectationResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -738,14 +738,21 @@ namespace Testably.Expectations.Results
         protected Expectation() { }
         public abstract class Combination : Testably.Expectations.Results.Expectation
         {
+            protected Combination(Testably.Expectations.Results.Expectation[] expectations) { }
             public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
+            protected abstract string GetSubjectLine();
+            protected abstract bool IsSuccess(int failureCount, int totalCount);
             public class All : Testably.Expectations.Results.Expectation.Combination
             {
                 public All(Testably.Expectations.Results.Expectation[] expectations) { }
+                protected override string GetSubjectLine() { }
+                protected override bool IsSuccess(int failureCount, int totalCount) { }
             }
             public class Any : Testably.Expectations.Results.Expectation.Combination
             {
                 public Any(Testably.Expectations.Results.Expectation[] expectations) { }
+                protected override string GetSubjectLine() { }
+                protected override bool IsSuccess(int failureCount, int totalCount) { }
             }
         }
     }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -40,6 +40,8 @@ namespace Testably.Expectations
         public static Testably.Expectations.Core.IExpectSubject<Testably.Expectations.ThatDelegate.WithValue<TValue>> That<TValue>(System.Threading.Tasks.Task<TValue> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Core.IExpectSubject<Testably.Expectations.ThatDelegate.WithValue<TValue>> That<TValue>(System.Threading.Tasks.ValueTask<TValue> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Core.IExpectSubject<T> That<T>(T? subject, [System.Runtime.CompilerServices.CallerArgumentExpression("subject")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.Expectation.Combination.All ThatAll(params Testably.Expectations.Results.Expectation[] expectations) { }
+        public static Testably.Expectations.Results.Expectation.Combination.Any ThatAny(params Testably.Expectations.Results.Expectation[] expectations) { }
     }
     [System.Diagnostics.StackTraceHidden]
     public static class Fail
@@ -731,7 +733,24 @@ namespace Testably.Expectations.Results
         public TSelf Once() { }
     }
     [System.Diagnostics.StackTraceHidden]
-    public class ExpectationResult
+    public abstract class Expectation
+    {
+        protected Expectation() { }
+        public abstract class Combination : Testably.Expectations.Results.Expectation
+        {
+            public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
+            public class All : Testably.Expectations.Results.Expectation.Combination
+            {
+                public All(Testably.Expectations.Results.Expectation[] expectations) { }
+            }
+            public class Any : Testably.Expectations.Results.Expectation.Combination
+            {
+                public Any(Testably.Expectations.Results.Expectation[] expectations) { }
+            }
+        }
+    }
+    [System.Diagnostics.StackTraceHidden]
+    public class ExpectationResult : Testably.Expectations.Results.Expectation
     {
         public ExpectationResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }
         public Testably.Expectations.Results.ExpectationResult Because(string reason) { }
@@ -743,7 +762,7 @@ namespace Testably.Expectations.Results
         public ExpectationResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }
     }
     [System.Diagnostics.StackTraceHidden]
-    public class ExpectationResult<TResult, TSelf>
+    public class ExpectationResult<TResult, TSelf> : Testably.Expectations.Results.Expectation
         where TSelf : Testably.Expectations.Results.ExpectationResult<TResult, TSelf>
     {
         public ExpectationResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -676,14 +676,21 @@ namespace Testably.Expectations.Results
         protected Expectation() { }
         public abstract class Combination : Testably.Expectations.Results.Expectation
         {
+            protected Combination(Testably.Expectations.Results.Expectation[] expectations) { }
             public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
+            protected abstract string GetSubjectLine();
+            protected abstract bool IsSuccess(int failureCount, int totalCount);
             public class All : Testably.Expectations.Results.Expectation.Combination
             {
                 public All(Testably.Expectations.Results.Expectation[] expectations) { }
+                protected override string GetSubjectLine() { }
+                protected override bool IsSuccess(int failureCount, int totalCount) { }
             }
             public class Any : Testably.Expectations.Results.Expectation.Combination
             {
                 public Any(Testably.Expectations.Results.Expectation[] expectations) { }
+                protected override string GetSubjectLine() { }
+                protected override bool IsSuccess(int failureCount, int totalCount) { }
             }
         }
     }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -36,6 +36,8 @@ namespace Testably.Expectations
         public static Testably.Expectations.Core.IExpectSubject<Testably.Expectations.ThatDelegate.WithValue<TValue>> That<TValue>(System.Func<TValue> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Core.IExpectSubject<Testably.Expectations.ThatDelegate.WithValue<TValue>> That<TValue>(System.Threading.Tasks.Task<TValue> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Core.IExpectSubject<T> That<T>(T? subject, [System.Runtime.CompilerServices.CallerArgumentExpression("subject")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.Expectation.Combination.All ThatAll(params Testably.Expectations.Results.Expectation[] expectations) { }
+        public static Testably.Expectations.Results.Expectation.Combination.Any ThatAny(params Testably.Expectations.Results.Expectation[] expectations) { }
     }
     [System.Diagnostics.StackTraceHidden]
     public static class Fail
@@ -669,7 +671,24 @@ namespace Testably.Expectations.Results
         public TSelf Once() { }
     }
     [System.Diagnostics.StackTraceHidden]
-    public class ExpectationResult
+    public abstract class Expectation
+    {
+        protected Expectation() { }
+        public abstract class Combination : Testably.Expectations.Results.Expectation
+        {
+            public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
+            public class All : Testably.Expectations.Results.Expectation.Combination
+            {
+                public All(Testably.Expectations.Results.Expectation[] expectations) { }
+            }
+            public class Any : Testably.Expectations.Results.Expectation.Combination
+            {
+                public Any(Testably.Expectations.Results.Expectation[] expectations) { }
+            }
+        }
+    }
+    [System.Diagnostics.StackTraceHidden]
+    public class ExpectationResult : Testably.Expectations.Results.Expectation
     {
         public ExpectationResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }
         public Testably.Expectations.Results.ExpectationResult Because(string reason) { }
@@ -681,7 +700,7 @@ namespace Testably.Expectations.Results
         public ExpectationResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }
     }
     [System.Diagnostics.StackTraceHidden]
-    public class ExpectationResult<TResult, TSelf>
+    public class ExpectationResult<TResult, TSelf> : Testably.Expectations.Results.Expectation
         where TSelf : Testably.Expectations.Results.ExpectationResult<TResult, TSelf>
     {
         public ExpectationResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }

--- a/Tests/Testably.Expectations.Tests/ExpectTests.cs
+++ b/Tests/Testably.Expectations.Tests/ExpectTests.cs
@@ -1,0 +1,124 @@
+﻿namespace Testably.Expectations.Tests;
+
+public class ExpectTests
+{
+	public class ThatAnyTests
+	{
+		[Fact]
+		public async Task ShouldEvaluateAndDisplayAllExpectations()
+		{
+			bool subjectA = false;
+			bool subjectB = false;
+
+			async Task Act()
+				=> await ThatAny(
+					That(subjectA).Should().BeTrue(),
+					That(subjectB).Should().BeTrue());
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected any of the following to succeed:
+				              [01] Expected subjectA to be True
+				              [02] Expected subjectB to be True
+				             but
+				              [01] found False
+				              [02] found False
+				             """);
+		}
+
+		[Theory]
+		[InlineData(true, true)]
+		[InlineData(true, false)]
+		[InlineData(false, true)]
+		public async Task WhenAnyConditionIsMet_ShouldSucceed(bool subjectA, bool subjectB)
+		{
+			async Task Act()
+				=> await ThatAny(
+					That(subjectA).Should().BeTrue(),
+					That(subjectB).Should().BeTrue());
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenNoExpectationWasProvided_ShouldThrowArgumentException()
+		{
+			async Task Act()
+				=> await ThatAny();
+
+			await That(Act).Should().Throw<ArgumentException>()
+				.WithParamName("expectations").And
+				.WithMessage("You must provide at least one expectation*").AsWildcard();
+		}
+	}
+
+	public class ThatAllTests
+	{
+		[Theory]
+		[InlineData(true, false)]
+		[InlineData(false, true)]
+		public async Task ShouldEvaluateAndDisplayAllExpectations(bool subjectA, bool subjectB)
+		{
+			async Task Act()
+				=> await ThatAll(
+					That(subjectA).Should().BeTrue(),
+					That(subjectB).Should().BeTrue());
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected all of the following to succeed:
+				               [01] Expected subjectA to be True
+				               [02] Expected subjectB to be True
+				              but
+				               [{(subjectB ? "01" : "02")}] found False
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenAllConditionIsMet_ShouldSucceed()
+		{
+			bool subjectA = true;
+			bool subjectB = true;
+
+			async Task Act()
+				=> await ThatAll(
+					That(subjectA).Should().BeTrue(),
+					That(subjectB).Should().BeTrue());
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenBothConditionsAreNotMet_ShouldFail()
+		{
+			bool subjectA = false;
+			bool subjectB = false;
+
+			async Task Act()
+				=> await ThatAll(
+					That(subjectA).Should().BeTrue(),
+					That(subjectB).Should().BeTrue());
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected all of the following to succeed:
+				              [01] Expected subjectA to be True
+				              [02] Expected subjectB to be True
+				             but
+				              [01] found False
+				              [02] found False
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenNoExpectationWasProvided_ShouldThrowArgumentException()
+		{
+			async Task Act()
+				=> await ThatAll();
+
+			await That(Act).Should().Throw<ArgumentException>()
+				.WithParamName("expectations").And
+				.WithMessage("You must provide at least one expectation*").AsWildcard();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ExpectTests.cs
+++ b/Tests/Testably.Expectations.Tests/ExpectTests.cs
@@ -26,6 +26,44 @@ public class ExpectTests
 				             """);
 		}
 
+		[Fact]
+		public async Task ShouldIncludeProperIndentationForMultilineResults()
+		{
+			string subjectA = "subject X";
+			string subjectB = "subject Y";
+			string subjectC = "subject Z";
+
+			async Task Act()
+				=> await ThatAny(
+					That(subjectA).Should().Be("subject A"),
+					That(subjectB).Should().Be("subject B"),
+					That(subjectC).Should().Be("subject C"));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected any of the following to succeed:
+				              [01] Expected subjectA to be equal to "subject A"
+				              [02] Expected subjectB to be equal to "subject B"
+				              [03] Expected subjectC to be equal to "subject C"
+				             but
+				              [01] found "subject X" which differs at index 8:
+				                              ↓ (actual)
+				                     "subject X"
+				                     "subject A"
+				                              ↑ (expected)
+				              [02] found "subject Y" which differs at index 8:
+				                              ↓ (actual)
+				                     "subject Y"
+				                     "subject B"
+				                              ↑ (expected)
+				              [03] found "subject Z" which differs at index 8:
+				                              ↓ (actual)
+				                     "subject Z"
+				                     "subject C"
+				                              ↑ (expected)
+				             """);
+		}
+
 		[Theory]
 		[InlineData(true, true)]
 		[InlineData(true, false)]
@@ -38,6 +76,80 @@ public class ExpectTests
 					That(subjectB).Should().BeTrue());
 
 			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenNested_ShouldIncludeProperIndentationForMultilineResults()
+		{
+			string subjectA = "subject X";
+			string subjectB = "some unexpected value";
+			string subjectC = "subject Z";
+
+			async Task Act()
+				=> await ThatAny(
+					That(false).Should().BeTrue(),
+					ThatAny(
+						That(subjectA).Should().Be("subject A"),
+						That(subjectB).Should().Be("subject B"),
+						That(subjectC).Should().Be("subject C")));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected any of the following to succeed:
+				              [01] Expected false to be True
+				               Expected any of the following to succeed:
+				                [02] Expected subjectA to be equal to "subject A"
+				                [03] Expected subjectB to be equal to "subject B"
+				                [04] Expected subjectC to be equal to "subject C"
+				             but
+				              [01] found False
+				                [02] found "subject X" which differs at index 8:
+				                                ↓ (actual)
+				                       "subject X"
+				                       "subject A"
+				                                ↑ (expected)
+				                [03] found "some unexpected value" which differs at index 1:
+				                         ↓ (actual)
+				                       "some unexpected value"
+				                       "subject B"
+				                         ↑ (expected)
+				                [04] found "subject Z" which differs at index 8:
+				                                ↓ (actual)
+				                       "subject Z"
+				                       "subject C"
+				                                ↑ (expected)
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenNested_ShouldUseIncrementingNumber()
+		{
+			bool subjectA = false;
+			bool subjectB = true;
+			bool subjectC = false;
+			bool subjectD = false;
+
+			async Task Act()
+				=> await ThatAny(
+					ThatAll(
+						That(subjectA).Should().BeTrue(),
+						That(subjectB).Should().BeTrue()),
+					That(subjectC).Should().BeTrue(),
+					That(subjectD).Should().BeTrue());
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected any of the following to succeed:
+				               Expected all of the following to succeed:
+				                [01] Expected subjectA to be True
+				                [02] Expected subjectB to be True
+				              [03] Expected subjectC to be True
+				              [04] Expected subjectD to be True
+				             but
+				                [01] found False
+				              [03] found False
+				              [04] found False
+				             """);
 		}
 
 		[Fact]
@@ -75,6 +187,39 @@ public class ExpectTests
 		}
 
 		[Fact]
+		public async Task ShouldIncludeProperIndentationForMultilineResults()
+		{
+			string subjectA = "subject A";
+			string subjectB = "subject C";
+			string subjectC = "subject B";
+
+			async Task Act()
+				=> await ThatAll(
+					That(subjectA).Should().Be("subject A"),
+					That(subjectB).Should().Be("subject B"),
+					That(subjectC).Should().Be("subject C"));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected all of the following to succeed:
+				              [01] Expected subjectA to be equal to "subject A"
+				              [02] Expected subjectB to be equal to "subject B"
+				              [03] Expected subjectC to be equal to "subject C"
+				             but
+				              [02] found "subject C" which differs at index 8:
+				                              ↓ (actual)
+				                     "subject C"
+				                     "subject B"
+				                              ↑ (expected)
+				              [03] found "subject B" which differs at index 8:
+				                              ↓ (actual)
+				                     "subject B"
+				                     "subject C"
+				                              ↑ (expected)
+				             """);
+		}
+
+		[Fact]
 		public async Task WhenAllConditionIsMet_ShouldSucceed()
 		{
 			bool subjectA = true;
@@ -107,6 +252,74 @@ public class ExpectTests
 				             but
 				              [01] found False
 				              [02] found False
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenNested_ShouldIncludeProperIndentationForMultilineResults()
+		{
+			string subjectA = "subject A";
+			string subjectB = "some unexpected value";
+			string subjectC = "subject B";
+
+			async Task Act()
+				=> await ThatAll(
+					That(true).Should().BeTrue(),
+					ThatAll(
+						That(subjectA).Should().Be("subject A"),
+						That(subjectB).Should().Be("subject B"),
+						That(subjectC).Should().Be("subject C")));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected all of the following to succeed:
+				              [01] Expected true to be True
+				               Expected all of the following to succeed:
+				                [02] Expected subjectA to be equal to "subject A"
+				                [03] Expected subjectB to be equal to "subject B"
+				                [04] Expected subjectC to be equal to "subject C"
+				             but
+				                [03] found "some unexpected value" which differs at index 1:
+				                         ↓ (actual)
+				                       "some unexpected value"
+				                       "subject B"
+				                         ↑ (expected)
+				                [04] found "subject B" which differs at index 8:
+				                                ↓ (actual)
+				                       "subject B"
+				                       "subject C"
+				                                ↑ (expected)
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenNested_ShouldUseIncrementingNumber()
+		{
+			bool subjectA = false;
+			bool subjectB = false;
+			bool subjectC = true;
+			bool subjectD = false;
+
+			async Task Act()
+				=> await ThatAll(
+					ThatAny(
+						That(subjectA).Should().BeTrue(),
+						That(subjectB).Should().BeTrue()),
+					That(subjectC).Should().BeTrue(),
+					That(subjectD).Should().BeTrue());
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected all of the following to succeed:
+				               Expected any of the following to succeed:
+				                [01] Expected subjectA to be True
+				                [02] Expected subjectB to be True
+				              [03] Expected subjectC to be True
+				              [04] Expected subjectD to be True
+				             but
+				                [01] found False
+				                [02] found False
+				              [04] found False
 				             """);
 		}
 


### PR DESCRIPTION
Similar to the [Assertion scope of fluentAssertions](https://fluentassertions.com/introduction#assertion-scopes) add the option to combine multiple expectations into one and only evaluate them at the end.
- *Fixes #107*

Syntax:
```csharp
await Expect.ThatAll(
  Expect.That(subjectA).Should().Be("foo"),
  Expect.That(collection).Should().All().Be("bar")
);
```

The result lists all expectations and all failures in the message (with a clear mapping via incrementing numbers).

Also implemented a `Expect.ThatAny` overload, that allows writing an "OR-combination" of expectations.