### PR TITLE
feat: include missing or superfluous whitespace in message

### DIFF
--- a/Source/Testably.Expectations/Core/Helpers/StringExtensions.cs
+++ b/Source/Testably.Expectations/Core/Helpers/StringExtensions.cs
@@ -36,6 +36,12 @@ internal static class StringExtensions
 	}
 
 	[return: NotNullIfNotNull(nameof(value))]
+	public static string? DisplayWhitespace(this string? value)
+	{
+		return value?.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+	}
+
+	[return: NotNullIfNotNull(nameof(value))]
 	public static string? ToSingleLineIf(this string? value, bool condition)
 	{
 		if (!condition)

--- a/Source/Testably.Expectations/Core/Helpers/StringExtensions.cs
+++ b/Source/Testably.Expectations/Core/Helpers/StringExtensions.cs
@@ -6,6 +6,12 @@ namespace Testably.Expectations.Core.Helpers;
 internal static class StringExtensions
 {
 	[return: NotNullIfNotNull(nameof(value))]
+	public static string? DisplayWhitespace(this string? value)
+	{
+		return value?.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+	}
+
+	[return: NotNullIfNotNull(nameof(value))]
 	public static string? Indent(this string? value, string indentation = "  ",
 		bool indentFirstLine = true)
 	{
@@ -33,12 +39,6 @@ internal static class StringExtensions
 	public static string? ToSingleLine(this string? value)
 	{
 		return value?.Replace("\n", "\\n").Replace("\r", "\\r");
-	}
-
-	[return: NotNullIfNotNull(nameof(value))]
-	public static string? DisplayWhitespace(this string? value)
-	{
-		return value?.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
 	}
 
 	[return: NotNullIfNotNull(nameof(value))]

--- a/Source/Testably.Expectations/Options/StringMatcher.cs
+++ b/Source/Testably.Expectations/Options/StringMatcher.cs
@@ -169,44 +169,43 @@ public class StringMatcher(string? pattern)
 			if (stringDifference.IndexOfFirstMismatch == 0 &&
 			    comparer.Equals(actual.TrimStart(), pattern))
 			{
-				return $"{prefix} which has unexpected whitespace at the beginning";
+				return
+					$"{prefix} which has unexpected whitespace (\"{actual.Substring(0, GetIndexOfFirstMatch(actual, pattern, comparer)).DisplayWhitespace().TruncateWithEllipsis(100)}\" at the beginning)";
 			}
 
 			if (stringDifference.IndexOfFirstMismatch == 0 &&
 			    comparer.Equals(actual, pattern.TrimStart()))
 			{
-				return $"{prefix} which misses some whitespace at the beginning";
+				return
+					$"{prefix} which misses some whitespace (\"{pattern.Substring(0, GetIndexOfFirstMatch(pattern, actual, comparer)).DisplayWhitespace().TruncateWithEllipsis(100)}\" at the beginning)";
 			}
 
 			if (stringDifference.IndexOfFirstMismatch == minCommonLength &&
 			    comparer.Equals(actual.TrimEnd(), pattern))
 			{
-				return $"{prefix} which has unexpected whitespace at the end";
+				return
+					$"{prefix} which has unexpected whitespace (\"{actual.Substring(stringDifference.IndexOfFirstMismatch).DisplayWhitespace().TruncateWithEllipsis(100)}\" at the end)";
 			}
 
 			if (stringDifference.IndexOfFirstMismatch == minCommonLength &&
 			    comparer.Equals(actual, pattern.TrimEnd()))
 			{
-				return $"{prefix} which misses some whitespace at the end";
-			}
-
-			if (comparer.Equals(actual.Trim(), pattern.Trim()))
-			{
-				return $"{prefix} which differs in whitespace";
+				return
+					$"{prefix} which misses some whitespace (\"{pattern.Substring(stringDifference.IndexOfFirstMismatch).DisplayWhitespace().TruncateWithEllipsis(100)}\" at the end)";
 			}
 
 			if (actual.Length < pattern.Length &&
 			    stringDifference.IndexOfFirstMismatch == actual.Length)
 			{
 				return
-					$"{prefix} with a length of {actual.Length} which is shorter than the expected length of {pattern.Length}";
+					$"{prefix} with a length of {actual.Length} which is shorter than the expected length of {pattern.Length} and misses:{Environment.NewLine}  \"{pattern.Substring(actual.Length).TruncateWithEllipsis(100)}\"";
 			}
 
 			if (actual.Length > pattern.Length &&
 			    stringDifference.IndexOfFirstMismatch == pattern.Length)
 			{
 				return
-					$"{prefix} with a length of {actual.Length} which is longer than the expected length of {pattern.Length}";
+					$"{prefix} with a length of {actual.Length} which is longer than the expected length of {pattern.Length} and has superfluous:{Environment.NewLine}  \"{actual.Substring(pattern.Length).TruncateWithEllipsis(100)}\"";
 			}
 
 			return $"{prefix} which {new StringDifference(actual, pattern, comparer)}";
@@ -229,6 +228,21 @@ public class StringMatcher(string? pattern)
 		}
 
 		#endregion
+
+		private int GetIndexOfFirstMatch(string stringWithLeadingWhitespace, string value,
+			IEqualityComparer<string> comparer)
+		{
+			for (int i = 0; i <= stringWithLeadingWhitespace.Length - value.Length; i++)
+			{
+				if (comparer.Equals(
+					stringWithLeadingWhitespace.Substring(i, value.Length), value))
+				{
+					return i;
+				}
+			}
+
+			return 0;
+		}
 	}
 
 	private sealed class RegexMatchType : IMatchType

--- a/Tests/Testably.Expectations.Tests/Core/StringMatcherTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/StringMatcherTests.cs
@@ -205,21 +205,7 @@ public class StringMatcherTests
 				=> await That(subject).Should().Be(expected);
 
 			await That(Act).Should().ThrowException()
-				.WithMessage("*misses some whitespace at the beginning*").AsWildcard();
-		}
-
-		[Fact]
-		public async Task
-			WhenTheExpectedStringHasTrailingAndLeadingWhitespace_ShouldFailWithDescriptiveMessage()
-		{
-			string subject = "ABC";
-			string expected = "\tABC\t";
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected);
-
-			await That(Act).Should().ThrowException().WithMessage("*differs in whitespace*")
-				.AsWildcard();
+				.WithMessage("*misses some whitespace (\" \" at the beginning)*").AsWildcard();
 		}
 
 		[Fact]
@@ -233,7 +219,7 @@ public class StringMatcherTests
 				=> await That(subject).Should().Be(expected);
 
 			await That(Act).Should().ThrowException()
-				.WithMessage("*misses some whitespace at the end*").AsWildcard();
+				.WithMessage("*misses some whitespace (\"  \" at the end)*").AsWildcard();
 		}
 
 		[Fact]
@@ -247,7 +233,7 @@ public class StringMatcherTests
 
 			await That(Act).Should()
 				.ThrowException()
-				.WithMessage("*length of 2 which is longer than the expected length of 0*")
+				.WithMessage("*length of 2 which is longer than the expected length of 0 and has superfluous*\"AB\"*")
 				.AsWildcard();
 		}
 
@@ -263,7 +249,7 @@ public class StringMatcherTests
 
 			await That(Act).Should()
 				.ThrowException()
-				.WithMessage("*length of 2 which is shorter than the expected length of 3*")
+				.WithMessage("*length of 2 which is shorter than the expected length of 3 and misses*\"C\"*")
 				.AsWildcard();
 		}
 
@@ -292,7 +278,7 @@ public class StringMatcherTests
 
 			await That(Act).Should()
 				.ThrowException()
-				.WithMessage("*length of 3 which is longer than the expected length of 2*")
+				.WithMessage("*length of 3 which is longer than the expected length of 2 and has superfluous*\"C\"*")
 				.AsWildcard();
 		}
 
@@ -319,21 +305,7 @@ public class StringMatcherTests
 				=> await That(subject).Should().Be(expected);
 
 			await That(Act).Should().ThrowException()
-				.WithMessage("*unexpected whitespace at the beginning*").AsWildcard();
-		}
-
-		[Fact]
-		public async Task
-			WhenTheSubjectHasTrailingAndLeadingWhitespace_ShouldFailWithDescriptiveMessage()
-		{
-			string subject = " ABC\t";
-			string expected = "ABC";
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected);
-
-			await That(Act).Should().ThrowException().WithMessage("*differs in whitespace*")
-				.AsWildcard();
+				.WithMessage("*unexpected whitespace (\"\\t \" at the beginning)*").AsWildcard();
 		}
 
 		[Fact]
@@ -346,7 +318,7 @@ public class StringMatcherTests
 				=> await That(subject).Should().Be(expected);
 
 			await That(Act).Should().ThrowException()
-				.WithMessage("*unexpected whitespace at the end*").AsWildcard();
+				.WithMessage("*unexpected whitespace (\"\\t\" at the end)*").AsWildcard();
 		}
 
 		[Fact]
@@ -360,7 +332,7 @@ public class StringMatcherTests
 
 			await That(Act).Should()
 				.ThrowException()
-				.WithMessage("*length of 0 which is shorter than the expected length of 2*")
+				.WithMessage("*length of 0 which is shorter than the expected length of 2 and misses*\"AB\"*")
 				.AsWildcard();
 		}
 

--- a/Tests/Testably.Expectations.Tests/Core/StringMatcherTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/StringMatcherTests.cs
@@ -86,9 +86,11 @@ public class StringMatcherTests
 		}
 
 		[Theory]
-		[InlineData("SomeVeryLongDummyTextWithMore_ThisLongTextIsUsedToCheckADifferenceAtTheEnd after 40 + 5 characters")]
+		[InlineData(
+			"SomeVeryLongDummyTextWithMore_ThisLongTextIsUsedToCheckADifferenceAtTheEnd after 40 + 5 characters")]
 		// ReSharper disable once StringLiteralTypo
-		[InlineData("SomeVeryLongDummyTextWithMore_ThisLongTextIsUsedToCheckADifferen after 40 + 15 characters")]
+		[InlineData(
+			"SomeVeryLongDummyTextWithMore_ThisLongTextIsUsedToCheckADifferen after 40 + 15 characters")]
 		public async Task
 			ShouldLookForAWordBoundaryBetween45And60CharactersAfterTheMismatchingIndexToHighlightTheMismatch(
 				string expected)
@@ -161,8 +163,10 @@ public class StringMatcherTests
 		[Fact]
 		public async Task WhenStringsAreLong_ShouldHighlightTheDifferences()
 		{
-			string subject = "this is a long text that differs in between two words and has lot of text afterwards";
-			string expected = "this is a long text which differs in between two words and has lot of text afterwards";
+			string subject =
+				"this is a long text that differs in between two words and has lot of text afterwards";
+			string expected =
+				"this is a long text which differs in between two words and has lot of text afterwards";
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -210,6 +214,23 @@ public class StringMatcherTests
 
 		[Fact]
 		public async Task
+			WhenTheExpectedStringHasLeadingWhitespace_ShouldLimitDisplayedWhitespaceTo100Characters()
+		{
+			const int maxCharacters = 100;
+			string subject = "ABC";
+			string expected = new string(' ', maxCharacters) + " ABC";
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().ThrowException()
+				.WithMessage(
+					$"*misses some whitespace (\"{new string(' ', maxCharacters)}…\" at the beginning)*")
+				.AsWildcard();
+		}
+
+		[Fact]
+		public async Task
 			WhenTheExpectedStringHasTrailingWhitespace_ShouldFailWithDescriptiveMessage()
 		{
 			string subject = "ABC";
@@ -223,6 +244,23 @@ public class StringMatcherTests
 		}
 
 		[Fact]
+		public async Task
+			WhenTheExpectedStringHasTrailingWhitespace_ShouldLimitDisplayedWhitespaceTo100Characters()
+		{
+			const int maxCharacters = 100;
+			string subject = "ABC";
+			string expected = "ABC " + new string(' ', maxCharacters);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().ThrowException()
+				.WithMessage(
+					$"*misses some whitespace (\"{new string(' ', maxCharacters)}…\" at the end)*")
+				.AsWildcard();
+		}
+
+		[Fact]
 		public async Task WhenTheExpectedStringIsEmpty_ShouldFailWithDescriptiveMessage()
 		{
 			string subject = "AB";
@@ -233,7 +271,8 @@ public class StringMatcherTests
 
 			await That(Act).Should()
 				.ThrowException()
-				.WithMessage("*length of 2 which is longer than the expected length of 0 and has superfluous*\"AB\"*")
+				.WithMessage(
+					"*length of 2 which is longer than the expected length of 0 and has superfluous*\"AB\"*")
 				.AsWildcard();
 		}
 
@@ -249,7 +288,26 @@ public class StringMatcherTests
 
 			await That(Act).Should()
 				.ThrowException()
-				.WithMessage("*length of 2 which is shorter than the expected length of 3 and misses*\"C\"*")
+				.WithMessage(
+					"*length of 2 which is shorter than the expected length of 3 and misses*\"C\"*")
+				.AsWildcard();
+		}
+
+		[Fact]
+		public async Task
+			WhenTheExpectedStringIsLongerThanTheSubjectString_ShouldLimitDisplayedDifferenceTo100Characters()
+		{
+			const int maxCharacters = 100;
+			string subject = "AB";
+			string expected = "ABX" + new string('X', maxCharacters);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should()
+				.ThrowException()
+				.WithMessage(
+					$"*length of 2 which is shorter than the expected length of 103 and misses*\"{new string('X', maxCharacters)}…\"*")
 				.AsWildcard();
 		}
 
@@ -278,7 +336,26 @@ public class StringMatcherTests
 
 			await That(Act).Should()
 				.ThrowException()
-				.WithMessage("*length of 3 which is longer than the expected length of 2 and has superfluous*\"C\"*")
+				.WithMessage(
+					"*length of 3 which is longer than the expected length of 2 and has superfluous*\"C\"*")
+				.AsWildcard();
+		}
+
+		[Fact]
+		public async Task
+			WhenTheExpectedStringIsShorterThanTheSubjectString_ShouldLimitDisplayedDifferenceTo100Characters()
+		{
+			const int maxCharacters = 100;
+			string subject = "ABX" + new string('X', maxCharacters);
+			string expected = "AB";
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should()
+				.ThrowException()
+				.WithMessage(
+					$"*length of 103 which is longer than the expected length of 2 and has superfluous*\"{new string('X', maxCharacters)}…\"*")
 				.AsWildcard();
 		}
 
@@ -309,6 +386,23 @@ public class StringMatcherTests
 		}
 
 		[Fact]
+		public async Task
+			WhenTheSubjectHasLeadingWhitespace_ShouldLimitDisplayedWhitespaceTo100Characters()
+		{
+			const int maxCharacters = 100;
+			string subject = new string(' ', maxCharacters) + " ABC";
+			string expected = "ABC";
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().ThrowException()
+				.WithMessage(
+					$"*unexpected whitespace (\"{new string(' ', maxCharacters)}…\" at the beginning)*")
+				.AsWildcard();
+		}
+
+		[Fact]
 		public async Task WhenTheSubjectHasTrailingWhitespace_ShouldFailWithDescriptiveMessage()
 		{
 			string subject = "ABC\t";
@@ -322,6 +416,23 @@ public class StringMatcherTests
 		}
 
 		[Fact]
+		public async Task
+			WhenTheSubjectHasTrailingWhitespace_ShouldLimitDisplayedWhitespaceTo100Characters()
+		{
+			const int maxCharacters = 100;
+			string subject = "ABC " + new string(' ', maxCharacters);
+			string expected = "ABC";
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().ThrowException()
+				.WithMessage(
+					$"*unexpected whitespace (\"{new string(' ', maxCharacters)}…\" at the end)*")
+				.AsWildcard();
+		}
+
+		[Fact]
 		public async Task WhenTheSubjectStringIsEmpty_ShouldFailWithDescriptiveMessage()
 		{
 			string subject = "";
@@ -332,7 +443,8 @@ public class StringMatcherTests
 
 			await That(Act).Should()
 				.ThrowException()
-				.WithMessage("*length of 0 which is shorter than the expected length of 2 and misses*\"AB\"*")
+				.WithMessage(
+					"*length of 0 which is shorter than the expected length of 2 and misses*\"AB\"*")
 				.AsWildcard();
 		}
 

--- a/Tests/Testably.Expectations.Tests/Options/StringMatcherTests.cs
+++ b/Tests/Testably.Expectations.Tests/Options/StringMatcherTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Testably.Expectations.Tests.Core;
+﻿namespace Testably.Expectations.Tests.Options;
 
 public class StringMatcherTests
 {


### PR DESCRIPTION
When two strings only differ in whitespace or length, the difference is now included in the failure message.
- Whitespace is escaped so that it is displayed as `\t`, `\n` or `\r`
- The displayed string is limited to 100 characters

*fixes #106*