### PR TITLE
fix: use correct type for buffer size

### DIFF
--- a/Source/Testably.Expectations/That/Streams/ThatBufferedStreamShould.HaveBufferSize.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatBufferedStreamShould.HaveBufferSize.cs
@@ -14,7 +14,7 @@ public static partial class ThatBufferedStreamShould
 	/// </summary>
 	public static AndOrResult<BufferedStream?, IThat<BufferedStream?>> HaveBufferSize(
 		this IThat<BufferedStream?> source,
-		long expected,
+		int expected,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ValueConstraint(
@@ -31,7 +31,7 @@ public static partial class ThatBufferedStreamShould
 	/// </summary>
 	public static AndOrResult<BufferedStream?, IThat<BufferedStream?>>
 		NotHaveBufferSize(this IThat<BufferedStream?> source,
-			long expected,
+			int expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ValueConstraint(

--- a/Source/Testably.Expectations/That/Streams/ThatBufferedStreamShould.HaveBufferSize.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatBufferedStreamShould.HaveBufferSize.cs
@@ -27,16 +27,18 @@ public static partial class ThatBufferedStreamShould
 			source);
 
 	/// <summary>
-	///     Verifies that the subject <see cref="BufferedStream" /> has the <paramref name="expected" /> buffer size.
+	///     Verifies that the subject <see cref="BufferedStream" /> does not have the <paramref name="unexpected" />
+	///     buffer size.
 	/// </summary>
 	public static AndOrResult<BufferedStream?, IThat<BufferedStream?>>
 		NotHaveBufferSize(this IThat<BufferedStream?> source,
-			int expected,
-			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+			int unexpected,
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ValueConstraint(
-					$"not have buffer size {expected}",
-					actual => actual != null && actual.BufferSize != expected,
+					$"not have buffer size {unexpected}",
+					actual => actual != null && actual.BufferSize != unexpected,
 					actual => actual == null ? "found <null>" : "it had"))
 				.AppendMethodStatement(nameof(NotHaveBufferSize), doNotPopulateThisValue),
 			source);

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -123,8 +123,8 @@ namespace Testably.Expectations
     }
     public static class ThatBufferedStreamShould
     {
-        public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> HaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, long expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> NotHaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, long expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> HaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, int expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> NotHaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, int expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatDateOnlyShould
     {

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -124,7 +124,7 @@ namespace Testably.Expectations
     public static class ThatBufferedStreamShould
     {
         public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> HaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, int expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> NotHaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, int expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> NotHaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, int unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatDateOnlyShould
     {

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -123,8 +123,8 @@ namespace Testably.Expectations
     }
     public static class ThatBufferedStreamShould
     {
-        public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> HaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, long expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> NotHaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, long expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> HaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, int expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> NotHaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, int expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatDateOnlyShould
     {

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -124,7 +124,7 @@ namespace Testably.Expectations
     public static class ThatBufferedStreamShould
     {
         public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> HaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, int expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> NotHaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, int expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static Testably.Expectations.Results.AndOrResult<System.IO.BufferedStream?, Testably.Expectations.Core.IThat<System.IO.BufferedStream?>> NotHaveBufferSize(this Testably.Expectations.Core.IThat<System.IO.BufferedStream?> source, int unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatDateOnlyShould
     {

--- a/Tests/Testably.Expectations.Tests/ThatTests/Streams/BufferedStreamShould.HaveBufferSizeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Streams/BufferedStreamShould.HaveBufferSizeTests.cs
@@ -9,31 +9,31 @@ public sealed partial class BufferedStreamShould
 	{
 		[Theory]
 		[AutoData]
-		public async Task WhenSubjectHasDifferentBufferSize_ShouldFail(int buffersize)
+		public async Task WhenSubjectHasDifferentBufferSize_ShouldFail(int bufferSize)
 		{
-			int actualBufferSize = buffersize > 10000 ? buffersize - 1 : buffersize + 1;
+			int actualBufferSize = bufferSize > 10000 ? bufferSize - 1 : bufferSize + 1;
 			using BufferedStream subject = GetBufferedStream(actualBufferSize);
 
 			async Task Act()
-				=> await That(subject).Should().HaveBufferSize(buffersize);
+				=> await That(subject).Should().HaveBufferSize(bufferSize);
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				                   Expected subject to
-				                   have buffer size {buffersize},
+				                   have buffer size {bufferSize},
 				                   but it had buffer size {actualBufferSize}
-				                   at Expect.That(subject).Should().HaveBufferSize(buffersize)
+				                   at Expect.That(subject).Should().HaveBufferSize(bufferSize)
 				                   """);
 		}
 
 		[Theory]
 		[AutoData]
-		public async Task WhenSubjectHasSameBufferSize_ShouldSucceed(int buffersize)
+		public async Task WhenSubjectHasSameBufferSize_ShouldSucceed(int bufferSize)
 		{
-			using BufferedStream subject = GetBufferedStream(buffersize);
+			using BufferedStream subject = GetBufferedStream(bufferSize);
 
 			async Task Act()
-				=> await That(subject).Should().HaveBufferSize(buffersize);
+				=> await That(subject).Should().HaveBufferSize(bufferSize);
 
 			await That(Act).Should().NotThrow();
 		}
@@ -60,32 +60,32 @@ public sealed partial class BufferedStreamShould
 	{
 		[Theory]
 		[AutoData]
-		public async Task WhenSubjectHasDifferentBufferSize_ShouldSucceed(int buffersize)
+		public async Task WhenSubjectHasDifferentBufferSize_ShouldSucceed(int bufferSize)
 		{
-			int actualBufferSize = buffersize > 10000 ? buffersize - 1 : buffersize + 1;
+			int actualBufferSize = bufferSize > 10000 ? bufferSize - 1 : bufferSize + 1;
 			using BufferedStream subject = GetBufferedStream(actualBufferSize);
 
 			async Task Act()
-				=> await That(subject).Should().NotHaveBufferSize(buffersize);
+				=> await That(subject).Should().NotHaveBufferSize(bufferSize);
 
 			await That(Act).Should().NotThrow();
 		}
 
 		[Theory]
 		[AutoData]
-		public async Task WhenSubjectHasSameBufferSize_ShouldFail(int buffersize)
+		public async Task WhenSubjectHasSameBufferSize_ShouldFail(int bufferSize)
 		{
-			using BufferedStream subject = GetBufferedStream(buffersize);
+			using BufferedStream subject = GetBufferedStream(bufferSize);
 
 			async Task Act()
-				=> await That(subject).Should().NotHaveBufferSize(buffersize);
+				=> await That(subject).Should().NotHaveBufferSize(bufferSize);
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				                   Expected subject to
-				                   not have buffer size {buffersize},
+				                   not have buffer size {bufferSize},
 				                   but it had
-				                   at Expect.That(subject).Should().NotHaveBufferSize(buffersize)
+				                   at Expect.That(subject).Should().NotHaveBufferSize(bufferSize)
 				                   """);
 		}
 


### PR DESCRIPTION
Fixes #114

Also fix the incorrect XML comment for `NotHaveBufferSize`