### PR TITLE
feat: add `BePositive` and `BeNegative` for numbers

### DIFF
--- a/Source/Testably.Expectations/Formatting/Formatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatter.cs
@@ -39,8 +39,18 @@ public class Formatter
 		new NumberFormatter<ushort>(v => v.ToString(CultureInfo.InvariantCulture)),
 		new NumberFormatter<long>(v => v.ToString(CultureInfo.InvariantCulture)),
 		new NumberFormatter<ulong>(v => v.ToString(CultureInfo.InvariantCulture)),
-		new NumberFormatter<float>(v => v.ToString(CultureInfo.InvariantCulture)),
-		new NumberFormatter<double>(v => v.ToString(CultureInfo.InvariantCulture)),
+		new NumberFormatter<float>(v => v switch
+		{
+			float.NegativeInfinity => "-\u221e",
+			float.PositiveInfinity => "+\u221e",
+			_ => v.ToString(CultureInfo.InvariantCulture)
+		}),
+		new NumberFormatter<double>(v => v switch
+		{
+			double.NegativeInfinity => "-\u221e",
+			double.PositiveInfinity => "+\u221e",
+			_ => v.ToString(CultureInfo.InvariantCulture)
+		}),
 		new NumberFormatter<decimal>(v => v.ToString(CultureInfo.InvariantCulture)),
 		new NumberFormatter(),
 	];

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeNegative.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeNegative.cs
@@ -1,0 +1,205 @@
+﻿using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatNumberShould
+{
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<sbyte, IThat<sbyte>> BeNegative(
+		this IThat<sbyte> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<sbyte>(
+					0,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<short, IThat<short>> BeNegative(
+		this IThat<short> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<short>(
+					0,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<int, IThat<int>> BeNegative(
+		this IThat<int> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<int>(
+					0,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<long, IThat<long>> BeNegative(
+		this IThat<long> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<long>(
+					0L,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<float, IThat<float>> BeNegative(
+		this IThat<float> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<float>(
+					0.0F,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<double, IThat<double>> BeNegative(
+		this IThat<double> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<double>(
+					0.0,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<decimal, IThat<decimal>> BeNegative(
+		this IThat<decimal> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<decimal>(
+					0,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<sbyte?, IThat<sbyte?>> BeNegative(
+		this IThat<sbyte?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<sbyte>(
+					0,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<short?, IThat<short?>> BeNegative(
+		this IThat<short?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<short>(
+					0,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<int?, IThat<int?>> BeNegative(
+		this IThat<int?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<int>(
+					0,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<long?, IThat<long?>> BeNegative(
+		this IThat<long?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<long>(
+					0L,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<float?, IThat<float?>> BeNegative(
+		this IThat<float?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<float>(
+					0.0F,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<double?, IThat<double?>> BeNegative(
+		this IThat<double?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<double>(
+					0.0,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<decimal?, IThat<decimal?>> BeNegative(
+		this IThat<decimal?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<decimal>(
+					0,
+					_ => "be negative",
+					(a, e) => a < e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BeNegative)),
+			source);
+}

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BePositive.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BePositive.cs
@@ -1,0 +1,205 @@
+﻿using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Expectations;
+
+public static partial class ThatNumberShould
+{
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<sbyte, IThat<sbyte>> BePositive(
+		this IThat<sbyte> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<sbyte>(
+					0,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<short, IThat<short>> BePositive(
+		this IThat<short> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<short>(
+					0,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<int, IThat<int>> BePositive(
+		this IThat<int> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<int>(
+					0,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<long, IThat<long>> BePositive(
+		this IThat<long> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<long>(
+					0L,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<float, IThat<float>> BePositive(
+		this IThat<float> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<float>(
+					0.0F,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<double, IThat<double>> BePositive(
+		this IThat<double> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<double>(
+					0.0,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<decimal, IThat<decimal>> BePositive(
+		this IThat<decimal> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint<decimal>(
+					0,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<sbyte?, IThat<sbyte?>> BePositive(
+		this IThat<sbyte?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<sbyte>(
+					0,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<short?, IThat<short?>> BePositive(
+		this IThat<short?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<short>(
+					0,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<int?, IThat<int?>> BePositive(
+		this IThat<int?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<int>(
+					0,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<long?, IThat<long?>> BePositive(
+		this IThat<long?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<long>(
+					0L,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<float?, IThat<float?>> BePositive(
+		this IThat<float?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<float>(
+					0.0F,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<double?, IThat<double?>> BePositive(
+		this IThat<double?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<double>(
+					0.0,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<decimal?, IThat<decimal?>> BePositive(
+		this IThat<decimal?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new NullableGenericConstraint<decimal>(
+					0,
+					_ => "be positive",
+					(a, e) => a > e,
+					(a, _) => $"found {Formatter.Format(a)}"))
+				.AppendMethodStatement(nameof(BePositive)),
+			source);
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeFiniteTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeFiniteTests.cs
@@ -19,10 +19,10 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(double.PositiveInfinity)]
-		[InlineData(double.NegativeInfinity)]
-		[InlineData(double.NaN)]
-		public async Task ForDouble_WhenSubjectIsInfinityOrNaN_ShouldFail(double subject)
+		[InlineData(double.PositiveInfinity, "+\u221e")]
+		[InlineData(double.NegativeInfinity, "-\u221e")]
+		[InlineData(double.NaN, "NaN")]
+		public async Task ForDouble_WhenSubjectIsInfinityOrNaN_ShouldFail(double subject, string format)
 		{
 			async Task Act() => await That(subject).Should().BeFinite();
 
@@ -30,7 +30,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be finite,
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              but found {format}
 				              at Expect.That(subject).Should().BeFinite()
 				              """);
 		}
@@ -62,10 +62,10 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(float.PositiveInfinity)]
-		[InlineData(float.NegativeInfinity)]
-		[InlineData(float.NaN)]
-		public async Task ForFloat_WhenSubjectIsInfinityOrNaN_ShouldFail(float subject)
+		[InlineData(float.PositiveInfinity, "+\u221e")]
+		[InlineData(float.NegativeInfinity, "-\u221e")]
+		[InlineData(float.NaN, "NaN")]
+		public async Task ForFloat_WhenSubjectIsInfinityOrNaN_ShouldFail(float subject, string format)
 		{
 			async Task Act()
 				=> await That(subject).Should().BeFinite();
@@ -74,7 +74,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be finite,
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              but found {format}
 				              at Expect.That(subject).Should().BeFinite()
 				              """);
 		}
@@ -107,12 +107,12 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(double.PositiveInfinity)]
-		[InlineData(double.NegativeInfinity)]
-		[InlineData(double.NaN)]
-		[InlineData(null)]
+		[InlineData(double.PositiveInfinity, "+\u221e")]
+		[InlineData(double.NegativeInfinity, "-\u221e")]
+		[InlineData(double.NaN, "NaN")]
+		[InlineData(null, "<null>")]
 		public async Task ForNullableDouble_WhenSubjectIsInfinityOrNaNOrNull_ShouldFail(
-			double? subject)
+			double? subject, string format)
 		{
 			async Task Act() => await That(subject).Should().BeFinite();
 
@@ -120,7 +120,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be finite,
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}
+				              but found {format}
 				              at Expect.That(subject).Should().BeFinite()
 				              """);
 		}
@@ -152,12 +152,12 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(float.PositiveInfinity)]
-		[InlineData(float.NegativeInfinity)]
-		[InlineData(float.NaN)]
-		[InlineData(null)]
+		[InlineData(float.PositiveInfinity, "+\u221e")]
+		[InlineData(float.NegativeInfinity, "-\u221e")]
+		[InlineData(float.NaN, "NaN")]
+		[InlineData(null, "<null>")]
 		public async Task ForNullableFloat_WhenSubjectIsInfinityOrNaNOrNull_ShouldFail(
-			float? subject)
+			float? subject, string format)
 		{
 			async Task Act()
 				=> await That(subject).Should().BeFinite();
@@ -166,7 +166,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be finite,
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}
+				              but found {format}
 				              at Expect.That(subject).Should().BeFinite()
 				              """);
 		}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeInfiniteTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeInfiniteTests.cs
@@ -200,9 +200,9 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(double.PositiveInfinity)]
-		[InlineData(double.NegativeInfinity)]
-		public async Task ForDouble_WhenSubjectIsInfinity_ShouldFail(double subject)
+		[InlineData(double.PositiveInfinity, "+\u221e")]
+		[InlineData(double.NegativeInfinity, "-\u221e")]
+		public async Task ForDouble_WhenSubjectIsInfinity_ShouldFail(double subject, string format)
 		{
 			async Task Act() => await That(subject).Should().NotBeInfinite();
 
@@ -210,7 +210,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be infinite,
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              but found {format}
 				              at Expect.That(subject).Should().NotBeInfinite()
 				              """);
 		}
@@ -243,9 +243,9 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(float.PositiveInfinity)]
-		[InlineData(float.NegativeInfinity)]
-		public async Task ForFloat_WhenSubjectIsInfinity_ShouldFail(float subject)
+		[InlineData(float.PositiveInfinity, "+\u221e")]
+		[InlineData(float.NegativeInfinity, "-\u221e")]
+		public async Task ForFloat_WhenSubjectIsInfinity_ShouldFail(float subject, string format)
 		{
 			async Task Act()
 				=> await That(subject).Should().NotBeInfinite();
@@ -254,7 +254,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be infinite,
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              but found {format}
 				              at Expect.That(subject).Should().NotBeInfinite()
 				              """);
 		}
@@ -288,9 +288,10 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(double.PositiveInfinity)]
-		[InlineData(double.NegativeInfinity)]
-		public async Task ForNullableDouble_WhenSubjectIsInfinity_ShouldFail(double? subject)
+		[InlineData(double.PositiveInfinity, "+\u221e")]
+		[InlineData(double.NegativeInfinity, "-\u221e")]
+		public async Task ForNullableDouble_WhenSubjectIsInfinity_ShouldFail(double? subject,
+			string format)
 		{
 			async Task Act() => await That(subject).Should().NotBeInfinite();
 
@@ -298,7 +299,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be infinite,
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}
+				              but found {format}
 				              at Expect.That(subject).Should().NotBeInfinite()
 				              """);
 		}
@@ -333,9 +334,10 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(float.PositiveInfinity)]
-		[InlineData(float.NegativeInfinity)]
-		public async Task ForNullableFloat_WhenSubjectIsInfinity_ShouldFail(float? subject)
+		[InlineData(float.PositiveInfinity, "+\u221e")]
+		[InlineData(float.NegativeInfinity, "-\u221e")]
+		public async Task ForNullableFloat_WhenSubjectIsInfinity_ShouldFail(float? subject,
+			string format)
 		{
 			async Task Act()
 				=> await That(subject).Should().NotBeInfinite();
@@ -344,7 +346,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be infinite,
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}
+				              but found {format}
 				              at Expect.That(subject).Should().NotBeInfinite()
 				              """);
 		}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeNaNTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeNaNTests.cs
@@ -18,6 +18,23 @@ public sealed partial class NumberShould
 			await That(Act).Should().NotThrow();
 		}
 
+		[Theory]
+		[InlineData(double.PositiveInfinity, "+\u221e")]
+		[InlineData(double.NegativeInfinity, "-\u221e")]
+		public async Task ForDouble_WhenSubjectIsInfinity_ShouldFail(double subject, string format)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNaN();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be NaN,
+				              but found {format}
+				              at Expect.That(subject).Should().BeNaN()
+				              """);
+		}
+
 		[Fact]
 		public async Task ForDouble_WhenSubjectIsNaN_ShouldSucceed()
 		{
@@ -35,8 +52,6 @@ public sealed partial class NumberShould
 		[InlineData(double.MinValue)]
 		[InlineData(double.MaxValue)]
 		[InlineData(double.Epsilon)]
-		[InlineData(double.NegativeInfinity)]
-		[InlineData(double.PositiveInfinity)]
 		public async Task ForDouble_WhenSubjectIsNormalValue_ShouldFail(double subject)
 		{
 			async Task Act()
@@ -62,6 +77,23 @@ public sealed partial class NumberShould
 			await That(Act).Should().NotThrow();
 		}
 
+		[Theory]
+		[InlineData(float.PositiveInfinity, "+\u221e")]
+		[InlineData(float.NegativeInfinity, "-\u221e")]
+		public async Task ForFloat_WhenSubjectIsInfinity_ShouldFail(float subject, string format)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNaN();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be NaN,
+				              but found {format}
+				              at Expect.That(subject).Should().BeNaN()
+				              """);
+		}
+
 		[Fact]
 		public async Task ForFloat_WhenSubjectIsNaN_ShouldSucceed()
 		{
@@ -80,8 +112,6 @@ public sealed partial class NumberShould
 		[InlineData(float.MinValue)]
 		[InlineData(float.MaxValue)]
 		[InlineData(float.Epsilon)]
-		[InlineData(float.NegativeInfinity)]
-		[InlineData(float.PositiveInfinity)]
 		public async Task ForFloat_WhenSubjectIsNormalValue_ShouldFail(float subject)
 		{
 			async Task Act()
@@ -108,6 +138,25 @@ public sealed partial class NumberShould
 			await That(Act).Should().NotThrow();
 		}
 
+		[Theory]
+		[InlineData(double.PositiveInfinity, "+\u221e")]
+		[InlineData(double.NegativeInfinity, "-\u221e")]
+		[InlineData(null, "<null>")]
+		public async Task ForNullableDouble_WhenSubjectIsInfinityOrNull_ShouldFail(
+			double? subject, string format)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNaN();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be NaN,
+				              but found {format}
+				              at Expect.That(subject).Should().BeNaN()
+				              """);
+		}
+
 		[Fact]
 		public async Task ForNullableDouble_WhenSubjectIsNaN_ShouldSucceed()
 		{
@@ -125,10 +174,7 @@ public sealed partial class NumberShould
 		[InlineData(double.MinValue)]
 		[InlineData(double.MaxValue)]
 		[InlineData(double.Epsilon)]
-		[InlineData(double.NegativeInfinity)]
-		[InlineData(double.PositiveInfinity)]
-		[InlineData(null)]
-		public async Task ForNullableDouble_WhenSubjectIsNormalValueOrNull_ShouldFail(
+		public async Task ForNullableDouble_WhenSubjectIsNormalValue_ShouldFail(
 			double? subject)
 		{
 			async Task Act()
@@ -154,6 +200,24 @@ public sealed partial class NumberShould
 			await That(Act).Should().NotThrow();
 		}
 
+		[Theory]
+		[InlineData(float.PositiveInfinity, "+\u221e")]
+		[InlineData(float.NegativeInfinity, "-\u221e")]
+		public async Task ForNullableFloat_WhenSubjectIsInfinity_ShouldFail(float? subject,
+			string format)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNaN();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be NaN,
+				              but found {format}
+				              at Expect.That(subject).Should().BeNaN()
+				              """);
+		}
+
 		[Fact]
 		public async Task ForNullableFloat_WhenSubjectIsNaN_ShouldSucceed()
 		{
@@ -172,8 +236,6 @@ public sealed partial class NumberShould
 		[InlineData(float.MinValue)]
 		[InlineData(float.MaxValue)]
 		[InlineData(float.Epsilon)]
-		[InlineData(float.NegativeInfinity)]
-		[InlineData(float.PositiveInfinity)]
 		public async Task ForNullableFloat_WhenSubjectIsNormalValue_ShouldFail(float? subject)
 		{
 			async Task Act()

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeNegativeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeNegativeTests.cs
@@ -1,0 +1,697 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
+
+public sealed partial class NumberShould
+{
+	public sealed class BeNegativeTests
+	{
+		[Theory]
+		[InlineData(1.0D)]
+		[InlineData(0D)]
+		public async Task ForDecimal_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(decimal subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1.0D)]
+		public async Task ForDecimal_WhenValueIsLessThanZero_ShouldSucceed(decimal subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1.0)]
+		[InlineData(0)]
+		public async Task ForDouble_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(double subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1.0)]
+		public async Task ForDouble_WhenValueIsLessThanZero_ShouldSucceed(double subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForDouble_WhenValueIsNaN_ShouldFail()
+		{
+			double subject = double.NaN;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForDouble_WhenValueIsNegativeInfinity_ShouldSucceed()
+		{
+			double subject = double.NegativeInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForDouble_WhenValueIsPositiveInfinity_ShouldFail()
+		{
+			double subject = double.PositiveInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found +∞
+				             at Expect.That(subject).Should().BeNegative()
+				             """);
+		}
+
+		[Theory]
+		[InlineData(1.0F)]
+		[InlineData(0)]
+		public async Task ForFloat_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(float subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1.0F)]
+		public async Task ForFloat_WhenValueIsLessThanZero_ShouldSucceed(float subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForFloat_WhenValueIsNaN_ShouldFail()
+		{
+			float subject = float.NaN;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForFloat_WhenValueIsNegativeInfinity_ShouldSucceed()
+		{
+			float subject = float.NegativeInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForFloat_WhenValueIsPositiveInfinity_ShouldFail()
+		{
+			float subject = float.PositiveInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found +∞
+				             at Expect.That(subject).Should().BeNegative()
+				             """);
+		}
+
+		[Theory]
+		[InlineData(1)]
+		[InlineData(0)]
+		public async Task ForInt_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(int subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		public async Task ForInt_WhenValueIsLessThanZero_ShouldSucceed(int subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1)]
+		[InlineData(0)]
+		public async Task ForLong_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(long subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		public async Task ForLong_WhenValueIsLessThanZero_ShouldSucceed(long subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1.0)]
+		[InlineData(0.0)]
+		public async Task ForNullableDecimal_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(
+			double value)
+		{
+			decimal? subject = new(value);
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1.0)]
+		public async Task ForNullableDecimal_WhenValueIsLessThanZero_ShouldSucceed(
+			double value)
+		{
+			decimal? subject = new(value);
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForNullableDecimal_WhenValueIsNull_ShouldFail()
+		{
+			decimal? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found <null>
+				             at Expect.That(subject).Should().BeNegative()
+				             """);
+		}
+
+		[Theory]
+		[InlineData(1.0)]
+		[InlineData(0.0)]
+		public async Task ForNullableDouble_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(
+			double? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1.0)]
+		public async Task ForNullableDouble_WhenValueIsLessThanZero_ShouldSucceed(
+			double? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForNullableDouble_WhenValueIsNaN_ShouldFail()
+		{
+			double? subject = double.NaN;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForNullableDouble_WhenValueIsNegativeInfinity_ShouldSucceed()
+		{
+			double? subject = double.NegativeInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForNullableDouble_WhenValueIsNull_ShouldFail()
+		{
+			double? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found <null>
+				             at Expect.That(subject).Should().BeNegative()
+				             """);
+		}
+
+		[Fact]
+		public async Task ForNullableDouble_WhenValueIsPositiveInfinity_ShouldFail()
+		{
+			double? subject = double.PositiveInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found +∞
+				             at Expect.That(subject).Should().BeNegative()
+				             """);
+		}
+
+		[Theory]
+		[InlineData(1.0F)]
+		[InlineData(0.0F)]
+		public async Task ForNullableFloat_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(
+			float? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1.0F)]
+		public async Task ForNullableFloat_WhenValueIsLessThanZero_ShouldSucceed(float? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForNullableFloat_WhenValueIsNaN_ShouldFail()
+		{
+			float? subject = float.NaN;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForNullableFloat_WhenValueIsNegativeInfinity_ShouldSucceed()
+		{
+			float? subject = float.NegativeInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForNullableFloat_WhenValueIsNull_ShouldFail()
+		{
+			float? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found <null>
+				             at Expect.That(subject).Should().BeNegative()
+				             """);
+		}
+
+		[Fact]
+		public async Task ForNullableFloat_WhenValueIsPositiveInfinity_ShouldFail()
+		{
+			float? subject = float.PositiveInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found +∞
+				             at Expect.That(subject).Should().BeNegative()
+				             """);
+		}
+
+		[Theory]
+		[InlineData(1)]
+		[InlineData(0)]
+		public async Task ForNullableInt_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(
+			int? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		public async Task ForNullableInt_WhenValueIsLessThanZero_ShouldSucceed(int? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForNullableInt_WhenValueIsNull_ShouldFail()
+		{
+			int? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found <null>
+				             at Expect.That(subject).Should().BeNegative()
+				             """);
+		}
+
+		[Theory]
+		[InlineData(1L)]
+		[InlineData(0L)]
+		public async Task ForNullableLong_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(
+			long? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1L)]
+		public async Task ForNullableLong_WhenValueIsLessThanZero_ShouldSucceed(long? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForNullableLong_WhenValueIsNull_ShouldFail()
+		{
+			long? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found <null>
+				             at Expect.That(subject).Should().BeNegative()
+				             """);
+		}
+
+		[Theory]
+		[InlineData((sbyte)1)]
+		[InlineData((sbyte)0)]
+		public async Task ForNullableSbyte_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(
+			sbyte? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData((sbyte)-1)]
+		public async Task ForNullableSbyte_WhenValueIsLessThanZero_ShouldSucceed(sbyte? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForNullableSbyte_WhenValueIsNull_ShouldFail()
+		{
+			sbyte? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found <null>
+				             at Expect.That(subject).Should().BeNegative()
+				             """);
+		}
+
+		[Theory]
+		[InlineData((short)1)]
+		[InlineData((short)0)]
+		public async Task ForNullableShort_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(
+			short? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData((short)-1)]
+		public async Task ForNullableShort_WhenValueIsLessThanZero_ShouldSucceed(short? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForNullableShort_WhenValueIsNull_ShouldFail()
+		{
+			short? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found <null>
+				             at Expect.That(subject).Should().BeNegative()
+				             """);
+		}
+
+		[Theory]
+		[InlineData(1)]
+		[InlineData(0)]
+		public async Task ForSbyte_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(sbyte subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		public async Task ForSbyte_WhenValueIsLessThanZero_ShouldSucceed(sbyte subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1)]
+		[InlineData(0)]
+		public async Task ForShort_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(short subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {subject}
+				              at Expect.That(subject).Should().BeNegative()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		public async Task ForShort_WhenValueIsLessThanZero_ShouldSucceed(short subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BePositiveTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BePositiveTests.cs
@@ -1,0 +1,695 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
+
+public sealed partial class NumberShould
+{
+	public sealed class BePositiveTests
+	{
+		[Theory]
+		[InlineData(1.0D)]
+		public async Task ForDecimal_WhenValueIsGreaterThanZero_ShouldSucceed(decimal subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1.0D)]
+		[InlineData(0D)]
+		public async Task ForDecimal_WhenValueIsLessThanOrEqualToZero_ShouldFail(decimal subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1.0)]
+		public async Task ForDouble_WhenValueIsGreaterThanZero_ShouldSucceed(double subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1.0)]
+		[InlineData(0)]
+		public async Task ForDouble_WhenValueIsLessThanOrEqualToZero_ShouldFail(double subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForDouble_WhenValueIsNaN_ShouldFail()
+		{
+			double subject = double.NaN;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found NaN
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Fact]
+		public async Task ForDouble_WhenValueIsNegativeInfinity_ShouldFail()
+		{
+			double subject = double.NegativeInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found -∞
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Fact]
+		public async Task ForDouble_WhenValueIsPositiveInfinity_ShouldSucceed()
+		{
+			double subject = double.PositiveInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1.0F)]
+		public async Task ForFloat_WhenValueIsGreaterThanZero_ShouldSucceed(float subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1.0F)]
+		[InlineData(0)]
+		public async Task ForFloat_WhenValueIsLessThanOrEqualToZero_ShouldFail(float subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForFloat_WhenValueIsNaN_ShouldFail()
+		{
+			float subject = float.NaN;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found NaN
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Fact]
+		public async Task ForFloat_WhenValueIsNegativeInfinity_ShouldFail()
+		{
+			float subject = float.NegativeInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found -∞
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Fact]
+		public async Task ForFloat_WhenValueIsPositiveInfinity_ShouldSucceed()
+		{
+			float subject = float.PositiveInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1)]
+		public async Task ForInt_WhenValueIsGreaterThanZero_ShouldSucceed(int subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public async Task ForInt_WhenValueIsLessThanOrEqualToZero_ShouldFail(int subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1)]
+		public async Task ForLong_WhenValueIsGreaterThanZero_ShouldSucceed(long subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public async Task ForLong_WhenValueIsLessThanOrEqualToZero_ShouldFail(long subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1.0)]
+		public async Task ForNullableDecimal_WhenValueIsGreaterThanZero_ShouldSucceed(
+			double value)
+		{
+			decimal? subject = new(value);
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1.0)]
+		[InlineData(0.0)]
+		public async Task ForNullableDecimal_WhenValueIsLessThanOrEqualToZero_ShouldFail(
+			double value)
+		{
+			decimal? subject = new(value);
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForNullableDecimal_WhenValueIsNull_ShouldFail()
+		{
+			decimal? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found <null>
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Theory]
+		[InlineData(1.0)]
+		public async Task ForNullableDouble_WhenValueIsGreaterThanZero_ShouldSucceed(
+			double? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1.0)]
+		[InlineData(0.0)]
+		public async Task ForNullableDouble_WhenValueIsLessThanOrEqualToZero_ShouldFail(
+			double? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForNullableDouble_WhenValueIsNaN_ShouldFail()
+		{
+			double? subject = double.NaN;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found NaN
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Fact]
+		public async Task ForNullableDouble_WhenValueIsNegativeInfinity_ShouldFail()
+		{
+			double? subject = double.NegativeInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found -∞
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Fact]
+		public async Task ForNullableDouble_WhenValueIsNull_ShouldFail()
+		{
+			double? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found <null>
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Fact]
+		public async Task ForNullableDouble_WhenValueIsPositiveInfinity_ShouldSucceed()
+		{
+			double? subject = double.PositiveInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1.0F)]
+		public async Task ForNullableFloat_WhenValueIsGreaterThanZero_ShouldSucceed(float? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1.0F)]
+		[InlineData(0.0F)]
+		public async Task ForNullableFloat_WhenValueIsLessThanOrEqualToZero_ShouldFail(
+			float? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForNullableFloat_WhenValueIsNaN_ShouldFail()
+		{
+			float? subject = float.NaN;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found NaN
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Fact]
+		public async Task ForNullableFloat_WhenValueIsNegativeInfinity_ShouldFail()
+		{
+			float? subject = float.NegativeInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found -∞
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Fact]
+		public async Task ForNullableFloat_WhenValueIsNull_ShouldFail()
+		{
+			float? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found <null>
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Fact]
+		public async Task ForNullableFloat_WhenValueIsPositiveInfinity_ShouldSucceed()
+		{
+			float? subject = float.PositiveInfinity;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1)]
+		public async Task ForNullableInt_WhenValueIsGreaterThanZero_ShouldSucceed(int? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public async Task ForNullableInt_WhenValueIsLessThanOrEqualToZero_ShouldFail(int? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForNullableInt_WhenValueIsNull_ShouldFail()
+		{
+			int? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found <null>
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Theory]
+		[InlineData(1L)]
+		public async Task ForNullableLong_WhenValueIsGreaterThanZero_ShouldSucceed(long? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1L)]
+		[InlineData(0L)]
+		public async Task ForNullableLong_WhenValueIsLessThanOrEqualToZero_ShouldFail(long? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForNullableLong_WhenValueIsNull_ShouldFail()
+		{
+			long? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found <null>
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Theory]
+		[InlineData((sbyte)1)]
+		public async Task ForNullableSbyte_WhenValueIsGreaterThanZero_ShouldSucceed(sbyte? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((sbyte)-1)]
+		[InlineData((sbyte)0)]
+		public async Task ForNullableSbyte_WhenValueIsLessThanOrEqualToZero_ShouldFail(
+			sbyte? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForNullableSbyte_WhenValueIsNull_ShouldFail()
+		{
+			sbyte? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found <null>
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Theory]
+		[InlineData((short)1)]
+		public async Task ForNullableShort_WhenValueIsGreaterThanZero_ShouldSucceed(short? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((short)-1)]
+		[InlineData((short)0)]
+		public async Task ForNullableShort_WhenValueIsLessThanOrEqualToZero_ShouldFail(
+			short? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Fact]
+		public async Task ForNullableShort_WhenValueIsNull_ShouldFail()
+		{
+			short? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found <null>
+				             at Expect.That(subject).Should().BePositive()
+				             """);
+		}
+
+		[Theory]
+		[InlineData(1)]
+		public async Task ForSbyte_WhenValueIsGreaterThanZero_ShouldSucceed(sbyte subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public async Task ForSbyte_WhenValueIsLessThanOrEqualToZero_ShouldFail(sbyte subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1)]
+		public async Task ForShort_WhenValueIsGreaterThanZero_ShouldSucceed(short subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		public async Task ForShort_WhenValueIsLessThanOrEqualToZero_ShouldFail(short subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {subject}
+				              at Expect.That(subject).Should().BePositive()
+				              """);
+		}
+	}
+}


### PR DESCRIPTION
Add methods `BePositive` and `BeNegative` for signed numbers: int, long, sbyte, short, float, double, decimal