### PR TITLE
refactor: remove disable once CheckNamespace where it is no longer necessary

### DIFF
--- a/Source/Testably.Expectations/That/Booleans/ThatBoolShould.Be.cs
+++ b/Source/Testably.Expectations/That/Booleans/ThatBoolShould.Be.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatBoolShould

--- a/Source/Testably.Expectations/That/Booleans/ThatBoolShould.BeFalse.cs
+++ b/Source/Testably.Expectations/That/Booleans/ThatBoolShould.BeFalse.cs
@@ -1,7 +1,6 @@
 ﻿using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatBoolShould

--- a/Source/Testably.Expectations/That/Booleans/ThatBoolShould.BeTrue.cs
+++ b/Source/Testably.Expectations/That/Booleans/ThatBoolShould.BeTrue.cs
@@ -1,7 +1,6 @@
 ﻿using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatBoolShould

--- a/Source/Testably.Expectations/That/Booleans/ThatBoolShould.Imply.cs
+++ b/Source/Testably.Expectations/That/Booleans/ThatBoolShould.Imply.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatBoolShould

--- a/Source/Testably.Expectations/That/Booleans/ThatBoolShould.cs
+++ b/Source/Testably.Expectations/That/Booleans/ThatBoolShould.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Booleans/ThatNullableBoolShould.Be.cs
+++ b/Source/Testably.Expectations/That/Booleans/ThatNullableBoolShould.Be.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableBoolShould

--- a/Source/Testably.Expectations/That/Booleans/ThatNullableBoolShould.BeFalse.cs
+++ b/Source/Testably.Expectations/That/Booleans/ThatNullableBoolShould.BeFalse.cs
@@ -1,7 +1,6 @@
 ﻿using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableBoolShould

--- a/Source/Testably.Expectations/That/Booleans/ThatNullableBoolShould.BeNull.cs
+++ b/Source/Testably.Expectations/That/Booleans/ThatNullableBoolShould.BeNull.cs
@@ -1,7 +1,6 @@
 ﻿using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableBoolShould

--- a/Source/Testably.Expectations/That/Booleans/ThatNullableBoolShould.BeTrue.cs
+++ b/Source/Testably.Expectations/That/Booleans/ThatNullableBoolShould.BeTrue.cs
@@ -1,7 +1,6 @@
 ﻿using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableBoolShould

--- a/Source/Testably.Expectations/That/Booleans/ThatNullableBoolShould.cs
+++ b/Source/Testably.Expectations/That/Booleans/ThatNullableBoolShould.cs
@@ -3,7 +3,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.Be.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatDateOnlyShould

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Chronology/ThatDateTimeOffsetShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateTimeOffsetShould.Be.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatDateTimeOffsetShould

--- a/Source/Testably.Expectations/That/Chronology/ThatDateTimeOffsetShould.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateTimeOffsetShould.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.Be.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatDateTimeShould

--- a/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeAfter.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatDateTimeShould

--- a/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeBefore.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatDateTimeShould

--- a/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeOnOrAfter.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatDateTimeShould

--- a/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeOnOrBefore.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatDateTimeShould

--- a/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.cs
@@ -3,7 +3,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Options;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.Be.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableDateTimeShould

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeAfter.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableDateTimeShould

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeBefore.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableDateTimeShould

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeOnOrAfter.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableDateTimeShould

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeOnOrBefore.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableDateTimeShould

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.cs
@@ -3,7 +3,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Options;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.Be.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatTimeOnlyShould

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeSpanShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeSpanShould.Be.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatTimeSpanShould

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeSpanShould.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeSpanShould.cs
@@ -3,7 +3,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Collections/BetweenResult.cs
+++ b/Source/Testably.Expectations/That/Collections/BetweenResult.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.All.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.All.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.AtLeast.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.AtLeast.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.AtMost.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.AtMost.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.Between.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.Between.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.None.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.None.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Collections/CollectionQuantifier.cs
+++ b/Source/Testably.Expectations/That/Collections/CollectionQuantifier.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Testably.Expectations.Core.EvaluationContext;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Collections/ICollectionEvaluator.cs
+++ b/Source/Testably.Expectations/That/Collections/ICollectionEvaluator.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.Be.cs
+++ b/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.Be.cs
@@ -6,7 +6,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.EvaluationContext;
 using Testably.Expectations.Results;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.cs
+++ b/Source/Testably.Expectations/That/Collections/QuantifiedCollectionResult.cs
@@ -1,5 +1,4 @@
 ﻿using Testably.Expectations.Core;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.All.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.All.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatAsyncEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.AtLeast.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.AtLeast.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatAsyncEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.AtMost.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.AtMost.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatAsyncEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.BeEmpty.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.BeEmpty.cs
@@ -8,7 +8,6 @@ using Testably.Expectations.Core.EvaluationContext;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatAsyncEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.Between.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.Between.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatAsyncEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.None.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.None.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatAsyncEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatAsyncEnumerableShould.cs
@@ -1,7 +1,6 @@
 ﻿#if NET6_0_OR_GREATER
 using System.Collections.Generic;
 using Testably.Expectations.Core;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.All.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.All.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtLeast.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtLeast.cs
@@ -2,7 +2,6 @@
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtMost.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.AtMost.cs
@@ -2,7 +2,6 @@
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.BeEmpty.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.BeEmpty.cs
@@ -6,7 +6,6 @@ using Testably.Expectations.Core.EvaluationContext;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.Between.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.Between.cs
@@ -2,7 +2,6 @@
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.Contain.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.Contain.cs
@@ -7,7 +7,6 @@ using Testably.Expectations.Core.EvaluationContext;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.None.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.None.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatEnumerableShould

--- a/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatEnumerableShould.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Testably.Expectations.Core;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Be.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Be.cs
@@ -9,7 +9,6 @@ using Testably.Expectations.Core.EvaluationContext;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatQuantifiedCollectionResultShouldSync

--- a/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.BeEquivalentTo.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.BeEquivalentTo.cs
@@ -11,7 +11,6 @@ using Testably.Expectations.Core.EvaluationContext;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatQuantifiedCollectionResultShouldSync

--- a/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Satisfy.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatQuantifiedCollectionResultShould.Satisfy.cs
@@ -9,7 +9,6 @@ using Testably.Expectations.Core.EvaluationContext;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatQuantifiedCollectionResultShouldSync

--- a/Source/Testably.Expectations/That/Collections/ThatStringCollectionShould.Contain.cs
+++ b/Source/Testably.Expectations/That/Collections/ThatStringCollectionShould.Contain.cs
@@ -6,7 +6,6 @@ using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStringCollectionShould

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegate.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegate.cs
@@ -1,6 +1,5 @@
 ﻿using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.ExecuteWithin.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.ExecuteWithin.cs
@@ -7,7 +7,6 @@ using Testably.Expectations.Core.Sources;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatDelegateShould

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.NotThrow.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.NotThrow.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Core.Helpers;
 using Testably.Expectations.Core.Sources;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatDelegateShould

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.Throw.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.Throw.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatDelegateShould

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.ThrowExactly.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.ThrowExactly.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.Helpers;
 using Testably.Expectations.Core.Sources;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatDelegateShould

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.ThrowException.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.ThrowException.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Testably.Expectations.Core;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatDelegateShould

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.Helpers;
 using Testably.Expectations.Core.Sources;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.OnlyIf.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.OnlyIf.cs
@@ -1,6 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithInner.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithInner.cs
@@ -2,7 +2,6 @@
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithInnerException.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithInnerException.cs
@@ -2,7 +2,6 @@
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithMessage.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithMessage.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Helpers;
 using Testably.Expectations.Results;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Enums/ThatEnumShould.Be.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatEnumShould.Be.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatEnumShould

--- a/Source/Testably.Expectations/That/Enums/ThatEnumShould.BeDefined.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatEnumShould.BeDefined.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatEnumShould

--- a/Source/Testably.Expectations/That/Enums/ThatEnumShould.HaveFlag.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatEnumShould.HaveFlag.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatEnumShould

--- a/Source/Testably.Expectations/That/Enums/ThatEnumShould.HaveValue.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatEnumShould.HaveValue.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatEnumShould

--- a/Source/Testably.Expectations/That/Enums/ThatEnumShould.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatEnumShould.cs
@@ -3,7 +3,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.Be.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.Be.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableEnumShould

--- a/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.BeDefined.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.BeDefined.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableEnumShould

--- a/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.BeNull.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.BeNull.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableEnumShould

--- a/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.HaveFlag.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.HaveFlag.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableEnumShould

--- a/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.HaveValue.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.HaveValue.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableEnumShould

--- a/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.cs
+++ b/Source/Testably.Expectations/That/Enums/ThatNullableEnumShould.cs
@@ -3,7 +3,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveInner.cs
+++ b/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveInner.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveInnerException.cs
+++ b/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveInnerException.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveMessage.cs
+++ b/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveMessage.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveParamName.cs
+++ b/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveParamName.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 using Testably.Expectations;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveRecursiveInnerExceptions.cs
+++ b/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveRecursiveInnerExceptions.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Helpers;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.cs
+++ b/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.cs
@@ -6,7 +6,6 @@ using Testably.Expectations.Core.Helpers;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Guids/ThatGuidShould.Be.cs
+++ b/Source/Testably.Expectations/That/Guids/ThatGuidShould.Be.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatGuidShould

--- a/Source/Testably.Expectations/That/Guids/ThatGuidShould.BeEmpty.cs
+++ b/Source/Testably.Expectations/That/Guids/ThatGuidShould.BeEmpty.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatGuidShould

--- a/Source/Testably.Expectations/That/Guids/ThatGuidShould.cs
+++ b/Source/Testably.Expectations/That/Guids/ThatGuidShould.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Guids/ThatNullableGuidShould.Be.cs
+++ b/Source/Testably.Expectations/That/Guids/ThatNullableGuidShould.Be.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableGuidShould

--- a/Source/Testably.Expectations/That/Guids/ThatNullableGuidShould.BeEmpty.cs
+++ b/Source/Testably.Expectations/That/Guids/ThatNullableGuidShould.BeEmpty.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableGuidShould

--- a/Source/Testably.Expectations/That/Guids/ThatNullableGuidShould.BeNull.cs
+++ b/Source/Testably.Expectations/That/Guids/ThatNullableGuidShould.BeNull.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNullableGuidShould

--- a/Source/Testably.Expectations/That/Guids/ThatNullableGuidShould.cs
+++ b/Source/Testably.Expectations/That/Guids/ThatNullableGuidShould.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.BeRedirection.cs
+++ b/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.BeRedirection.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatHttpResponseMessageShould

--- a/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.BeSuccess.cs
+++ b/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.BeSuccess.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatHttpResponseMessageShould

--- a/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveClientError.cs
+++ b/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveClientError.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatHttpResponseMessageShould

--- a/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveContent.cs
+++ b/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveContent.cs
@@ -8,7 +8,6 @@ using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatHttpResponseMessageShould

--- a/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveError.cs
+++ b/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveError.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatHttpResponseMessageShould

--- a/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveServerError.cs
+++ b/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveServerError.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatHttpResponseMessageShould

--- a/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveStatusCode.cs
+++ b/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.HaveStatusCode.cs
@@ -10,7 +10,6 @@ using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatHttpResponseMessageShould

--- a/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.cs
+++ b/Source/Testably.Expectations/That/Http/ThatHttpResponseMessageShould.cs
@@ -12,7 +12,6 @@ using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.Helpers;
 using Testably.Expectations.Formatting;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.Be.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.Be.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNumberShould

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeFinite.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeFinite.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNumberShould

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeGreaterThan.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeGreaterThan.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNumberShould

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeGreaterThanOrEqualTo.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeGreaterThanOrEqualTo.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNumberShould

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeInfinite.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeInfinite.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNumberShould

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeLessThan.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeLessThan.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNumberShould

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeLessThanOrEqualTo.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeLessThanOrEqualTo.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNumberShould

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeNaN.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeNaN.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNumberShould

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeNegative.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BeNegative.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNumberShould

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BePositive.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.BePositive.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatNumberShould

--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Objects/ThatObjectShould.Be.cs
+++ b/Source/Testably.Expectations/That/Objects/ThatObjectShould.Be.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatObjectShould

--- a/Source/Testably.Expectations/That/Objects/ThatObjectShould.BeNull.cs
+++ b/Source/Testably.Expectations/That/Objects/ThatObjectShould.BeNull.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatObjectShould

--- a/Source/Testably.Expectations/That/Objects/ThatObjectShould.For.cs
+++ b/Source/Testably.Expectations/That/Objects/ThatObjectShould.For.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatObjectShould

--- a/Source/Testably.Expectations/That/Objects/ThatObjectShould.cs
+++ b/Source/Testably.Expectations/That/Objects/ThatObjectShould.cs
@@ -2,7 +2,6 @@
 using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/Streams/ThatBufferedStreamShould.HaveBufferSize.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatBufferedStreamShould.HaveBufferSize.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatBufferedStreamShould

--- a/Source/Testably.Expectations/That/Streams/ThatBufferedStreamShould.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatBufferedStreamShould.cs
@@ -3,7 +3,6 @@ using System;
 using System.IO;
 using Testably.Expectations.Core.Constraints;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Streams/ThatStreamShould.BeReadOnly.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatStreamShould.BeReadOnly.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStreamShould

--- a/Source/Testably.Expectations/That/Streams/ThatStreamShould.BeReadable.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatStreamShould.BeReadable.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStreamShould

--- a/Source/Testably.Expectations/That/Streams/ThatStreamShould.BeSeekable.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatStreamShould.BeSeekable.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStreamShould

--- a/Source/Testably.Expectations/That/Streams/ThatStreamShould.BeWritable.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatStreamShould.BeWritable.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStreamShould

--- a/Source/Testably.Expectations/That/Streams/ThatStreamShould.BeWriteOnly.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatStreamShould.BeWriteOnly.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStreamShould

--- a/Source/Testably.Expectations/That/Streams/ThatStreamShould.HaveLength.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatStreamShould.HaveLength.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStreamShould

--- a/Source/Testably.Expectations/That/Streams/ThatStreamShould.HavePosition.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatStreamShould.HavePosition.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStreamShould

--- a/Source/Testably.Expectations/That/Streams/ThatStreamShould.cs
+++ b/Source/Testably.Expectations/That/Streams/ThatStreamShould.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 /// <summary>

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.Be.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.Be.cs
@@ -4,7 +4,6 @@ using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStringShould

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.BeNull.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.BeNull.cs
@@ -3,7 +3,6 @@ using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStringShould

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.Contain.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.Contain.cs
@@ -7,7 +7,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStringShould

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.EndWith.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.EndWith.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStringShould

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.StartWith.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.StartWith.cs
@@ -5,7 +5,6 @@ using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatStringShould

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.cs
@@ -1,6 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 

--- a/Source/Testably.Expectations/That/ThatGenericShould.BeSameAs.cs
+++ b/Source/Testably.Expectations/That/ThatGenericShould.BeSameAs.cs
@@ -3,7 +3,6 @@ using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Results;
 
-// ReSharper disable once CheckNamespace
 namespace Testably.Expectations;
 
 public static partial class ThatGenericShould

--- a/Source/Testably.Expectations/That/ThatGenericShould.cs
+++ b/Source/Testably.Expectations/That/ThatGenericShould.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Testably.Expectations.Core.Constraints;
-// ReSharper disable once CheckNamespace
 
 namespace Testably.Expectations;
 


### PR DESCRIPTION
Remove `// ReSharper disable once CheckNamespace` where it is no longer required