### PR TITLE
refactor: add missing tests for `Be` on numbers

### DIFF
--- a/Source/Testably.Expectations/That/Numbers/ThatNumberShould.Be.cs
+++ b/Source/Testably.Expectations/That/Numbers/ThatNumberShould.Be.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
@@ -17,7 +18,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<byte, IThat<byte>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<byte>(
 					expected,
@@ -38,7 +39,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<sbyte>(
 					expected,
@@ -59,7 +60,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<short, IThat<short>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<short>(
 					expected,
@@ -80,7 +81,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<ushort>(
 					expected,
@@ -101,7 +102,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<int, IThat<int>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<int>(
 					expected,
@@ -143,7 +144,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<long, IThat<long>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<long>(
 					expected,
@@ -185,7 +186,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<float, IThat<float>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<float>(
 					expected,
@@ -206,7 +207,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<double, IThat<double>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<double>(
 					expected,
@@ -227,7 +228,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<decimal>(
 					expected,
@@ -248,7 +249,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<byte>(
 					expected,
@@ -269,7 +270,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<sbyte>(
 					expected,
@@ -290,7 +291,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<short>(
 					expected,
@@ -311,7 +312,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<ushort>(
 					expected,
@@ -332,7 +333,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<int>(
 					expected,
@@ -374,7 +375,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<long>(
 					expected,
@@ -416,7 +417,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<float>(
 					expected,
@@ -437,7 +438,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<double>(
 					expected,
@@ -458,7 +459,7 @@ public static partial class ThatNumberShould
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<decimal>(
 					expected,
@@ -480,7 +481,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<byte, IThat<byte>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<byte>(
 					unexpected,
@@ -502,7 +503,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<sbyte>(
 					unexpected,
@@ -524,7 +525,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<short, IThat<short>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<short>(
 					unexpected,
@@ -546,7 +547,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<ushort>(
 					unexpected,
@@ -568,7 +569,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<int, IThat<int>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<int>(
 					unexpected,
@@ -612,7 +613,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<long, IThat<long>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<long>(
 					unexpected,
@@ -656,7 +657,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<float, IThat<float>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<float>(
 					unexpected,
@@ -678,7 +679,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<double, IThat<double>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<double>(
 					unexpected,
@@ -700,7 +701,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint<decimal>(
 					unexpected,
@@ -722,7 +723,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<byte>(
 					unexpected,
@@ -744,7 +745,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<sbyte>(
 					unexpected,
@@ -766,7 +767,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<short>(
 					unexpected,
@@ -788,7 +789,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<ushort>(
 					unexpected,
@@ -810,7 +811,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<int>(
 					unexpected,
@@ -854,7 +855,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<long>(
 					unexpected,
@@ -898,7 +899,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<float>(
 					unexpected,
@@ -920,7 +921,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => a.Equals(e) || (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<double>(
 					unexpected,
@@ -942,7 +943,7 @@ public static partial class ThatNumberShould
 		string doNotPopulateThisValue = "")
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(source.ExpectationBuilder
 				.AddConstraint(new NullableGenericConstraint<decimal>(
 					unexpected,

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.Be.WithinTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.Be.WithinTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
+﻿using System.Globalization;
+
+namespace Testably.Expectations.Tests.ThatTests.Numbers;
 
 public sealed partial class NumberShould
 {
@@ -6,41 +8,44 @@ public sealed partial class NumberShould
 	{
 		public sealed class WithinTests
 		{
-			[Fact]
-			public async Task ForByte_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((byte)5, (byte)6)]
+			[InlineData((byte)5, (byte)4)]
+			public async Task ForByte_WhenInsideTolerance_ShouldSucceed(
+				byte subject, byte expected)
 			{
-				byte subject = 12;
-				byte expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForByte_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((byte)5, (byte)7)]
+			[InlineData((byte)5, (byte)3)]
+			public async Task ForByte_WhenOutsideTolerance_ShouldFail(
+				byte subject, byte expected)
 			{
-				byte subject = 12;
-				byte expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForDecimal_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(12.5, 12.6)]
+			[InlineData(12.5, 12.4)]
+			public async Task ForDecimal_WhenInsideTolerance_ShouldSucceed(
+				double subjectValue, double expectedValue)
 			{
-				decimal subject = new(12.2);
-				decimal expected = new(12.1);
+				decimal subject = new(subjectValue);
+				decimal expected = new(expectedValue);
 
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(new decimal(0.1));
@@ -48,31 +53,33 @@ public sealed partial class NumberShould
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForDecimal_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(12.5, 12.7)]
+			[InlineData(12.5, 12.3)]
+			public async Task ForDecimal_WhenOutsideTolerance_ShouldFail(
+				double subjectValue, double expectedValue)
 			{
-				decimal subject = new(12.3);
-				decimal expected = new(12.1);
+				decimal subject = new(subjectValue);
+				decimal expected = new(expectedValue);
 
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(new decimal(0.1));
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 12.1 ± 0.1,
-					             but found 12.3
-					             at Expect.That(subject).Should().Be(expected).Within(new decimal(0.1))
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              but found 12.5
+					              at Expect.That(subject).Should().Be(expected).Within(new decimal(0.1))
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForDecimal_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForDecimal_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					decimal subject, decimal expected)
 			{
-				decimal subject = new(12.2);
-				decimal expected = new(12.1);
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(new decimal(-0.1));
 
@@ -81,43 +88,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForDouble_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(12.5, 12.6)]
+			[InlineData(12.5, 12.4)]
+			public async Task ForDouble_WhenInsideTolerance_ShouldSucceed(
+				double subject, double expected)
 			{
-				double subject = 12.2;
-				double expected = 12.1;
-
 				async Task Act()
-					=> await That(subject).Should().Be(expected).Within(0.1);
+					=> await That(subject).Should().Be(expected).Within(0.11);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForDouble_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(12.5, 12.7)]
+			[InlineData(12.5, 12.3)]
+			public async Task ForDouble_WhenOutsideTolerance_ShouldFail(
+				double subject, double expected)
 			{
-				double subject = 12.3;
-				double expected = 12.1;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(0.1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 12.1 ± 0.1,
-					             but found 12.3
-					             at Expect.That(subject).Should().Be(expected).Within(0.1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              but found 12.5
+					              at Expect.That(subject).Should().Be(expected).Within(0.1)
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForDouble_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForDouble_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					double subject, double expected)
 			{
-				double subject = 12.2;
-				double expected = 12.1;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(-0.1);
 
@@ -126,43 +132,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForFloat_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(12.5F, 12.6F)]
+			[InlineData(12.5F, 12.4F)]
+			public async Task ForFloat_WhenInsideTolerance_ShouldSucceed(
+				float subject, float expected)
 			{
-				float subject = 12.2F;
-				float expected = 12.1F;
-
 				async Task Act()
-					=> await That(subject).Should().Be(expected).Within(0.1F);
+					=> await That(subject).Should().Be(expected).Within(0.11F);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForFloat_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(12.5F, 12.7F)]
+			[InlineData(12.5F, 12.3F)]
+			public async Task ForFloat_WhenOutsideTolerance_ShouldFail(
+				float subject, float expected)
 			{
-				float subject = 12.3F;
-				float expected = 12.1F;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(0.1F);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 12.1 ± 0.1,
-					             but found 12.3
-					             at Expect.That(subject).Should().Be(expected).Within(0.1F)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              but found 12.5
+					              at Expect.That(subject).Should().Be(expected).Within(0.1F)
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForFloat_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForFloat_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					float subject, float expected)
 			{
-				float subject = 12.2F;
-				float expected = 12.1F;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(-0.1F);
 
@@ -171,43 +176,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForInt_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForInt_WhenInsideTolerance_ShouldSucceed(
+				int subject, int expected)
 			{
-				int subject = 12;
-				int expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForInt_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForInt_WhenOutsideTolerance_ShouldFail(
+				int subject, int expected)
 			{
-				int subject = 12;
-				int expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForInt_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForInt_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					int subject, int expected)
 			{
-				int subject = 12;
-				int expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(-1);
 
@@ -216,43 +220,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForLong_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5L, 6L)]
+			[InlineData(5L, 4L)]
+			public async Task ForLong_WhenInsideTolerance_ShouldSucceed(
+				long subject, long expected)
 			{
-				long subject = 12;
-				long expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForLong_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5L, 7L)]
+			[InlineData(5L, 3L)]
+			public async Task ForLong_WhenOutsideTolerance_ShouldFail(
+				long subject, long expected)
 			{
-				long subject = 12;
-				long expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForLong_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForLong_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					long subject, long expected)
 			{
-				long subject = 12;
-				long expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(-1);
 
@@ -261,41 +264,44 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableByte_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((byte)5, (byte)6)]
+			[InlineData((byte)5, (byte)4)]
+			public async Task ForNullableByte_WhenInsideTolerance_ShouldSucceed(
+				byte? subject, byte? expected)
 			{
-				byte? subject = 12;
-				byte? expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableByte_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((byte)5, (byte)7)]
+			[InlineData((byte)5, (byte)3)]
+			public async Task ForNullableByte_WhenOutsideTolerance_ShouldFail(
+				byte? subject, byte? expected)
 			{
-				byte? subject = 12;
-				byte? expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableDecimal_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(12.5, 12.6)]
+			[InlineData(12.5, 12.4)]
+			public async Task ForNullableDecimal_WhenInsideTolerance_ShouldSucceed(
+				double subjectValue, double expectedValue)
 			{
-				decimal? subject = new(12.2);
-				decimal? expected = new(12.1);
+				decimal? subject = new(subjectValue);
+				decimal? expected = new(expectedValue);
 
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(new decimal(0.1));
@@ -303,31 +309,33 @@ public sealed partial class NumberShould
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableDecimal_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(12.5, 12.7)]
+			[InlineData(12.5, 12.3)]
+			public async Task ForNullableDecimal_WhenOutsideTolerance_ShouldFail(
+				double subjectValue, double expectedValue)
 			{
-				decimal? subject = new(12.3);
-				decimal? expected = new(12.1);
+				decimal? subject = new(subjectValue);
+				decimal expected = new(expectedValue);
 
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(new decimal(0.1));
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 12.1 ± 0.1,
-					             but found 12.3
-					             at Expect.That(subject).Should().Be(expected).Within(new decimal(0.1))
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              but found 12.5
+					              at Expect.That(subject).Should().Be(expected).Within(new decimal(0.1))
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableDecimal_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableDecimal_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					decimal? subject, decimal? expected)
 			{
-				decimal? subject = new(12.2);
-				decimal? expected = new(12.1);
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(new decimal(-0.1));
 
@@ -336,43 +344,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableDouble_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(12.5, 12.6)]
+			[InlineData(12.5, 12.4)]
+			public async Task ForNullableDouble_WhenInsideTolerance_ShouldSucceed(
+				double? subject, double? expected)
 			{
-				double? subject = 12.2;
-				double? expected = 12.1;
-
 				async Task Act()
-					=> await That(subject).Should().Be(expected).Within(0.1);
+					=> await That(subject).Should().Be(expected).Within(0.11);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableDouble_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(12.5, 12.7)]
+			[InlineData(12.5, 12.3)]
+			public async Task ForNullableDouble_WhenOutsideTolerance_ShouldFail(
+				double? subject, double? expected)
 			{
-				double? subject = 12.3;
-				double? expected = 12.1;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(0.1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 12.1 ± 0.1,
-					             but found 12.3
-					             at Expect.That(subject).Should().Be(expected).Within(0.1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected?.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              but found 12.5
+					              at Expect.That(subject).Should().Be(expected).Within(0.1)
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableDouble_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableDouble_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					double? subject, double? expected)
 			{
-				double? subject = 12.2;
-				double? expected = 12.1;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(-0.1);
 
@@ -381,43 +388,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableFloat_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(12.5F, 12.6F)]
+			[InlineData(12.5F, 12.4F)]
+			public async Task ForNullableFloat_WhenInsideTolerance_ShouldSucceed(
+				float? subject, float? expected)
 			{
-				float? subject = 12.2F;
-				float? expected = 12.1F;
-
 				async Task Act()
-					=> await That(subject).Should().Be(expected).Within(0.1F);
+					=> await That(subject).Should().Be(expected).Within(0.11F);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableFloat_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(12.5F, 12.7F)]
+			[InlineData(12.5F, 12.3F)]
+			public async Task ForNullableFloat_WhenOutsideTolerance_ShouldFail(
+				float? subject, float? expected)
 			{
-				float? subject = 12.3F;
-				float? expected = 12.1F;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(0.1F);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 12.1 ± 0.1,
-					             but found 12.3
-					             at Expect.That(subject).Should().Be(expected).Within(0.1F)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected?.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              but found 12.5
+					              at Expect.That(subject).Should().Be(expected).Within(0.1F)
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableFloat_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableFloat_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					float? subject, float? expected)
 			{
-				float? subject = 12.2F;
-				float? expected = 12.1F;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(-0.1F);
 
@@ -426,43 +432,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableInt_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForNullableInt_WhenInsideTolerance_ShouldSucceed(
+				int? subject, int? expected)
 			{
-				int? subject = 12;
-				int? expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableInt_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForNullableInt_WhenOutsideTolerance_ShouldFail(
+				int? subject, int? expected)
 			{
-				int? subject = 12;
-				int? expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableInt_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableInt_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					int? subject, int? expected)
 			{
-				int? subject = 12;
-				int? expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(-1);
 
@@ -471,43 +476,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableLong_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((long)5, (long)6)]
+			[InlineData((long)5, (long)4)]
+			public async Task ForNullableLong_WhenInsideTolerance_ShouldSucceed(
+				long? subject, long? expected)
 			{
-				long? subject = 12;
-				long? expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableLong_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((long)5, (long)7)]
+			[InlineData((long)5, (long)3)]
+			public async Task ForNullableLong_WhenOutsideTolerance_ShouldFail(
+				long? subject, long? expected)
 			{
-				long? subject = 12;
-				long? expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableLong_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableLong_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					long? subject, long? expected)
 			{
-				long? subject = 12;
-				long? expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(-1);
 
@@ -516,43 +520,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableSbyte_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((sbyte)5, (sbyte)6)]
+			[InlineData((sbyte)5, (sbyte)4)]
+			public async Task ForNullableSbyte_WhenInsideTolerance_ShouldSucceed(
+				sbyte? subject, sbyte? expected)
 			{
-				sbyte? subject = 12;
-				sbyte? expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableSbyte_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((sbyte)5, (sbyte)7)]
+			[InlineData((sbyte)5, (sbyte)3)]
+			public async Task ForNullableSbyte_WhenOutsideTolerance_ShouldFail(
+				sbyte? subject, sbyte? expected)
 			{
-				sbyte? subject = 12;
-				sbyte? expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableSbyte_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableSbyte_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					sbyte? subject, sbyte? expected)
 			{
-				sbyte? subject = 12;
-				sbyte? expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(-1);
 
@@ -561,43 +564,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableShort_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((short)5, (short)6)]
+			[InlineData((short)5, (short)4)]
+			public async Task ForNullableShort_WhenInsideTolerance_ShouldSucceed(
+				short? subject, short? expected)
 			{
-				short? subject = 12;
-				short? expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableShort_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((short)5, (short)7)]
+			[InlineData((short)5, (short)3)]
+			public async Task ForNullableShort_WhenOutsideTolerance_ShouldFail(
+				short? subject, short? expected)
 			{
-				short? subject = 12;
-				short? expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableShort_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableShort_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					short? subject, short? expected)
 			{
-				short? subject = 12;
-				short? expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(-1);
 
@@ -606,133 +608,132 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableUint_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((uint)5, (uint)6)]
+			[InlineData((uint)5, (uint)4)]
+			public async Task ForNullableUint_WhenInsideTolerance_ShouldSucceed(
+				uint? subject, uint? expected)
 			{
-				uint? subject = 12;
-				uint? expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableUint_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((uint)5, (uint)7)]
+			[InlineData((uint)5, (uint)3)]
+			public async Task ForNullableUint_WhenOutsideTolerance_ShouldFail(
+				uint? subject, uint? expected)
 			{
-				uint? subject = 12;
-				uint? expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableUlong_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((ulong)5, (ulong)6)]
+			[InlineData((ulong)5, (ulong)4)]
+			public async Task ForNullableUlong_WhenInsideTolerance_ShouldSucceed(
+				ulong? subject, ulong? expected)
 			{
-				ulong? subject = 12;
-				ulong? expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableUlong_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((ulong)5, (ulong)7)]
+			[InlineData((ulong)5, (ulong)3)]
+			public async Task ForNullableUlong_WhenOutsideTolerance_ShouldFail(
+				ulong? subject, ulong? expected)
 			{
-				ulong? subject = 12;
-				ulong? expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableUshort_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((ushort)5, (ushort)6)]
+			[InlineData((ushort)5, (ushort)4)]
+			public async Task ForNullableUshort_WhenInsideTolerance_ShouldSucceed(
+				ushort? subject, ushort? expected)
 			{
-				ushort? subject = 12;
-				ushort? expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableUshort_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((ushort)5, (ushort)7)]
+			[InlineData((ushort)5, (ushort)3)]
+			public async Task ForNullableUshort_WhenOutsideTolerance_ShouldFail(
+				ushort? subject, ushort? expected)
 			{
-				ushort? subject = 12;
-				ushort? expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForSbyte_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForSbyte_WhenInsideTolerance_ShouldSucceed(
+				sbyte subject, sbyte expected)
 			{
-				sbyte subject = 12;
-				sbyte expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForSbyte_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForSbyte_WhenOutsideTolerance_ShouldFail(
+				sbyte subject, sbyte expected)
 			{
-				sbyte subject = 12;
-				sbyte expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForSbyte_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForSbyte_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					sbyte subject, sbyte expected)
 			{
-				sbyte subject = 12;
-				sbyte expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(-1);
 
@@ -741,43 +742,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForShort_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForShort_WhenInsideTolerance_ShouldSucceed(
+				short subject, short expected)
 			{
-				short subject = 12;
-				short expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForShort_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForShort_WhenOutsideTolerance_ShouldFail(
+				short subject, short expected)
 			{
-				short subject = 12;
-				short expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForShort_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForShort_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					short subject, short expected)
 			{
-				short subject = 12;
-				short expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(-1);
 
@@ -786,155 +786,161 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForUint_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForUint_WhenInsideTolerance_ShouldSucceed(
+				uint subject, uint expected)
 			{
-				uint subject = 12;
-				uint expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForUint_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForUint_WhenOutsideTolerance_ShouldFail(
+				uint subject, uint expected)
 			{
-				uint subject = 12;
-				uint expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForUlong_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForUlong_WhenInsideTolerance_ShouldSucceed(
+				ulong subject, ulong expected)
 			{
-				ulong subject = 12;
-				ulong expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForUlong_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForUlong_WhenOutsideTolerance_ShouldFail(
+				ulong subject, ulong expected)
 			{
-				ulong subject = 12;
-				ulong expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForUshort_WhenInsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForUshort_WhenInsideTolerance_ShouldSucceed(
+				ushort subject, ushort expected)
 			{
-				ushort subject = 12;
-				ushort expected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForUshort_WhenOutsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForUshort_WhenOutsideTolerance_ShouldFail(
+				ushort subject, ushort expected)
 			{
-				ushort subject = 12;
-				ushort expected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().Be(expected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             be 10 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().Be(expected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              be {expected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().Be(expected).Within(1)
+					              """);
 			}
 		}
 	}
-
+	
 	public sealed class NotBe
 	{
 		public sealed class WithinTests
 		{
-			[Fact]
-			public async Task ForByte_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((byte)5, (byte)6)]
+			[InlineData((byte)5, (byte)4)]
+			public async Task ForByte_WhenInsideTolerance_ShouldFail(
+				byte subject, byte unexpected)
 			{
-				byte subject = 12;
-				byte unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForByte_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((byte)5, (byte)7)]
+			[InlineData((byte)5, (byte)3)]
+			public async Task ForByte_WhenOutsideTolerance_ShouldSucceed(
+				byte subject, byte unexpected)
 			{
-				byte subject = 12;
-				byte unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForDecimal_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(12.5, 12.6)]
+			[InlineData(12.5, 12.4)]
+			public async Task ForDecimal_WhenInsideTolerance_ShouldFail(
+				double subjectValue, double unexpectedValue)
 			{
-				decimal subject = new(12.2);
-				decimal unexpected = new(12.1);
+				decimal subject = new(subjectValue);
+				decimal unexpected = new(unexpectedValue);
 
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(new decimal(0.1));
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 12.1 ± 0.1,
-					             but found 12.2
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(new decimal(0.1))
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              but found 12.5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(new decimal(0.1))
+					              """);
 			}
 
-			[Fact]
-			public async Task ForDecimal_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(12.5, 12.7)]
+			[InlineData(12.5, 12.3)]
+			public async Task ForDecimal_WhenOutsideTolerance_ShouldSucceed(
+				double subjectValue, double unexpectedValue)
 			{
-				decimal subject = new(12.3);
-				decimal unexpected = new(12.1);
+				decimal subject = new(subjectValue);
+				decimal unexpected = new(unexpectedValue);
 
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(new decimal(0.1));
@@ -942,13 +948,12 @@ public sealed partial class NumberShould
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForDecimal_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForDecimal_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					decimal subject, decimal unexpected)
 			{
-				decimal subject = new(12.2);
-				decimal unexpected = new(12.1);
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(new decimal(-0.1));
 
@@ -957,43 +962,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForDouble_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(12.5, 12.6)]
+			[InlineData(12.5, 12.4)]
+			public async Task ForDouble_WhenInsideTolerance_ShouldFail(
+				double subject, double unexpected)
 			{
-				double subject = 12.2;
-				double unexpected = 12.1;
-
 				async Task Act()
-					=> await That(subject).Should().NotBe(unexpected).Within(0.1);
+					=> await That(subject).Should().NotBe(unexpected).Within(0.11);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 12.1 ± 0.1,
-					             but found 12.2
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(0.1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected.ToString(CultureInfo.InvariantCulture)} ± 0.11,
+					              but found 12.5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(0.11)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForDouble_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(12.5, 12.7)]
+			[InlineData(12.5, 12.3)]
+			public async Task ForDouble_WhenOutsideTolerance_ShouldSucceed(
+				double subject, double unexpected)
 			{
-				double subject = 12.3;
-				double unexpected = 12.1;
-
 				async Task Act()
-					=> await That(subject).Should().NotBe(unexpected).Within(0.1);
+					=> await That(subject).Should().NotBe(unexpected).Within(0.11);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForDouble_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForDouble_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					double subject, double unexpected)
 			{
-				double subject = 12.2;
-				double unexpected = 12.1;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(-0.1);
 
@@ -1002,43 +1006,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForFloat_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(12.5F, 12.6F)]
+			[InlineData(12.5F, 12.4F)]
+			public async Task ForFloat_WhenInsideTolerance_ShouldFail(
+				float subject, float unexpected)
 			{
-				float subject = 12.2F;
-				float unexpected = 12.1F;
-
 				async Task Act()
-					=> await That(subject).Should().NotBe(unexpected).Within(0.1F);
+					=> await That(subject).Should().NotBe(unexpected).Within(0.11F);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 12.1 ± 0.1,
-					             but found 12.2
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(0.1F)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected.ToString(CultureInfo.InvariantCulture)} ± 0.11,
+					              but found 12.5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(0.11F)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForFloat_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(12.5F, 12.7F)]
+			[InlineData(12.5F, 12.3F)]
+			public async Task ForFloat_WhenOutsideTolerance_ShouldSucceed(
+				float subject, float unexpected)
 			{
-				float subject = 12.3F;
-				float unexpected = 12.1F;
-
 				async Task Act()
-					=> await That(subject).Should().NotBe(unexpected).Within(0.1F);
+					=> await That(subject).Should().NotBe(unexpected).Within(0.11F);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForFloat_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForFloat_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					float subject, float unexpected)
 			{
-				float subject = 12.2F;
-				float unexpected = 12.1F;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(-0.1F);
 
@@ -1047,43 +1050,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForInt_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForInt_WhenInsideTolerance_ShouldFail(
+				int subject, int unexpected)
 			{
-				int subject = 12;
-				int unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForInt_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForInt_WhenOutsideTolerance_ShouldSucceed(
+				int subject, int unexpected)
 			{
-				int subject = 12;
-				int unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForInt_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForInt_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					int subject, int unexpected)
 			{
-				int subject = 12;
-				int unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(-1);
 
@@ -1092,43 +1094,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForLong_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5L, 6L)]
+			[InlineData(5L, 4L)]
+			public async Task ForLong_WhenInsideTolerance_ShouldFail(
+				long subject, long unexpected)
 			{
-				long subject = 12;
-				long unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForLong_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5L, 7L)]
+			[InlineData(5L, 3L)]
+			public async Task ForLong_WhenOutsideTolerance_ShouldSucceed(
+				long subject, long unexpected)
 			{
-				long subject = 12;
-				long unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForLong_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForLong_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					long subject, long unexpected)
 			{
-				long subject = 12;
-				long unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(-1);
 
@@ -1137,59 +1138,65 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableByte_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((byte)5, (byte)6)]
+			[InlineData((byte)5, (byte)4)]
+			public async Task ForNullableByte_WhenInsideTolerance_ShouldFail(
+				byte? subject, byte? unexpected)
 			{
-				byte? subject = 12;
-				byte? unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableByte_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((byte)5, (byte)7)]
+			[InlineData((byte)5, (byte)3)]
+			public async Task ForNullableByte_WhenOutsideTolerance_ShouldSucceed(
+				byte? subject, byte? unexpected)
 			{
-				byte? subject = 12;
-				byte? unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableDecimal_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(12.5, 12.6)]
+			[InlineData(12.5, 12.4)]
+			public async Task ForNullableDecimal_WhenInsideTolerance_ShouldFail(
+				double subjectValue, double unexpectedValue)
 			{
-				decimal? subject = new(12.2);
-				decimal? unexpected = new(12.1);
+				decimal? subject = new(subjectValue);
+				decimal unexpected = new(unexpectedValue);
 
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(new decimal(0.1));
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 12.1 ± 0.1,
-					             but found 12.2
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(new decimal(0.1))
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              but found 12.5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(new decimal(0.1))
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableDecimal_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(12.5, 12.7)]
+			[InlineData(12.5, 12.3)]
+			public async Task ForNullableDecimal_WhenOutsideTolerance_ShouldSucceed(
+				double subjectValue, double unexpectedValue)
 			{
-				decimal? subject = new(12.3);
-				decimal? unexpected = new(12.1);
+				decimal? subject = new(subjectValue);
+				decimal? unexpected = new(unexpectedValue);
 
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(new decimal(0.1));
@@ -1197,13 +1204,12 @@ public sealed partial class NumberShould
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableDecimal_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableDecimal_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					decimal? subject, decimal? unexpected)
 			{
-				decimal? subject = new(12.2);
-				decimal? unexpected = new(12.1);
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(new decimal(-0.1));
 
@@ -1212,43 +1218,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableDouble_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(12.5, 12.6)]
+			[InlineData(12.5, 12.4)]
+			public async Task ForNullableDouble_WhenInsideTolerance_ShouldFail(
+				double? subject, double? unexpected)
 			{
-				double? subject = 12.2;
-				double? unexpected = 12.1;
-
 				async Task Act()
-					=> await That(subject).Should().NotBe(unexpected).Within(0.1);
+					=> await That(subject).Should().NotBe(unexpected).Within(0.11);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 12.1 ± 0.1,
-					             but found 12.2
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(0.1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected?.ToString(CultureInfo.InvariantCulture)} ± 0.11,
+					              but found 12.5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(0.11)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableDouble_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(12.5, 12.7)]
+			[InlineData(12.5, 12.3)]
+			public async Task ForNullableDouble_WhenOutsideTolerance_ShouldSucceed(
+				double? subject, double? unexpected)
 			{
-				double? subject = 12.3;
-				double? unexpected = 12.1;
-
 				async Task Act()
-					=> await That(subject).Should().NotBe(unexpected).Within(0.1);
+					=> await That(subject).Should().NotBe(unexpected).Within(0.11);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableDouble_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableDouble_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					double? subject, double? unexpected)
 			{
-				double? subject = 12.2;
-				double? unexpected = 12.1;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(-0.1);
 
@@ -1257,43 +1262,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableFloat_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(12.5F, 12.6F)]
+			[InlineData(12.5F, 12.4F)]
+			public async Task ForNullableFloat_WhenInsideTolerance_ShouldFail(
+				float? subject, float? unexpected)
 			{
-				float? subject = 12.2F;
-				float? unexpected = 12.1F;
-
 				async Task Act()
-					=> await That(subject).Should().NotBe(unexpected).Within(0.1F);
+					=> await That(subject).Should().NotBe(unexpected).Within(0.11F);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 12.1 ± 0.1,
-					             but found 12.2
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(0.1F)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected?.ToString(CultureInfo.InvariantCulture)} ± 0.11,
+					              but found 12.5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(0.11F)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableFloat_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(12.5F, 12.7F)]
+			[InlineData(12.5F, 12.3F)]
+			public async Task ForNullableFloat_WhenOutsideTolerance_ShouldSucceed(
+				float? subject, float? unexpected)
 			{
-				float? subject = 12.3F;
-				float? unexpected = 12.1F;
-
 				async Task Act()
-					=> await That(subject).Should().NotBe(unexpected).Within(0.1F);
+					=> await That(subject).Should().NotBe(unexpected).Within(0.11F);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableFloat_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableFloat_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					float? subject, float? unexpected)
 			{
-				float? subject = 12.2F;
-				float? unexpected = 12.1F;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(-0.1F);
 
@@ -1302,43 +1306,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableInt_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForNullableInt_WhenInsideTolerance_ShouldFail(
+				int? subject, int? unexpected)
 			{
-				int? subject = 12;
-				int? unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableInt_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForNullableInt_WhenOutsideTolerance_ShouldSucceed(
+				int? subject, int? unexpected)
 			{
-				int? subject = 12;
-				int? unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableInt_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableInt_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					int? subject, int? unexpected)
 			{
-				int? subject = 12;
-				int? unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(-1);
 
@@ -1347,43 +1350,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableLong_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((long)5, (long)6)]
+			[InlineData((long)5, (long)4)]
+			public async Task ForNullableLong_WhenInsideTolerance_ShouldFail(
+				long? subject, long? unexpected)
 			{
-				long? subject = 12;
-				long? unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableLong_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((long)5, (long)7)]
+			[InlineData((long)5, (long)3)]
+			public async Task ForNullableLong_WhenOutsideTolerance_ShouldSucceed(
+				long? subject, long? unexpected)
 			{
-				long? subject = 12;
-				long? unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableLong_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableLong_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					long? subject, long? unexpected)
 			{
-				long? subject = 12;
-				long? unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(-1);
 
@@ -1392,43 +1394,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableSbyte_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((sbyte)5, (sbyte)6)]
+			[InlineData((sbyte)5, (sbyte)4)]
+			public async Task ForNullableSbyte_WhenInsideTolerance_ShouldFail(
+				sbyte? subject, sbyte? unexpected)
 			{
-				sbyte? subject = 12;
-				sbyte? unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableSbyte_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((sbyte)5, (sbyte)7)]
+			[InlineData((sbyte)5, (sbyte)3)]
+			public async Task ForNullableSbyte_WhenOutsideTolerance_ShouldSucceed(
+				sbyte? subject, sbyte? unexpected)
 			{
-				sbyte? subject = 12;
-				sbyte? unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableSbyte_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableSbyte_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					sbyte? subject, sbyte? unexpected)
 			{
-				sbyte? subject = 12;
-				sbyte? unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(-1);
 
@@ -1437,43 +1438,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableShort_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((short)5, (short)6)]
+			[InlineData((short)5, (short)4)]
+			public async Task ForNullableShort_WhenInsideTolerance_ShouldFail(
+				short? subject, short? unexpected)
 			{
-				short? subject = 12;
-				short? unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableShort_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((short)5, (short)7)]
+			[InlineData((short)5, (short)3)]
+			public async Task ForNullableShort_WhenOutsideTolerance_ShouldSucceed(
+				short? subject, short? unexpected)
 			{
-				short? subject = 12;
-				short? unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForNullableShort_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForNullableShort_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					short? subject, short? unexpected)
 			{
-				short? subject = 12;
-				short? unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(-1);
 
@@ -1482,133 +1482,132 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForNullableUint_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((uint)5, (uint)6)]
+			[InlineData((uint)5, (uint)4)]
+			public async Task ForNullableUint_WhenInsideTolerance_ShouldFail(
+				uint? subject, uint? unexpected)
 			{
-				uint? subject = 12;
-				uint? unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableUint_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((uint)5, (uint)7)]
+			[InlineData((uint)5, (uint)3)]
+			public async Task ForNullableUint_WhenOutsideTolerance_ShouldSucceed(
+				uint? subject, uint? unexpected)
 			{
-				uint? subject = 12;
-				uint? unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableUlong_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((ulong)5, (ulong)6)]
+			[InlineData((ulong)5, (ulong)4)]
+			public async Task ForNullableUlong_WhenInsideTolerance_ShouldFail(
+				ulong? subject, ulong? unexpected)
 			{
-				ulong? subject = 12;
-				ulong? unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableUlong_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((ulong)5, (ulong)7)]
+			[InlineData((ulong)5, (ulong)3)]
+			public async Task ForNullableUlong_WhenOutsideTolerance_ShouldSucceed(
+				ulong? subject, ulong? unexpected)
 			{
-				ulong? subject = 12;
-				ulong? unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForNullableUshort_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData((ushort)5, (ushort)6)]
+			[InlineData((ushort)5, (ushort)4)]
+			public async Task ForNullableUshort_WhenInsideTolerance_ShouldFail(
+				ushort? subject, ushort? unexpected)
 			{
-				ushort? subject = 12;
-				ushort? unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForNullableUshort_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData((ushort)5, (ushort)7)]
+			[InlineData((ushort)5, (ushort)3)]
+			public async Task ForNullableUshort_WhenOutsideTolerance_ShouldSucceed(
+				ushort? subject, ushort? unexpected)
 			{
-				ushort? subject = 12;
-				ushort? unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForSbyte_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForSbyte_WhenInsideTolerance_ShouldFail(
+				sbyte subject, sbyte unexpected)
 			{
-				sbyte subject = 12;
-				sbyte unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForSbyte_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForSbyte_WhenOutsideTolerance_ShouldSucceed(
+				sbyte subject, sbyte unexpected)
 			{
-				sbyte subject = 12;
-				sbyte unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForSbyte_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForSbyte_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					sbyte subject, sbyte unexpected)
 			{
-				sbyte subject = 12;
-				sbyte unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(-1);
 
@@ -1617,43 +1616,42 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForShort_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForShort_WhenInsideTolerance_ShouldFail(
+				short subject, short unexpected)
 			{
-				short subject = 12;
-				short unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForShort_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForShort_WhenOutsideTolerance_ShouldSucceed(
+				short subject, short unexpected)
 			{
-				short subject = 12;
-				short unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
+			[Theory]
+			[AutoData]
 			public async Task
-				ForShort_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+				ForShort_WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(
+					short subject, short unexpected)
 			{
-				short subject = 12;
-				short unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(-1);
 
@@ -1662,90 +1660,90 @@ public sealed partial class NumberShould
 					.WithMessage("*Tolerance must be non-negative*").AsWildcard();
 			}
 
-			[Fact]
-			public async Task ForUint_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForUint_WhenInsideTolerance_ShouldFail(
+				uint subject, uint unexpected)
 			{
-				uint subject = 12;
-				uint unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForUint_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForUint_WhenOutsideTolerance_ShouldSucceed(
+				uint subject, uint unexpected)
 			{
-				uint subject = 12;
-				uint unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForUlong_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForUlong_WhenInsideTolerance_ShouldFail(
+				ulong subject, ulong unexpected)
 			{
-				ulong subject = 12;
-				ulong unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForUlong_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForUlong_WhenOutsideTolerance_ShouldSucceed(
+				ulong subject, ulong unexpected)
 			{
-				ulong subject = 12;
-				ulong unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().NotThrow();
 			}
 
-			[Fact]
-			public async Task ForUshort_WhenInsideTolerance_ShouldFail()
+			[Theory]
+			[InlineData(5, 6)]
+			[InlineData(5, 4)]
+			public async Task ForUshort_WhenInsideTolerance_ShouldFail(
+				ushort subject, ushort unexpected)
 			{
-				ushort subject = 12;
-				ushort unexpected = 11;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 
 				await That(Act).Should().Throw<XunitException>()
-					.WithMessage("""
-					             Expected subject to
-					             not be 11 ± 1,
-					             but found 12
-					             at Expect.That(subject).Should().NotBe(unexpected).Within(1)
-					             """);
+					.WithMessage($"""
+					              Expected subject to
+					              not be {unexpected} ± 1,
+					              but found 5
+					              at Expect.That(subject).Should().NotBe(unexpected).Within(1)
+					              """);
 			}
 
-			[Fact]
-			public async Task ForUshort_WhenOutsideTolerance_ShouldSucceed()
+			[Theory]
+			[InlineData(5, 7)]
+			[InlineData(5, 3)]
+			public async Task ForUshort_WhenOutsideTolerance_ShouldSucceed(
+				ushort subject, ushort unexpected)
 			{
-				ushort subject = 12;
-				ushort unexpected = 10;
-
 				async Task Act()
 					=> await That(subject).Should().NotBe(unexpected).Within(1);
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeTests.cs
@@ -7,28 +7,29 @@ public sealed partial class NumberShould
 	public sealed class BeTests
 	{
 		[Theory]
-		[InlineData(1.0F, 2.1F)]
-		[InlineData(5.8F, -3.03F)]
-		public async Task ShouldFailForDifferentFloatValues(float subject,
-			float expected)
+		[AutoData]
+		public async Task ForByte_WhenExpectedIsNull_ShouldFail(
+			byte subject)
 		{
+			byte? expected = null;
+
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              be <null>,
+				              but found {subject}
 				              at Expect.That(subject).Should().Be(expected)
 				              """);
 		}
 
 		[Theory]
-		[InlineData(1, 2)]
-		[InlineData(5, -3)]
-		public async Task ShouldFailForDifferentIntegerValues(int subject,
-			int expected)
+		[InlineData((byte)1, (byte)2)]
+		[InlineData((byte)1, (byte)0)]
+		public async Task ForByte_WhenValueIsDifferentToExpected_ShouldFail(byte subject,
+			byte? expected)
 		{
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -43,10 +44,103 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(1.0F, 2.1F)]
-		[InlineData(5.8F, -3.03F)]
-		public async Task ShouldFailForDifferentNullableFloatValues(float? subject,
-			float? expected)
+		[InlineData((byte)1, (byte)1)]
+		public async Task ForByte_WhenValueIsEqualToExpected_ShouldSucceed(byte subject,
+			byte? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForDecimal_WhenExpectedIsNull_ShouldFail(decimal subject)
+		{
+			decimal? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1.1, 2.1)]
+		[InlineData(1.1, 0.1)]
+		public async Task ForDecimal_WhenValueIsDifferentToExpected_ShouldFail(
+			double subjectValue, double expectedValue)
+		{
+			decimal subject = new(subjectValue);
+			decimal expected = new(expectedValue);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1.1, 1.1)]
+		public async Task ForDecimal_WhenValueIsEqualToExpected_ShouldSucceed(
+			double subjectValue, double expectedValue)
+		{
+			decimal subject = new(subjectValue);
+			decimal? expected = new(expectedValue);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(2.0, 2.0F)]
+		public async Task ForDouble_WhenExpectedIsEqualFloat_ShouldSucceed(
+			double subject, float expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForDouble_WhenExpectedIsNull_ShouldFail(double subject)
+		{
+			double? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1.1, 2.1)]
+		[InlineData(1.1, 0.1)]
+		public async Task ForDouble_WhenValueIsDifferentToExpected_ShouldFail(
+			double subject, double expected)
 		{
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -54,16 +148,93 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1.1, 1.1)]
+		public async Task ForDouble_WhenValueIsEqualToExpected_ShouldSucceed(
+			double subject, double? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForFloat_WhenExpectedIsNull_ShouldFail(float subject)
+		{
+			float? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((float)1.1, (float)2.1)]
+		[InlineData((float)1.1, (float)0.1)]
+		public async Task ForFloat_WhenValueIsDifferentToExpected_ShouldFail(
+			float subject, float expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((float)1.1, (float)1.1)]
+		public async Task ForFloat_WhenValueIsEqualToExpected_ShouldSucceed(
+			float subject, float? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForInt_WhenExpectedIsNull_ShouldFail(
+			int subject)
+		{
+			int? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but found {subject}
 				              at Expect.That(subject).Should().Be(expected)
 				              """);
 		}
 
 		[Theory]
 		[InlineData(1, 2)]
-		[InlineData(5, -3)]
-		public async Task ShouldFailForDifferentNullableIntegerValues(int? subject,
+		[InlineData(2, 1)]
+		public async Task ForInt_WhenValueIsDifferentToExpected_ShouldFail(int subject,
 			int? expected)
 		{
 			async Task Act()
@@ -79,8 +250,225 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
+		[InlineData(1, 1)]
+		public async Task ForInt_WhenValueIsEqualToExpected_ShouldSucceed(int subject,
+			int? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1L, 1)]
+		public async Task ForLong_WhenExpectedIsEqualInt_ShouldSucceed(long subject, int expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
 		[AutoData]
-		public async Task ShouldFailForFloatComparisonWithNull(float subject)
+		public async Task ForLong_WhenExpectedIsNull_ShouldFail(
+			long subject)
+		{
+			long? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((long)1, (long)2)]
+		[InlineData((long)1, (long)0)]
+		public async Task ForLong_WhenValueIsDifferentToExpected_ShouldFail(long subject,
+			long? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((long)1, (long)1)]
+		public async Task ForLong_WhenValueIsEqualToExpected_ShouldSucceed(long subject,
+			long? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((byte)1, (byte)2)]
+		[InlineData((byte)1, (byte)0)]
+		public async Task ForNullableByte_WhenValueIsDifferentToExpected_ShouldFail(
+			byte? subject, byte? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((byte)1, (byte)1)]
+		public async Task ForNullableByte_WhenValueIsEqualToExpected_ShouldSucceed(
+			byte? subject, byte? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableByte_WhenValueIsNull_ShouldFail(
+			byte? expected)
+		{
+			byte? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found <null>
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableDecimal_WhenExpectedIsNull_ShouldFail(decimal? subject)
+		{
+			decimal? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1.1, 2.1)]
+		[InlineData(1.1, 0.1)]
+		public async Task ForNullableDecimal_WhenValueIsDifferentToExpected_ShouldFail(
+			double? subjectValue, double? expectedValue)
+		{
+			decimal? subject = subjectValue == null ? null : new decimal(subjectValue.Value);
+			decimal? expected = expectedValue == null ? null : new decimal(expectedValue.Value);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
+				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1.1, 1.1)]
+		public async Task ForNullableDecimal_WhenValueIsEqualToExpected_ShouldSucceed(
+			double? subjectValue, double? expectedValue)
+		{
+			decimal? subject = subjectValue == null ? null : new decimal(subjectValue.Value);
+			decimal? expected = expectedValue == null ? null : new decimal(expectedValue.Value);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableDouble_WhenExpectedIsNull_ShouldFail(double? subject)
+		{
+			double? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1.1, 2.1)]
+		[InlineData(1.1, 0.1)]
+		public async Task ForNullableDouble_WhenValueIsDifferentToExpected_ShouldFail(
+			double? subject, double? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
+				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1.1, 1.1)]
+		public async Task ForNullableDouble_WhenValueIsEqualToExpected_ShouldSucceed(
+			double? subject, double? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableFloat_WhenExpectedIsNull_ShouldFail(float? subject)
 		{
 			float? expected = null;
 
@@ -97,10 +485,376 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[AutoData]
-		public async Task ShouldFailForIntegerComparisonWithNull(int subject)
+		[InlineData((float)1.1, (float)2.1)]
+		[InlineData((float)1.1, (float)0.1)]
+		public async Task ForNullableFloat_WhenValueIsDifferentToExpected_ShouldFail(
+			float? subject, float? expected)
 		{
-			int? expected = null;
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
+				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((float)1.1, (float)1.1)]
+		public async Task ForNullableFloat_WhenValueIsEqualToExpected_ShouldSucceed(
+			float? subject, float? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1, 2)]
+		[InlineData(1, 0)]
+		public async Task ForNullableInt_WhenValueIsDifferentToExpected_ShouldFail(
+			int? subject, int? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1, 1)]
+		public async Task ForNullableInt_WhenValueIsEqualToExpected_ShouldSucceed(
+			int? subject, int? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableInt_WhenValueIsNull_ShouldFail(
+			int? expected)
+		{
+			int? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found <null>
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((long)1, (long)2)]
+		[InlineData((long)1, (long)0)]
+		public async Task ForNullableLong_WhenValueIsDifferentToExpected_ShouldFail(
+			long? subject, long? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((long)1, (long)1)]
+		public async Task ForNullableLong_WhenValueIsEqualToExpected_ShouldSucceed(
+			long? subject, long? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableLong_WhenValueIsNull_ShouldFail(
+			long? expected)
+		{
+			long? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found <null>
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((sbyte)1, (sbyte)2)]
+		[InlineData((sbyte)1, (sbyte)0)]
+		public async Task ForNullableSbyte_WhenValueIsDifferentToExpected_ShouldFail(
+			sbyte? subject, sbyte? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((sbyte)1, (sbyte)1)]
+		public async Task ForNullableSbyte_WhenValueIsEqualToExpected_ShouldSucceed(
+			sbyte? subject, sbyte? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableSbyte_WhenValueIsNull_ShouldFail(
+			sbyte? expected)
+		{
+			sbyte? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found <null>
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((short)1, (short)2)]
+		[InlineData((short)1, (short)0)]
+		public async Task ForNullableShort_WhenValueIsDifferentToExpected_ShouldFail(
+			short? subject, short? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((short)1, (short)1)]
+		public async Task ForNullableShort_WhenValueIsEqualToExpected_ShouldSucceed(
+			short? subject, short? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableShort_WhenValueIsNull_ShouldFail(
+			short? expected)
+		{
+			short? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found <null>
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((uint)1, (uint)2)]
+		[InlineData((uint)1, (uint)0)]
+		public async Task ForNullableUint_WhenValueIsDifferentToExpected_ShouldFail(
+			uint? subject, uint? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((uint)1, (uint)1)]
+		public async Task ForNullableUint_WhenValueIsEqualToExpected_ShouldSucceed(
+			uint? subject, uint? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableUint_WhenValueIsNull_ShouldFail(
+			uint? expected)
+		{
+			uint? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found <null>
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((ulong)1, (ulong)2)]
+		[InlineData((ulong)1, (ulong)0)]
+		public async Task ForNullableUlong_WhenValueIsDifferentToExpected_ShouldFail(
+			ulong? subject, ulong? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((ulong)1, (ulong)1)]
+		public async Task ForNullableUlong_WhenValueIsEqualToExpected_ShouldSucceed(
+			ulong? subject, ulong? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableUlong_WhenValueIsNull_ShouldFail(
+			ulong? expected)
+		{
+			ulong? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found <null>
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((ushort)1, (ushort)2)]
+		[InlineData((ushort)1, (ushort)0)]
+		public async Task ForNullableUshort_WhenValueIsDifferentToExpected_ShouldFail(
+			ushort? subject, ushort? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((ushort)1, (ushort)1)]
+		public async Task ForNullableUshort_WhenValueIsEqualToExpected_ShouldSucceed(
+			ushort? subject, ushort? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableUshort_WhenValueIsNull_ShouldFail(
+			ushort? expected)
+		{
+			ushort? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found <null>
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForSbyte_WhenExpectedIsNull_ShouldFail(
+			sbyte subject)
+		{
+			sbyte? expected = null;
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -115,10 +869,40 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[AutoData]
-		public async Task ShouldFailForNullableFloatComparisonWithNull(float? subject)
+		[InlineData((sbyte)1, (sbyte)2)]
+		[InlineData((sbyte)1, (sbyte)0)]
+		public async Task ForSbyte_WhenValueIsDifferentToExpected_ShouldFail(sbyte subject,
+			sbyte? expected)
 		{
-			float? expected = null;
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((sbyte)1, (sbyte)1)]
+		public async Task ForSbyte_WhenValueIsEqualToExpected_ShouldSucceed(sbyte subject,
+			sbyte? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForShort_WhenExpectedIsNull_ShouldFail(
+			short subject)
+		{
+			short? expected = null;
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -133,10 +917,40 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[AutoData]
-		public async Task ShouldFailForNullableIntegerComparisonWithNull(int? subject)
+		[InlineData((short)1, (short)2)]
+		[InlineData((short)1, (short)0)]
+		public async Task ForShort_WhenValueIsDifferentToExpected_ShouldFail(short subject,
+			short? expected)
 		{
-			int? expected = null;
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((short)1, (short)1)]
+		public async Task ForShort_WhenValueIsEqualToExpected_ShouldSucceed(short subject,
+			short? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForUint_WhenExpectedIsNull_ShouldFail(
+			uint subject)
+		{
+			uint? expected = null;
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -151,11 +965,28 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[AutoData]
-		public async Task ShouldSucceedForEqualDoubleAndFloatValues(float expected)
+		[InlineData((uint)1, (uint)2)]
+		[InlineData((uint)1, (uint)0)]
+		public async Task ForUint_WhenValueIsDifferentToExpected_ShouldFail(uint subject,
+			uint? expected)
 		{
-			double subject = expected;
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
 
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((uint)1, (uint)1)]
+		public async Task ForUint_WhenValueIsEqualToExpected_ShouldSucceed(uint subject,
+			uint? expected)
+		{
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
 
@@ -164,10 +995,46 @@ public sealed partial class NumberShould
 
 		[Theory]
 		[AutoData]
-		public async Task ShouldSucceedForEqualFloatValueAndNullableValue(float subject)
+		public async Task ForUlong_WhenExpectedIsNull_ShouldFail(
+			ulong subject)
 		{
-			float? expected = subject;
+			ulong? expected = null;
 
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((ulong)1, (ulong)2)]
+		[InlineData((ulong)1, (ulong)0)]
+		public async Task ForUlong_WhenValueIsDifferentToExpected_ShouldFail(ulong subject,
+			ulong? expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((ulong)1, (ulong)1)]
+		public async Task ForUlong_WhenValueIsEqualToExpected_ShouldSucceed(ulong subject,
+			ulong? expected)
+		{
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
 
@@ -176,118 +1043,46 @@ public sealed partial class NumberShould
 
 		[Theory]
 		[AutoData]
-		public async Task ShouldSucceedForEqualFloatValues(float subject)
+		public async Task ForUshort_WhenExpectedIsNull_ShouldFail(
+			ushort subject)
 		{
-			float expected = subject;
+			ushort? expected = null;
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
 		}
 
 		[Theory]
-		[AutoData]
-		public async Task ShouldSucceedForEqualIntegerValueAndNullableValue(int subject)
+		[InlineData((ushort)1, (ushort)2)]
+		[InlineData((ushort)1, (ushort)0)]
+		public async Task ForUshort_WhenValueIsDifferentToExpected_ShouldFail(ushort subject,
+			ushort? expected)
 		{
-			int? expected = subject;
-
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {expected},
+				              but found {subject}
+				              at Expect.That(subject).Should().Be(expected)
+				              """);
 		}
 
 		[Theory]
-		[AutoData]
-		public async Task ShouldSucceedForEqualIntegerValues(int subject)
+		[InlineData((ushort)1, (ushort)1)]
+		public async Task ForUshort_WhenValueIsEqualToExpected_ShouldSucceed(ushort subject,
+			ushort? expected)
 		{
-			int expected = subject;
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected);
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task ShouldSucceedForEqualLongAndIntegerValues(int expected)
-		{
-			long subject = expected;
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected);
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task ShouldSucceedForEqualNullableDoubleAndNullableFloatValues(float? expected)
-		{
-			double? subject = expected;
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected);
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task ShouldSucceedForEqualNullableFloatValueAndExpectedValue(float expected)
-		{
-			float? subject = expected;
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected);
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task ShouldSucceedForEqualNullableFloatValues(float? subject)
-		{
-			float? expected = subject;
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected);
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task ShouldSucceedForEqualNullableIntegerValueAndExpectedValue(int expected)
-		{
-			int? subject = expected;
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected);
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task ShouldSucceedForEqualNullableIntegerValues(int? subject)
-		{
-			int? expected = subject;
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected);
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Theory]
-		[AutoData]
-		public async Task ShouldSucceedForEqualNullableLongAndNullableIntegerValues(int? expected)
-		{
-			long? subject = expected;
-
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
 
@@ -298,60 +1093,968 @@ public sealed partial class NumberShould
 	public sealed class NotBeTests
 	{
 		[Theory]
-		[InlineData(1, 2)]
-		[InlineData(5, -3)]
-		public async Task WhenNullableSubjectIsDifferent_ShouldSucceed(int? subject, int? expected)
+		[AutoData]
+		public async Task ForByte_WhenUnexpectedIsNull_ShouldSucceed(
+			byte subject)
+		{
+			byte? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((byte)1, (byte)2)]
+		[InlineData((byte)1, (byte)0)]
+		public async Task ForByte_WhenValueIsDifferentToUnexpected_ShouldSucceed(byte subject,
+			byte? unexpected)
 		{
 			async Task Act()
-				=> await That(subject).Should().NotBe(expected);
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((byte)1, (byte)1)]
+		public async Task ForByte_WhenValueIsEqualToUnexpected_ShouldFail(byte subject,
+			byte? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForDecimal_WhenUnexpectedIsNull_ShouldSucceed(decimal subject)
+		{
+			decimal? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1.1, 2.1)]
+		[InlineData(1.1, 0.1)]
+		public async Task ForDecimal_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			double subjectValue, double unexpectedValue)
+		{
+			decimal subject = new(subjectValue);
+			decimal unexpected = new(unexpectedValue);
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1.1, 1.1)]
+		public async Task ForDecimal_WhenValueIsEqualToUnexpected_ShouldFail(
+			double subjectValue, double unexpectedValue)
+		{
+			decimal subject = new(subjectValue);
+			decimal unexpected = new(unexpectedValue);
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(2.0, 2.0F)]
+		public async Task ForDouble_WhenUnexpectedIsEqualFloat_ShouldFail(
+			double subject, float unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForDouble_WhenUnexpectedIsNull_ShouldSucceed(double subject)
+		{
+			double? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1.1, 2.1)]
+		[InlineData(1.1, 0.1)]
+		public async Task ForDouble_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			double subject, double unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1.1, 1.1)]
+		public async Task ForDouble_WhenValueIsEqualToUnexpected_ShouldFail(
+			double subject, double? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected?.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForFloat_WhenUnexpectedIsNull_ShouldSucceed(float subject)
+		{
+			float? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((float)1.1, (float)2.1)]
+		[InlineData((float)1.1, (float)0.1)]
+		public async Task ForFloat_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			float subject, float unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((float)1.1, (float)1.1)]
+		public async Task ForFloat_WhenValueIsEqualToUnexpected_ShouldFail(
+			float subject, float? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected?.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForInt_WhenUnexpectedIsNull_ShouldSucceed(
+			int subject)
+		{
+			int? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1, 2)]
+		[InlineData(2, 1)]
+		public async Task ForInt_WhenValueIsDifferentToUnexpected_ShouldSucceed(int subject,
+			int? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1, 1)]
+		public async Task ForInt_WhenValueIsEqualToUnexpected_ShouldFail(int subject,
+			int? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData(1L, 1)]
+		public async Task ForLong_WhenUnexpectedIsEqualToInt_ShouldFail(
+			long subject, int unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForLong_WhenUnexpectedIsNull_ShouldSucceed(
+			long subject)
+		{
+			long? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((long)1, (long)2)]
+		[InlineData((long)1, (long)0)]
+		public async Task ForLong_WhenValueIsDifferentToUnexpected_ShouldSucceed(long subject,
+			long? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((long)1, (long)1)]
+		public async Task ForLong_WhenValueIsEqualToUnexpected_ShouldFail(long subject,
+			long? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[InlineData((byte)1, (byte)2)]
+		[InlineData((byte)1, (byte)0)]
+		public async Task ForNullableByte_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			byte? subject, byte? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((byte)1, (byte)1)]
+		public async Task ForNullableByte_WhenValueIsEqualToUnexpected_ShouldFail(
+			byte? subject, byte? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableByte_WhenValueIsNull_ShouldSucceed(
+			byte? unexpected)
+		{
+			byte? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
 
 			await That(Act).Should().NotThrow();
 		}
 
 		[Theory]
 		[AutoData]
-		public async Task WhenNullableSubjectIsTheSame_ShouldFail(int? subject)
+		public async Task ForNullableDecimal_WhenUnexpectedIsNull_ShouldSucceed(decimal? subject)
 		{
-			int? expected = subject;
+			decimal? unexpected = null;
 
 			async Task Act()
-				=> await That(subject).Should().NotBe(expected);
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1.1, 2.1)]
+		[InlineData(1.1, 0.1)]
+		public async Task ForNullableDecimal_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			double? subjectValue, double? unexpectedValue)
+		{
+			decimal? subject = subjectValue == null ? null : new decimal(subjectValue.Value);
+			decimal? unexpected =
+				unexpectedValue == null ? null : new decimal(unexpectedValue.Value);
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1.1, 1.1)]
+		public async Task ForNullableDecimal_WhenValueIsEqualToUnexpected_ShouldFail(
+			double? subjectValue, double? unexpectedValue)
+		{
+			decimal? subject = subjectValue == null ? null : new decimal(subjectValue.Value);
+			decimal? unexpected =
+				unexpectedValue == null ? null : new decimal(unexpectedValue.Value);
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {expected},
-				              but found {subject}
-				              at Expect.That(subject).Should().NotBe(expected)
+				              not be {unexpected?.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject?.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableDouble_WhenUnexpectedIsNull_ShouldSucceed(double? subject)
+		{
+			double? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1.1, 2.1)]
+		[InlineData(1.1, 0.1)]
+		public async Task ForNullableDouble_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			double? subject, double? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1.1, 1.1)]
+		public async Task ForNullableDouble_WhenValueIsEqualToUnexpected_ShouldFail(
+			double? subject, double? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected?.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject?.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableFloat_WhenUnexpectedIsNull_ShouldSucceed(float? subject)
+		{
+			float? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((float)1.1, (float)2.1)]
+		[InlineData((float)1.1, (float)0.1)]
+		public async Task ForNullableFloat_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			float? subject, float? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((float)1.1, (float)1.1)]
+		public async Task ForNullableFloat_WhenValueIsEqualToUnexpected_ShouldFail(
+			float? subject, float? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected?.ToString(CultureInfo.InvariantCulture)},
+				              but found {subject?.ToString(CultureInfo.InvariantCulture)}
+				              at Expect.That(subject).Should().NotBe(unexpected)
 				              """);
 		}
 
 		[Theory]
 		[InlineData(1, 2)]
-		[InlineData(5, -3)]
-		public async Task WhenSubjectIsDifferent_ShouldSucceed(int subject, int expected)
+		[InlineData(1, 0)]
+		public async Task ForNullableInt_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			int? subject, int? unexpected)
 		{
 			async Task Act()
-				=> await That(subject).Should().NotBe(expected);
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(1, 1)]
+		public async Task ForNullableInt_WhenValueIsEqualToUnexpected_ShouldFail(
+			int? subject, int? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableInt_WhenValueIsNull_ShouldSucceed(
+			int? unexpected)
+		{
+			int? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((long)1, (long)2)]
+		[InlineData((long)1, (long)0)]
+		public async Task ForNullableLong_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			long? subject, long? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((long)1, (long)1)]
+		public async Task ForNullableLong_WhenValueIsEqualToUnexpected_ShouldFail(
+			long? subject, long? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableLong_WhenValueIsNull_ShouldSucceed(
+			long? unexpected)
+		{
+			long? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((sbyte)1, (sbyte)2)]
+		[InlineData((sbyte)1, (sbyte)0)]
+		public async Task ForNullableSbyte_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			sbyte? subject, sbyte? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((sbyte)1, (sbyte)1)]
+		public async Task ForNullableSbyte_WhenValueIsEqualToUnexpected_ShouldFail(
+			sbyte? subject, sbyte? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableSbyte_WhenValueIsNull_ShouldSucceed(
+			sbyte? unexpected)
+		{
+			sbyte? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((short)1, (short)2)]
+		[InlineData((short)1, (short)0)]
+		public async Task ForNullableShort_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			short? subject, short? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((short)1, (short)1)]
+		public async Task ForNullableShort_WhenValueIsEqualToUnexpected_ShouldFail(
+			short? subject, short? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableShort_WhenValueIsNull_ShouldSucceed(
+			short? unexpected)
+		{
+			short? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((uint)1, (uint)2)]
+		[InlineData((uint)1, (uint)0)]
+		public async Task ForNullableUint_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			uint? subject, uint? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((uint)1, (uint)1)]
+		public async Task ForNullableUint_WhenValueIsEqualToUnexpected_ShouldFail(
+			uint? subject, uint? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableUint_WhenValueIsNull_ShouldSucceed(
+			uint? unexpected)
+		{
+			uint? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((ulong)1, (ulong)2)]
+		[InlineData((ulong)1, (ulong)0)]
+		public async Task ForNullableUlong_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			ulong? subject, ulong? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((ulong)1, (ulong)1)]
+		public async Task ForNullableUlong_WhenValueIsEqualToUnexpected_ShouldFail(
+			ulong? subject, ulong? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableUlong_WhenValueIsNull_ShouldSucceed(
+			ulong? unexpected)
+		{
+			ulong? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((ushort)1, (ushort)2)]
+		[InlineData((ushort)1, (ushort)0)]
+		public async Task ForNullableUshort_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			ushort? subject, ushort? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((ushort)1, (ushort)1)]
+		public async Task ForNullableUshort_WhenValueIsEqualToUnexpected_ShouldFail(
+			ushort? subject, ushort? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForNullableUshort_WhenValueIsNull_ShouldSucceed(
+			ushort? unexpected)
+		{
+			ushort? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
 
 			await That(Act).Should().NotThrow();
 		}
 
 		[Theory]
 		[AutoData]
-		public async Task WhenSubjectIsTheSame_ShouldFail(int subject)
+		public async Task ForSbyte_WhenUnexpectedIsNull_ShouldSucceed(
+			sbyte subject)
 		{
-			int expected = subject;
+			sbyte? unexpected = null;
 
 			async Task Act()
-				=> await That(subject).Should().NotBe(expected);
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((sbyte)1, (sbyte)2)]
+		[InlineData((sbyte)1, (sbyte)0)]
+		public async Task ForSbyte_WhenValueIsDifferentToUnexpected_ShouldSucceed(sbyte subject,
+			sbyte? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((sbyte)1, (sbyte)1)]
+		public async Task ForSbyte_WhenValueIsEqualToUnexpected_ShouldFail(sbyte subject,
+			sbyte? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {expected},
+				              not be {unexpected},
 				              but found {subject}
-				              at Expect.That(subject).Should().NotBe(expected)
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForShort_WhenUnexpectedIsNull_ShouldSucceed(
+			short subject)
+		{
+			short? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((short)1, (short)2)]
+		[InlineData((short)1, (short)0)]
+		public async Task ForShort_WhenValueIsDifferentToUnexpected_ShouldSucceed(short subject,
+			short? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((short)1, (short)1)]
+		public async Task ForShort_WhenValueIsEqualToUnexpected_ShouldFail(short subject,
+			short? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForUint_WhenUnexpectedIsNull_ShouldSucceed(
+			uint subject)
+		{
+			uint? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((uint)1, (uint)2)]
+		[InlineData((uint)1, (uint)0)]
+		public async Task ForUint_WhenValueIsDifferentToUnexpected_ShouldSucceed(uint subject,
+			uint? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((uint)1, (uint)1)]
+		public async Task ForUint_WhenValueIsEqualToUnexpected_ShouldFail(uint subject,
+			uint? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForUlong_WhenUnexpectedIsNull_ShouldSucceed(
+			ulong subject)
+		{
+			ulong? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((ulong)1, (ulong)2)]
+		[InlineData((ulong)1, (ulong)0)]
+		public async Task ForUlong_WhenValueIsDifferentToUnexpected_ShouldSucceed(ulong subject,
+			ulong? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((ulong)1, (ulong)1)]
+		public async Task ForUlong_WhenValueIsEqualToUnexpected_ShouldFail(ulong subject,
+			ulong? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForUshort_WhenUnexpectedIsNull_ShouldSucceed(
+			ushort subject)
+		{
+			ushort? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((ushort)1, (ushort)2)]
+		[InlineData((ushort)1, (ushort)0)]
+		public async Task ForUshort_WhenValueIsDifferentToUnexpected_ShouldSucceed(ushort subject,
+			ushort? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData((ushort)1, (ushort)1)]
+		public async Task ForUshort_WhenValueIsEqualToUnexpected_ShouldFail(ushort subject,
+			ushort? unexpected)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {unexpected},
+				              but found {subject}
+				              at Expect.That(subject).Should().NotBe(unexpected)
 				              """);
 		}
 	}


### PR DESCRIPTION
Add missing tests for `Be` and `Be.Within` on numbers.