### PR TITLE
feat: add `BeEmpty`, `BeNullOrEmpty` and `BeNullOrWhiteSpace` for strings

### DIFF
--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.BeEmpty.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.BeEmpty.cs
@@ -7,28 +7,28 @@ namespace Testably.Expectations;
 public static partial class ThatStringShould
 {
 	/// <summary>
-	///     Verifies that the subject is <see langword="null" />.
+	///     Verifies that the subject is empty.
 	/// </summary>
-	public static AndOrResult<string?, IThat<string?>> BeNull(
+	public static AndOrResult<string?, IThat<string?>> BeEmpty(
 		this IThat<string?> source)
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint(
 					"",
-					_ => "be null",
-					(a, _) => a is null,
+					_ => "be empty",
+					(a, _) => a == "",
 					(a, _) => $"found {Formatter.Format(a)}")),
 			source);
 
 	/// <summary>
-	///     Verifies that the subject is not <see langword="null" />.
+	///     Verifies that the subject is not empty.
 	/// </summary>
-	public static AndOrResult<string, IThat<string?>> NotBeNull(
+	public static AndOrResult<string, IThat<string?>> NotBeEmpty(
 		this IThat<string?> source)
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint(
 					"",
-					_ => "not be null",
-					(a, _) => a is not null,
+					_ => "not be empty",
+					(a, _) => a != "",
 					(_, _) => "it was")),
 			source);
 }

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.BeNullOrEmpty.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.BeNullOrEmpty.cs
@@ -8,29 +8,29 @@ namespace Testably.Expectations;
 public static partial class ThatStringShould
 {
 	/// <summary>
-	///     Verifies that the subject is empty.
+	///     Verifies that the subject is <see langword="null" /> or empty.
 	/// </summary>
-	public static AndOrResult<string?, IThat<string?>> BeEmpty(
+	public static AndOrResult<string?, IThat<string?>> BeNullOrEmpty(
 		this IThat<string?> source)
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint(
 					"",
-					_ => "be empty",
-					(a, _) => a == "",
+					_ => "be null or empty",
+					(a, _) => string.IsNullOrEmpty(a),
 					(a, _)
 						=> $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
 			source);
 
 	/// <summary>
-	///     Verifies that the subject is not empty.
+	///     Verifies that the subject is not <see langword="null" /> or empty.
 	/// </summary>
-	public static AndOrResult<string, IThat<string?>> NotBeEmpty(
+	public static AndOrResult<string, IThat<string?>> NotBeNullOrEmpty(
 		this IThat<string?> source)
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new GenericConstraint(
 					"",
-					_ => "not be empty",
-					(a, _) => a != "",
-					(_, _) => "it was")),
+					_ => "not be null or empty",
+					(a, _) => !string.IsNullOrEmpty(a),
+					(a, _) => $"found {Formatter.Format(a)}")),
 			source);
 }

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.BeNullOrWhiteSpace.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.BeNullOrWhiteSpace.cs
@@ -1,0 +1,37 @@
+﻿using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatStringShould
+{
+	/// <summary>
+	///     Verifies that the subject is <see langword="null" />, empty or consists only of white-space characters.
+	/// </summary>
+	public static AndOrResult<string?, IThat<string?>> BeNullOrWhiteSpace(
+		this IThat<string?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint(
+					"",
+					_ => "be null or white-space",
+					(a, _) => string.IsNullOrWhiteSpace(a),
+					(a, _)
+						=> $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not <see langword="null" />, empty or consists only of white-space characters.
+	/// </summary>
+	public static AndOrResult<string, IThat<string?>> NotBeNullOrWhiteSpace(
+		this IThat<string?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint(
+					"",
+					_ => "not be null or white-space",
+					(a, _) => !string.IsNullOrWhiteSpace(a),
+					(a, _)
+						=> $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+			source);
+}

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.cs
@@ -1,4 +1,6 @@
-﻿using Testably.Expectations.Core;
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Constraints;
 
 namespace Testably.Expectations;
 
@@ -12,4 +14,31 @@ public static partial class ThatStringShould
 	/// </summary>
 	public static IThat<string?> Should(this IExpectSubject<string?> subject)
 		=> subject.Should(_ => { });
+
+	private readonly struct GenericConstraint(
+		string? expected,
+		Func<string?, string> expectation,
+		Func<string?, string?, bool> condition,
+		Func<string?, string?, string> failureMessageFactory) : IValueConstraint<string?>
+	{
+		public ConstraintResult IsMetBy(string? actual)
+		{
+			if (expected is null)
+			{
+				return new ConstraintResult.Failure(ToString(),
+					failureMessageFactory(actual, expected));
+			}
+
+			if (condition(actual, expected))
+			{
+				return new ConstraintResult.Success<string?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(),
+				failureMessageFactory(actual, expected));
+		}
+
+		public override string ToString()
+			=> expectation(expected);
+	}
 }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -686,10 +686,16 @@ namespace Testably.Expectations
     public static class ThatStringShould
     {
         public static Testably.Expectations.Results.StringMatcherResult<string?, Testably.Expectations.Core.IThat<string?>> Be(this Testably.Expectations.Core.IThat<string?> source, Testably.Expectations.Options.StringMatcher expected) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNull(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNullOrEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNullOrWhiteSpace(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.StringCountResult<string?, Testably.Expectations.Core.IThat<string?>> Contain(this Testably.Expectations.Core.IThat<string?> source, string expected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> EndWith(this Testably.Expectations.Core.IThat<string?> source, string expected) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNull(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNullOrEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNullOrWhiteSpace(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotContain(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotEndWith(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotStartWith(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -686,10 +686,16 @@ namespace Testably.Expectations
     public static class ThatStringShould
     {
         public static Testably.Expectations.Results.StringMatcherResult<string?, Testably.Expectations.Core.IThat<string?>> Be(this Testably.Expectations.Core.IThat<string?> source, Testably.Expectations.Options.StringMatcher expected) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNull(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNullOrEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNullOrWhiteSpace(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.StringCountResult<string?, Testably.Expectations.Core.IThat<string?>> Contain(this Testably.Expectations.Core.IThat<string?> source, string expected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> EndWith(this Testably.Expectations.Core.IThat<string?> source, string expected) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNull(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNullOrEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNullOrWhiteSpace(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotContain(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotEndWith(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotStartWith(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -631,10 +631,16 @@ namespace Testably.Expectations
     public static class ThatStringShould
     {
         public static Testably.Expectations.Results.StringMatcherResult<string?, Testably.Expectations.Core.IThat<string?>> Be(this Testably.Expectations.Core.IThat<string?> source, Testably.Expectations.Options.StringMatcher expected) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNull(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNullOrEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNullOrWhiteSpace(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.StringCountResult<string?, Testably.Expectations.Core.IThat<string?>> Contain(this Testably.Expectations.Core.IThat<string?> source, string expected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> EndWith(this Testably.Expectations.Core.IThat<string?> source, string expected) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNull(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNullOrEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNullOrWhiteSpace(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotContain(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotEndWith(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotStartWith(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeEmptyTests.cs
@@ -31,6 +31,22 @@ public sealed partial class StringShould
 		}
 
 		[Fact]
+		public async Task WhenActualIsNotEmpty_ShouldLimitDisplayedStringTo100Characters()
+		{
+			string subject = StringWithMoreThan100Characters;
+
+			async Task Act()
+				=> await That(subject).Should().BeEmpty();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be empty,
+				              but found "{StringWith100Characters}…".
+				              """);
+		}
+
+		[Fact]
 		public async Task WhenActualIsNull_ShouldFail()
 		{
 			string? subject = null;

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeEmptyTests.cs
@@ -1,0 +1,89 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.Strings;
+
+public sealed partial class StringShould
+{
+	public class BeEmptyTests
+	{
+		[Fact]
+		public async Task WhenActualIsEmpty_ShouldSucceed()
+		{
+			string subject = "";
+
+			async Task Act()
+				=> await That(subject).Should().BeEmpty();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenActualIsNotEmpty_ShouldFail(string? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeEmpty();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be empty,
+				              but found "{subject}".
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsNull_ShouldFail()
+		{
+			string? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeEmpty();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be empty,
+				             but found <null>.
+				             """);
+		}
+	}
+
+	public sealed class NotBeEmptyTests
+	{
+		[Fact]
+		public async Task WhenActualIsEmpty_ShouldFail()
+		{
+			string subject = "";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeEmpty();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be empty,
+				             but it was.
+				             """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenActualIsNotEmpty_ShouldSucceed(string? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBeEmpty();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsNull_ShouldSucceed()
+		{
+			string? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeEmpty();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrEmptyTests.cs
@@ -2,7 +2,7 @@
 
 public sealed partial class StringShould
 {
-	public class BeEmptyTests
+	public class BeNullOrEmptyTests
 	{
 		[Fact]
 		public async Task WhenActualIsEmpty_ShouldSucceed()
@@ -10,7 +10,7 @@ public sealed partial class StringShould
 			string subject = "";
 
 			async Task Act()
-				=> await That(subject).Should().BeEmpty();
+				=> await That(subject).Should().BeNullOrEmpty();
 
 			await That(Act).Should().NotThrow();
 		}
@@ -20,30 +20,25 @@ public sealed partial class StringShould
 		public async Task WhenActualIsNotEmpty_ShouldFail(string? subject)
 		{
 			async Task Act()
-				=> await That(subject).Should().BeEmpty();
+				=> await That(subject).Should().BeNullOrEmpty();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be empty,
+				              be null or empty,
 				              but found "{subject}".
 				              """);
 		}
 
 		[Fact]
-		public async Task WhenActualIsNull_ShouldFail()
+		public async Task WhenActualIsNull_ShouldSucceed()
 		{
 			string? subject = null;
 
 			async Task Act()
-				=> await That(subject).Should().BeEmpty();
+				=> await That(subject).Should().BeNullOrEmpty();
 
-			await That(Act).Should().Throw<XunitException>()
-				.WithMessage("""
-				             Expected subject to
-				             be empty,
-				             but found <null>.
-				             """);
+			await That(Act).Should().NotThrow();
 		}
 
 		[Fact]
@@ -52,18 +47,18 @@ public sealed partial class StringShould
 			string subject = " \t ";
 
 			async Task Act()
-				=> await That(subject).Should().BeEmpty();
+				=> await That(subject).Should().BeNullOrEmpty();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
 				             Expected subject to
-				             be empty,
+				             be null or empty,
 				             but found " \t ".
 				             """);
 		}
 	}
 
-	public sealed class NotBeEmptyTests
+	public sealed class NotBeNullOrEmptyTests
 	{
 		[Fact]
 		public async Task WhenActualIsEmpty_ShouldFail()
@@ -71,13 +66,13 @@ public sealed partial class StringShould
 			string subject = "";
 
 			async Task Act()
-				=> await That(subject).Should().NotBeEmpty();
+				=> await That(subject).Should().NotBeNullOrEmpty();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
 				             Expected subject to
-				             not be empty,
-				             but it was.
+				             not be null or empty,
+				             but found "".
 				             """);
 		}
 
@@ -86,7 +81,7 @@ public sealed partial class StringShould
 		public async Task WhenActualIsNotEmpty_ShouldSucceed(string? subject)
 		{
 			async Task Act()
-				=> await That(subject).Should().NotBeEmpty();
+				=> await That(subject).Should().NotBeNullOrEmpty();
 
 			await That(Act).Should().NotThrow();
 		}
@@ -97,9 +92,14 @@ public sealed partial class StringShould
 			string? subject = null;
 
 			async Task Act()
-				=> await That(subject).Should().NotBeEmpty();
+				=> await That(subject).Should().NotBeNullOrEmpty();
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be null or empty,
+				             but found <null>.
+				             """);
 		}
 
 		[Fact]
@@ -108,7 +108,7 @@ public sealed partial class StringShould
 			string subject = " \t ";
 
 			async Task Act()
-				=> await That(subject).Should().NotBeEmpty();
+				=> await That(subject).Should().NotBeNullOrEmpty();
 
 			await That(Act).Should().NotThrow();
 		}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrEmptyTests.cs
@@ -31,6 +31,22 @@ public sealed partial class StringShould
 		}
 
 		[Fact]
+		public async Task WhenActualIsNotEmpty_ShouldLimitDisplayedStringTo100Characters()
+		{
+			string subject = StringWithMoreThan100Characters;
+
+			async Task Act()
+				=> await That(subject).Should().BeNullOrEmpty();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be null or empty,
+				              but found "{StringWith100Characters}…".
+				              """);
+		}
+
+		[Fact]
 		public async Task WhenActualIsNull_ShouldSucceed()
 		{
 			string? subject = null;

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrWhiteSpaceTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrWhiteSpaceTests.cs
@@ -31,6 +31,22 @@ public sealed partial class StringShould
 		}
 
 		[Fact]
+		public async Task WhenActualIsNotEmpty_ShouldLimitDisplayedStringTo100Characters()
+		{
+			string subject = StringWithMoreThan100Characters;
+
+			async Task Act()
+				=> await That(subject).Should().BeNullOrWhiteSpace();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be null or white-space,
+				              but found "{StringWith100Characters}…".
+				              """);
+		}
+
+		[Fact]
 		public async Task WhenActualIsNull_ShouldSucceed()
 		{
 			string? subject = null;
@@ -95,6 +111,22 @@ public sealed partial class StringShould
 				             not be null or white-space,
 				             but found <null>.
 				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsWhiteSpace_ShouldLimitDisplayedStringTo100Characters()
+		{
+			string subject = new(' ', 101);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNullOrWhiteSpace();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be null or white-space,
+				              but found "{new string(' ', 100)}…".
+				              """);
 		}
 
 		[Fact]

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrWhiteSpaceTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrWhiteSpaceTests.cs
@@ -1,0 +1,116 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.Strings;
+
+public sealed partial class StringShould
+{
+	public class BeNullOrWhiteSpaceTests
+	{
+		[Fact]
+		public async Task WhenActualIsEmpty_ShouldSucceed()
+		{
+			string subject = "";
+
+			async Task Act()
+				=> await That(subject).Should().BeNullOrWhiteSpace();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenActualIsNotEmpty_ShouldFail(string? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().BeNullOrWhiteSpace();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be null or white-space,
+				              but found "{subject}".
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsNull_ShouldSucceed()
+		{
+			string? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeNullOrWhiteSpace();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsWhitespace_ShouldFail()
+		{
+			string subject = " \t ";
+
+			async Task Act()
+				=> await That(subject).Should().BeNullOrWhiteSpace();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeNullOrWhiteSpaceTests
+	{
+		[Fact]
+		public async Task WhenActualIsEmpty_ShouldFail()
+		{
+			string subject = "";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNullOrWhiteSpace();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be null or white-space,
+				             but found "".
+				             """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenActualIsNotEmpty_ShouldSucceed(string? subject)
+		{
+			async Task Act()
+				=> await That(subject).Should().NotBeNullOrWhiteSpace();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsNull_ShouldSucceed()
+		{
+			string? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNullOrWhiteSpace();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be null or white-space,
+				             but found <null>.
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsWhitespace_ShouldSucceed()
+		{
+			string subject = " \t ";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNullOrWhiteSpace();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be null or white-space,
+				             but found " \t ".
+				             """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullTests.cs
@@ -43,7 +43,7 @@ public sealed partial class StringShould
 			async Task Act()
 				=> await That(subject).Should().BeNull();
 
-			await Act();
+			await That(Act).Should().NotThrow();
 		}
 	}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.cs
@@ -4,6 +4,11 @@ namespace Testably.Expectations.Tests.ThatTests.Strings;
 
 public sealed partial class StringShould
 {
+	private static readonly string StringWith100Characters =
+		"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut l";
+	private static readonly string StringWithMoreThan100Characters =
+		"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore";
+	
 	/// <summary>
 	///     A test <see cref="IEqualityComparer{T}" /> for <see langword="string" />s that
 	///     ignores case differences only in vocals.

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.cs
@@ -6,9 +6,10 @@ public sealed partial class StringShould
 {
 	private static readonly string StringWith100Characters =
 		"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut l";
+
 	private static readonly string StringWithMoreThan100Characters =
 		"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore";
-	
+
 	/// <summary>
 	///     A test <see cref="IEqualityComparer{T}" /> for <see langword="string" />s that
 	///     ignores case differences only in vocals.


### PR DESCRIPTION
From #130:
Add expectations for
- `BeEmpty` / `NotBeEmpty`
- `BeNullOrEmpty` / `NotBeNullOrEmpty`
- `BeNullOrWhiteSpace` / `NotBeNullOrWhiteSpace`