### PR TITLE
feat: add `BeLowerCased` and `BeUpperCased` for strings

### DIFF
--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.BeLowerCased.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.BeLowerCased.cs
@@ -1,0 +1,38 @@
+﻿using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatStringShould
+{
+	/// <summary>
+	///     Verifies that all cased characters in the subject are lower-case.<br />
+	///     That is, that the string could be the result of a call to <see cref="string.ToLowerInvariant()" />,
+	/// </summary>
+	public static AndOrResult<string?, IThat<string?>> BeLowerCased(
+		this IThat<string?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint(
+					"",
+					_ => "be lower-cased",
+					(a, _) => a != null && a == a.ToLowerInvariant(),
+					(a, _)
+						=> $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+			source);
+
+	/// <summary>
+	///     Verifies that of all cased characters in the subject some are upper-case.<br />
+	///     That is, that the string could not be the result of a call to <see cref="string.ToLowerInvariant()" />,
+	/// </summary>
+	public static AndOrResult<string, IThat<string?>> NotBeLowerCased(
+		this IThat<string?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint(
+					"",
+					_ => "not be lower-cased",
+					(a, _) => a == null || a != a.ToLowerInvariant(),
+					(a, _) => $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+			source);
+}

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.BeUpperCased.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.BeUpperCased.cs
@@ -1,0 +1,37 @@
+﻿using Testably.Expectations.Core;
+using Testably.Expectations.Core.Helpers;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatStringShould
+{
+	/// <summary>
+	///     Verifies that all cased characters in the subject are upper-case.<br />
+	///     That is, that the string could be the result of a call to <see cref="string.ToUpperInvariant()" />,
+	/// </summary>
+	public static AndOrResult<string?, IThat<string?>> BeUpperCased(
+		this IThat<string?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint(
+					"",
+					_ => "be upper-cased",
+					(a, _) => a != null && a == a.ToUpperInvariant(),
+					(a, _) => $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+			source);
+
+	/// <summary>
+	///     Verifies that of all cased characters in the subject some are lower-case.<br />
+	///     That is, that the string could not be the result of a call to <see cref="string.ToUpperInvariant()" />,
+	/// </summary>
+	public static AndOrResult<string, IThat<string?>> NotBeUpperCased(
+		this IThat<string?> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new GenericConstraint(
+					"",
+					_ => "not be upper-cased",
+					(a, _) => a == null || a != a.ToUpperInvariant(),
+					(a, _) => $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+			source);
+}

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -687,15 +687,19 @@ namespace Testably.Expectations
     {
         public static Testably.Expectations.Results.StringMatcherResult<string?, Testably.Expectations.Core.IThat<string?>> Be(this Testably.Expectations.Core.IThat<string?> source, Testably.Expectations.Options.StringMatcher expected) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeLowerCased(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNull(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNullOrEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNullOrWhiteSpace(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeUpperCased(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.StringCountResult<string?, Testably.Expectations.Core.IThat<string?>> Contain(this Testably.Expectations.Core.IThat<string?> source, string expected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> EndWith(this Testably.Expectations.Core.IThat<string?> source, string expected) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeLowerCased(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNull(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNullOrEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNullOrWhiteSpace(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeUpperCased(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotContain(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotEndWith(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotStartWith(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -687,15 +687,19 @@ namespace Testably.Expectations
     {
         public static Testably.Expectations.Results.StringMatcherResult<string?, Testably.Expectations.Core.IThat<string?>> Be(this Testably.Expectations.Core.IThat<string?> source, Testably.Expectations.Options.StringMatcher expected) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeLowerCased(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNull(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNullOrEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNullOrWhiteSpace(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeUpperCased(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.StringCountResult<string?, Testably.Expectations.Core.IThat<string?>> Contain(this Testably.Expectations.Core.IThat<string?> source, string expected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> EndWith(this Testably.Expectations.Core.IThat<string?> source, string expected) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeLowerCased(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNull(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNullOrEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNullOrWhiteSpace(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeUpperCased(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotContain(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotEndWith(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotStartWith(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -632,15 +632,19 @@ namespace Testably.Expectations
     {
         public static Testably.Expectations.Results.StringMatcherResult<string?, Testably.Expectations.Core.IThat<string?>> Be(this Testably.Expectations.Core.IThat<string?> source, Testably.Expectations.Options.StringMatcher expected) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeLowerCased(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNull(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNullOrEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeNullOrWhiteSpace(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string?, Testably.Expectations.Core.IThat<string?>> BeUpperCased(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.StringCountResult<string?, Testably.Expectations.Core.IThat<string?>> Contain(this Testably.Expectations.Core.IThat<string?> source, string expected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> EndWith(this Testably.Expectations.Core.IThat<string?> source, string expected) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeLowerCased(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNull(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNullOrEmpty(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeNullOrWhiteSpace(this Testably.Expectations.Core.IThat<string?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<string, Testably.Expectations.Core.IThat<string?>> NotBeUpperCased(this Testably.Expectations.Core.IThat<string?> source) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotContain(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotEndWith(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }
         public static Testably.Expectations.Results.StringEqualityResult<string?, Testably.Expectations.Core.IThat<string?>> NotStartWith(this Testably.Expectations.Core.IThat<string?> source, string unexpected) { }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeLowerCasedTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeLowerCasedTests.cs
@@ -1,0 +1,258 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.Strings;
+
+public sealed partial class StringShould
+{
+	public class BeLowerCasedTests
+	{
+		[Fact]
+		public async Task WhenActualIsEmpty_ShouldSucceed()
+		{
+			string subject = "";
+
+			async Task Act()
+				=> await That(subject).Should().BeLowerCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsLowerCased_ShouldSucceed()
+		{
+			string subject = "abc";
+
+			async Task Act()
+				=> await That(subject).Should().BeLowerCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsLowerCasedOrCaseless_ShouldSucceed()
+		{
+			string subject = "a漢字b";
+
+			async Task Act()
+				=> await That(subject).Should().BeLowerCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsLowerCasedOrSpecialCharacters_ShouldSucceed()
+		{
+			string subject = "a-b-c!";
+
+			async Task Act()
+				=> await That(subject).Should().BeLowerCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsMixedCased_ShouldFail()
+		{
+			string subject = "aBc";
+
+			async Task Act()
+				=> await That(subject).Should().BeLowerCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be lower-cased,
+				             but found "aBc".
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsNotLowerCased_ShouldLimitDisplayedStringTo100Characters()
+		{
+			string subject = StringWithMoreThan100Characters;
+
+			async Task Act()
+				=> await That(subject).Should().BeLowerCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be lower-cased,
+				              but found "{StringWith100Characters}…".
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsNull_ShouldFail()
+		{
+			string? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeLowerCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be lower-cased,
+				             but found <null>.
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsUpperCased_ShouldFail()
+		{
+			string subject = "ABC";
+
+			async Task Act()
+				=> await That(subject).Should().BeLowerCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be lower-cased,
+				             but found "ABC".
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsWhitespace_ShouldSucceed()
+		{
+			string subject = " \t\r\n";
+
+			async Task Act()
+				=> await That(subject).Should().BeLowerCased();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeLowerCasedTests
+	{
+		[Fact]
+		public async Task WhenActualIsEmpty_ShouldFail()
+		{
+			string subject = "";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeLowerCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be lower-cased,
+				             but found "".
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsLowerCased_ShouldFail()
+		{
+			string subject = "abc";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeLowerCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be lower-cased,
+				             but found "abc".
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsLowerCasedOrCaseless_ShouldFail()
+		{
+			string subject = "a漢字b";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeLowerCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be lower-cased,
+				             but found "a漢字b".
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsLowerCasedOrSpecialCharacters_ShouldFail()
+		{
+			string subject = "a-b-c!";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeLowerCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be lower-cased,
+				             but found "a-b-c!".
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsMixedCased_ShouldSucceed()
+		{
+			string subject = "aBc";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeLowerCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsNotLowerCased_ShouldLimitDisplayedStringTo100Characters()
+		{
+			string subject = StringWithMoreThan100Characters.ToLowerInvariant();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeLowerCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be lower-cased,
+				              but found "{StringWith100Characters.ToLowerInvariant()}…".
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsNull_ShouldSucceed()
+		{
+			string? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeLowerCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsUpperCased_ShouldSucceed()
+		{
+			string subject = "ABC";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeLowerCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsWhitespace_ShouldSucceed()
+		{
+			string subject = " \t ";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeLowerCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be lower-cased,
+				             but found " \t ".
+				             """);
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeUpperCasedTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeUpperCasedTests.cs
@@ -1,0 +1,258 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.Strings;
+
+public sealed partial class StringShould
+{
+	public class BeUpperCasedTests
+	{
+		[Fact]
+		public async Task WhenActualIsEmpty_ShouldSucceed()
+		{
+			string subject = "";
+
+			async Task Act()
+				=> await That(subject).Should().BeUpperCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsLowerCased_ShouldFail()
+		{
+			string subject = "abc";
+
+			async Task Act()
+				=> await That(subject).Should().BeUpperCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be upper-cased,
+				             but found "abc".
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsMixedCased_ShouldFail()
+		{
+			string subject = "AbC";
+
+			async Task Act()
+				=> await That(subject).Should().BeUpperCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be upper-cased,
+				             but found "AbC".
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsNotUpperCased_ShouldLimitDisplayedStringTo100Characters()
+		{
+			string subject = StringWithMoreThan100Characters;
+
+			async Task Act()
+				=> await That(subject).Should().BeUpperCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be upper-cased,
+				              but found "{StringWith100Characters}…".
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsNull_ShouldFail()
+		{
+			string? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeUpperCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be upper-cased,
+				             but found <null>.
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsUpperCased_ShouldSucceed()
+		{
+			string subject = "ABC";
+
+			async Task Act()
+				=> await That(subject).Should().BeUpperCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsUpperCasedOrCaseless_ShouldSucceed()
+		{
+			string subject = "A漢字B";
+
+			async Task Act()
+				=> await That(subject).Should().BeUpperCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsUpperCasedOrSpecialCharacters_ShouldSucceed()
+		{
+			string subject = "A-B-C!";
+
+			async Task Act()
+				=> await That(subject).Should().BeUpperCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsWhitespace_ShouldSucceed()
+		{
+			string subject = " \t\r\n";
+
+			async Task Act()
+				=> await That(subject).Should().BeUpperCased();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeUpperCasedTests
+	{
+		[Fact]
+		public async Task WhenActualIsEmpty_ShouldFail()
+		{
+			string subject = "";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeUpperCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be upper-cased,
+				             but found "".
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsLowerCased_ShouldSucceed()
+		{
+			string subject = "abc";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeUpperCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsMixedCased_ShouldSucceed()
+		{
+			string subject = "AbC";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeUpperCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsNotUpperCased_ShouldLimitDisplayedStringTo100Characters()
+		{
+			string subject = StringWithMoreThan100Characters.ToUpperInvariant();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeUpperCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be upper-cased,
+				              but found "{StringWith100Characters.ToUpperInvariant()}…".
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsNull_ShouldSucceed()
+		{
+			string? subject = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeUpperCased();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenActualIsUpperCased_ShouldFail()
+		{
+			string subject = "ABC";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeUpperCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be upper-cased,
+				             but found "ABC".
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsUpperCasedOrCaseless_ShouldFail()
+		{
+			string subject = "A漢字B";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeUpperCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be upper-cased,
+				             but found "A漢字B".
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsUpperCasedOrSpecialCharacters_ShouldFail()
+		{
+			string subject = "A-B-C!";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeUpperCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be upper-cased,
+				             but found "A-B-C!".
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenActualIsWhitespace_ShouldSucceed()
+		{
+			string subject = " \t ";
+
+			async Task Act()
+				=> await That(subject).Should().NotBeUpperCased();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be upper-cased,
+				             but found " \t ".
+				             """);
+		}
+	}
+}


### PR DESCRIPTION
From #130:
Add expectations for
- `BeLowerCased` / `NotBeLowerCased`
- `BeUpperCased` / `NotBeUpperCased`