### PR TITLE
refactor: consolidate usage of `Formatter.Format`

### DIFF
--- a/Source/Testably.Expectations/Core/Helpers/FailureMessageBuilder.cs
+++ b/Source/Testably.Expectations/Core/Helpers/FailureMessageBuilder.cs
@@ -10,7 +10,7 @@ internal class FailureMessageBuilder : IFailureMessageBuilder
 		=> $"""
 		    Expected {subject} to
 		    {failure.ExpectationText},
-		    but {failure.ResultText}.
+		    but {failure.ResultText}
 		    """;
 
 	#endregion

--- a/Source/Testably.Expectations/Formatting/Formatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatter.cs
@@ -58,10 +58,11 @@ public class Formatter
 	/// <summary>
 	///     Formats the <paramref name="value" /> according to the formatting <paramref name="options" />.
 	/// </summary>
+	/// <remarks>Default value for <paramref name="options" /> is <see cref="FormattingOptions.SingleLine" />.</remarks>
 	public static string Format<T>(T? value, FormattingOptions? options = null)
 	{
 		StringBuilder stringBuilder = new();
-		options ??= FormattingOptions.Default;
+		options ??= FormattingOptions.SingleLine;
 		Initialization.State.Value.Formatter.Format(value, stringBuilder, options);
 		return stringBuilder.ToString();
 	}

--- a/Source/Testably.Expectations/Formatting/Formatters/StringFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/StringFormatter.cs
@@ -10,7 +10,14 @@ internal class StringFormatter : FormatterBase<string>
 		FormattingOptions options)
 	{
 		stringBuilder.Append('\"');
-		stringBuilder.Append(value.ToSingleLineIf(!options.UseLineBreaks));
+		if (options.UseLineBreaks)
+		{
+			stringBuilder.Append(value);
+		}
+		else
+		{
+			stringBuilder.Append(value.DisplayWhitespace().TruncateWithEllipsis(100));
+		}
 		stringBuilder.Append('\"');
 	}
 }

--- a/Source/Testably.Expectations/Formatting/FormattingOptions.cs
+++ b/Source/Testably.Expectations/Formatting/FormattingOptions.cs
@@ -8,7 +8,7 @@ public class FormattingOptions
 	/// <summary>
 	///     Format the objects on multiple lines.
 	/// </summary>
-	public static FormattingOptions Default { get; } = new(true);
+	public static FormattingOptions MultipleLines { get; } = new(true);
 
 	/// <summary>
 	///     Format the objects on a single line.

--- a/Source/Testably.Expectations/Options/ObjectEqualityOptions.cs
+++ b/Source/Testably.Expectations/Options/ObjectEqualityOptions.cs
@@ -80,7 +80,8 @@ public class ObjectEqualityOptions
 		{
 			if (HandleSpecialCases(a, b, out bool? specialCaseResult))
 			{
-				return new Result(specialCaseResult.Value, $"found {Formatter.Format(a)}");
+				return new Result(specialCaseResult.Value,
+					$"found {Formatter.Format(a, FormattingOptions.MultipleLines)}");
 			}
 
 			List<ComparisonFailure> failures = Compare.CheckEquivalent(a, b,
@@ -146,7 +147,7 @@ public class ObjectEqualityOptions
 
 		/// <inheritdoc />
 		public Result AreConsideredEqual(object? a, object? b)
-			=> new(Equals(a, b), $"found {Formatter.Format(a)}");
+			=> new(Equals(a, b), $"found {Formatter.Format(a, FormattingOptions.MultipleLines)}");
 
 		/// <inheritdoc />
 		public string GetExpectation(string expectedExpression)
@@ -161,7 +162,8 @@ public class ObjectEqualityOptions
 
 		/// <inheritdoc />
 		public Result AreConsideredEqual(object? a, object? b)
-			=> new(comparer.Equals(a, b), $"found {Formatter.Format(a)}");
+			=> new(comparer.Equals(a, b),
+				$"found {Formatter.Format(a, FormattingOptions.MultipleLines)}");
 
 		/// <inheritdoc />
 		public string GetExpectation(string expectedExpression)

--- a/Source/Testably.Expectations/That/Objects/ThatObjectShould.Be.cs
+++ b/Source/Testably.Expectations/That/Objects/ThatObjectShould.Be.cs
@@ -67,7 +67,7 @@ public static partial class ThatObjectShould
 			}
 
 			return new ConstraintResult.Failure(ToString(),
-				$"found {Formatter.Format(actual)}");
+				$"found {Formatter.Format(actual, FormattingOptions.MultipleLines)}");
 		}
 
 		public override string ToString()

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.BeEmpty.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.BeEmpty.cs
@@ -18,7 +18,7 @@ public static partial class ThatStringShould
 					_ => "be empty",
 					(a, _) => a == "",
 					(a, _)
-						=> $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+						=> $"found {Formatter.Format(a, FormattingOptions.SingleLine)}")),
 			source);
 
 	/// <summary>

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.BeLowerCased.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.BeLowerCased.cs
@@ -19,7 +19,7 @@ public static partial class ThatStringShould
 					_ => "be lower-cased",
 					(a, _) => a != null && a == a.ToLowerInvariant(),
 					(a, _)
-						=> $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+						=> $"found {Formatter.Format(a, FormattingOptions.SingleLine)}")),
 			source);
 
 	/// <summary>
@@ -33,6 +33,6 @@ public static partial class ThatStringShould
 					"",
 					_ => "not be lower-cased",
 					(a, _) => a == null || a != a.ToLowerInvariant(),
-					(a, _) => $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+					(a, _) => $"found {Formatter.Format(a, FormattingOptions.SingleLine)}")),
 			source);
 }

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.BeNullOrEmpty.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.BeNullOrEmpty.cs
@@ -18,7 +18,7 @@ public static partial class ThatStringShould
 					_ => "be null or empty",
 					(a, _) => string.IsNullOrEmpty(a),
 					(a, _)
-						=> $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+						=> $"found {Formatter.Format(a, FormattingOptions.SingleLine)}")),
 			source);
 
 	/// <summary>

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.BeNullOrWhiteSpace.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.BeNullOrWhiteSpace.cs
@@ -18,7 +18,7 @@ public static partial class ThatStringShould
 					_ => "be null or white-space",
 					(a, _) => string.IsNullOrWhiteSpace(a),
 					(a, _)
-						=> $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+						=> $"found {Formatter.Format(a, FormattingOptions.SingleLine)}")),
 			source);
 
 	/// <summary>
@@ -32,6 +32,6 @@ public static partial class ThatStringShould
 					_ => "not be null or white-space",
 					(a, _) => !string.IsNullOrWhiteSpace(a),
 					(a, _)
-						=> $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+						=> $"found {Formatter.Format(a, FormattingOptions.SingleLine)}")),
 			source);
 }

--- a/Source/Testably.Expectations/That/Strings/ThatStringShould.BeUpperCased.cs
+++ b/Source/Testably.Expectations/That/Strings/ThatStringShould.BeUpperCased.cs
@@ -18,7 +18,7 @@ public static partial class ThatStringShould
 					"",
 					_ => "be upper-cased",
 					(a, _) => a != null && a == a.ToUpperInvariant(),
-					(a, _) => $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+					(a, _) => $"found {Formatter.Format(a, FormattingOptions.SingleLine)}")),
 			source);
 
 	/// <summary>
@@ -32,6 +32,6 @@ public static partial class ThatStringShould
 					"",
 					_ => "not be upper-cased",
 					(a, _) => a == null || a != a.ToUpperInvariant(),
-					(a, _) => $"found {Formatter.Format(a.DisplayWhitespace().TruncateWithEllipsis(100))}")),
+					(a, _) => $"found {Formatter.Format(a, FormattingOptions.SingleLine)}")),
 			source);
 }

--- a/Source/Testably.Expectations/That/ThatGenericShould.BeSameAs.cs
+++ b/Source/Testably.Expectations/That/ThatGenericShould.BeSameAs.cs
@@ -16,9 +16,9 @@ public static partial class ThatGenericShould
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ConditionConstraint<object?>(
 					expected,
-					$"refer to {doNotPopulateThisValue} {Formatter.Format(expected)}",
+					$"refer to {doNotPopulateThisValue} {Formatter.Format(expected, FormattingOptions.MultipleLines)}",
 					(a, e) => ReferenceEquals(e, a),
-					(a, _) => $"found {Formatter.Format(a)}")),
+					(a, _) => $"found {Formatter.Format(a, FormattingOptions.MultipleLines)}")),
 			source);
 
 	/// <summary>
@@ -31,7 +31,7 @@ public static partial class ThatGenericShould
 		=> new(source.ExpectationBuilder
 				.AddConstraint(new ConditionConstraint<object?>(
 					unexpected,
-					$"not refer to {doNotPopulateThisValue} {Formatter.Format(unexpected)}",
+					$"not refer to {doNotPopulateThisValue} {Formatter.Format(unexpected, FormattingOptions.MultipleLines)}",
 					(a, e) => !ReferenceEquals(e, a),
 					(_, _) => "it did")),
 			source);

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -863,7 +863,7 @@ namespace Testably.Expectations.Formatting
     }
     public class FormattingOptions
     {
-        public static Testably.Expectations.Formatting.FormattingOptions Default { get; }
+        public static Testably.Expectations.Formatting.FormattingOptions MultipleLines { get; }
         public static Testably.Expectations.Formatting.FormattingOptions SingleLine { get; }
     }
 }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -863,7 +863,7 @@ namespace Testably.Expectations.Formatting
     }
     public class FormattingOptions
     {
-        public static Testably.Expectations.Formatting.FormattingOptions Default { get; }
+        public static Testably.Expectations.Formatting.FormattingOptions MultipleLines { get; }
         public static Testably.Expectations.Formatting.FormattingOptions SingleLine { get; }
     }
 }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -801,7 +801,7 @@ namespace Testably.Expectations.Formatting
     }
     public class FormattingOptions
     {
-        public static Testably.Expectations.Formatting.FormattingOptions Default { get; }
+        public static Testably.Expectations.Formatting.FormattingOptions MultipleLines { get; }
         public static Testably.Expectations.Formatting.FormattingOptions SingleLine { get; }
     }
 }

--- a/Tests/Testably.Expectations.Internal.Tests/ThatTests/Delegates/DelegateShould.ExecuteWithinTests.cs
+++ b/Tests/Testably.Expectations.Internal.Tests/ThatTests/Delegates/DelegateShould.ExecuteWithinTests.cs
@@ -38,7 +38,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             execute within 0:00.100,
-				             but it took 0:00.300.
+				             but it took 0:00.300
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -73,7 +73,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             execute within 0:00.100,
-				             but it took 0:00.300.
+				             but it took 0:00.300
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -116,7 +116,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             execute within 0:00.100,
-				             but it took 0:00.300.
+				             but it took 0:00.300
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -159,7 +159,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             execute within 0:00.100,
-				             but it took 0:00.300.
+				             but it took 0:00.300
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -201,7 +201,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             execute within 0:00.100,
-				             but it took 0:00.300.
+				             but it took 0:00.300
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -248,7 +248,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             execute within 0:00.100,
-				             but it took 0:00.300.
+				             but it took 0:00.300
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -289,7 +289,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             execute within 0:00.100,
-				             but it took 0:00.300.
+				             but it took 0:00.300
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -340,7 +340,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             execute within 0:00.100,
-				             but it took 0:00.300.
+				             but it took 0:00.300
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -364,7 +364,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             not execute within 0:00.500,
-				             but it took only 0:00.010.
+				             but it took only 0:00.010
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -399,7 +399,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             not execute within 0:00.500,
-				             but it took only 0:00.010.
+				             but it took only 0:00.010
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -438,7 +438,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             not execute within 0:00.500,
-				             but it took only 0:00.010.
+				             but it took only 0:00.010
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -481,7 +481,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             not execute within 0:00.500,
-				             but it took only 0:00.010.
+				             but it took only 0:00.010
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -522,7 +522,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             not execute within 0:00.500,
-				             but it took only 0:00.010.
+				             but it took only 0:00.010
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -565,7 +565,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             not execute within 0:00.500,
-				             but it took only 0:00.010.
+				             but it took only 0:00.010
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -609,7 +609,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             not execute within 0:00.500,
-				             but it took only 0:00.010.
+				             but it took only 0:00.010
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}
@@ -656,7 +656,7 @@ public sealed class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             not execute within 0:00.500,
-				             but it took only 0:00.010.
+				             but it took only 0:00.010
 				             """);
 			await That(stopwatch.IsRunning).Should().BeFalse();
 		}

--- a/Tests/Testably.Expectations.Tests/Core/BecauseTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/BecauseTests.cs
@@ -74,11 +74,6 @@ public class BecauseTests
 	[Fact]
 	public async Task WhenCombineWithAnd_ShouldApplyBecauseReasonOnlyOnPreviousConstraint()
 	{
-		string expectedMessage = """
-		                         Expected subject to
-		                         be True, because we only apply it to previous constraints and be False,
-		                         but found True.
-		                         """;
 		string because = "we only apply it to previous constraints";
 		bool subject = true;
 
@@ -87,7 +82,11 @@ public class BecauseTests
 				.And.BeFalse();
 
 		await That(Act).Should().ThrowException()
-			.WithMessage(expectedMessage);
+			.WithMessage("""
+			             Expected subject to
+			             be True, because we only apply it to previous constraints and be False,
+			             but found True
+			             """);
 	}
 
 	[Fact]
@@ -111,7 +110,7 @@ public class BecauseTests
 		string expectedMessage = """
 		                         Expected subject to
 		                         be False,
-		                         but found True.
+		                         but found True
 		                         """;
 
 		bool subject = true;

--- a/Tests/Testably.Expectations.Tests/Core/Nodes/AndNodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Nodes/AndNodeTests.cs
@@ -12,7 +12,7 @@ public sealed class AndNodeTests
 			.WithMessage("""
 			             Expected true to
 			             be False and be True,
-			             but found True.
+			             but found True
 			             """);
 	}
 
@@ -26,7 +26,7 @@ public sealed class AndNodeTests
 			.WithMessage("""
 			             Expected true to
 			             be True and be False,
-			             but found True.
+			             but found True
 			             """);
 	}
 
@@ -40,7 +40,7 @@ public sealed class AndNodeTests
 			.WithMessage("""
 			             Expected true to
 			             be False and imply False,
-			             but found True and it did not.
+			             but found True and it did not
 			             """);
 	}
 

--- a/Tests/Testably.Expectations.Tests/Core/Nodes/OrNodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Nodes/OrNodeTests.cs
@@ -30,7 +30,7 @@ public sealed class OrNodeTests
 			.WithMessage("""
 			             Expected true to
 			             be False or imply False,
-			             but found True and it did not.
+			             but found True and it did not
 			             """);
 	}
 

--- a/Tests/Testably.Expectations.Tests/Core/Nodes/PrecedenceTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Nodes/PrecedenceTests.cs
@@ -14,7 +14,7 @@ public sealed class PrecedenceTests
 				.WithMessage("""
 				             Expected true to
 				             be False and be True or be False,
-				             but found True.
+				             but found True
 				             """);
 		}
 
@@ -37,7 +37,7 @@ public sealed class PrecedenceTests
 				.WithMessage("""
 				             Expected true to
 				             be False or be True and be False,
-				             but found True.
+				             but found True
 				             """);
 		}
 
@@ -51,7 +51,7 @@ public sealed class PrecedenceTests
 				.WithMessage("""
 				             Expected true to
 				             be True and be False or be False,
-				             but found True.
+				             but found True
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/Core/Nodes/WhichNodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Nodes/WhichNodeTests.cs
@@ -23,7 +23,7 @@ public sealed class WhichNodeTests
 			                ↓ (actual)
 			               "foo"
 			               "bar"
-			                ↑ (expected).
+			                ↑ (expected)
 			             """);
 	}
 

--- a/Tests/Testably.Expectations.Tests/Formatting/DefaultFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Formatting/DefaultFormatterTests.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Expectations.Formatting;
-
-namespace Testably.Expectations.Tests.Formatting;
+﻿namespace Testably.Expectations.Tests.Formatting;
 
 public sealed class DefaultFormatterTests
 {

--- a/Tests/Testably.Expectations.Tests/Formatting/DefaultFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Formatting/DefaultFormatterTests.cs
@@ -27,7 +27,7 @@ public sealed class DefaultFormatterTests
 			Value = 2
 		};
 
-		string result = Formatter.Format(value, FormattingOptions.Default);
+		string result = Formatter.Format(value, FormattingOptions.MultipleLines);
 
 		await That(result).Should().Be("""
 		                               Dummy {
@@ -47,7 +47,7 @@ public sealed class DefaultFormatterTests
 		string expected = string.Join($"{Environment.NewLine}  ", values) + Environment.NewLine;
 		ClassWithToString subject = new(value);
 
-		string result = Formatter.Format(subject, FormattingOptions.Default);
+		string result = Formatter.Format(subject, FormattingOptions.MultipleLines);
 
 		await That(result).Should().Be(expected);
 	}

--- a/Tests/Testably.Expectations.Tests/Formatting/Formatters/BooleanFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Formatting/Formatters/BooleanFormatterTests.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Expectations.Formatting;
-
-namespace Testably.Expectations.Tests.Formatting.Formatters;
+﻿namespace Testably.Expectations.Tests.Formatting.Formatters;
 
 public sealed class BooleanFormatterTests
 {

--- a/Tests/Testably.Expectations.Tests/Formatting/Formatters/CollectionFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Formatting/Formatters/CollectionFormatterTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Tests.Formatting.Formatters;
 

--- a/Tests/Testably.Expectations.Tests/Formatting/Formatters/DateTimeFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Formatting/Formatters/DateTimeFormatterTests.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Expectations.Formatting;
-
-namespace Testably.Expectations.Tests.Formatting.Formatters;
+﻿namespace Testably.Expectations.Tests.Formatting.Formatters;
 
 public sealed class DateTimeFormatterTests
 {

--- a/Tests/Testably.Expectations.Tests/Formatting/Formatters/DateTimeOffsetFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Formatting/Formatters/DateTimeOffsetFormatterTests.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Expectations.Formatting;
-
-namespace Testably.Expectations.Tests.Formatting.Formatters;
+﻿namespace Testably.Expectations.Tests.Formatting.Formatters;
 
 public sealed class DateTimeOffsetFormatterTests
 {

--- a/Tests/Testably.Expectations.Tests/Formatting/Formatters/EnumFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Formatting/Formatters/EnumFormatterTests.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Expectations.Formatting;
-
-namespace Testably.Expectations.Tests.Formatting.Formatters;
+﻿namespace Testably.Expectations.Tests.Formatting.Formatters;
 
 public sealed class EnumFormatterTests
 {

--- a/Tests/Testably.Expectations.Tests/Formatting/Formatters/NumberFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Formatting/Formatters/NumberFormatterTests.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Expectations.Formatting;
-
-namespace Testably.Expectations.Tests.Formatting.Formatters;
+﻿namespace Testably.Expectations.Tests.Formatting.Formatters;
 
 public sealed class NumberFormatterTests
 {

--- a/Tests/Testably.Expectations.Tests/Formatting/Formatters/StringFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Formatting/Formatters/StringFormatterTests.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Expectations.Formatting;
-
-namespace Testably.Expectations.Tests.Formatting.Formatters;
+﻿namespace Testably.Expectations.Tests.Formatting.Formatters;
 
 public sealed class StringFormatterTests
 {

--- a/Tests/Testably.Expectations.Tests/Formatting/Formatters/TimeSpanFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Formatting/Formatters/TimeSpanFormatterTests.cs
@@ -1,5 +1,4 @@
 ﻿using Testably.Expectations.Extensions;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Tests.Formatting.Formatters;
 

--- a/Tests/Testably.Expectations.Tests/Formatting/Formatters/TypeFormatterTests.cs
+++ b/Tests/Testably.Expectations.Tests/Formatting/Formatters/TypeFormatterTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq.Expressions;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Tests.Formatting.Formatters;
 

--- a/Tests/Testably.Expectations.Tests/Options/StringMatcherTests.cs
+++ b/Tests/Testably.Expectations.Tests/Options/StringMatcherTests.cs
@@ -80,7 +80,7 @@ public class StringMatcherTests
 				                           ↓ (actual)
 				                "…-> Bob : Another authentication Request{nl}Alice <-- Bob :…"
 				                "…-> Bob : Invalid authentication Request{nl}Alice <-- Bob :…"
-				                           ↑ (expected).
+				                           ↑ (expected)
 				              """);
 		}
 
@@ -178,7 +178,7 @@ public class StringMatcherTests
 				                                ↓ (actual)
 				               "…is a long text that differs in between two words and has lot…"
 				               "…is a long text which differs in between two words and has…"
-				                                ↑ (expected).
+				                                ↑ (expected)
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/BoolShould.BeFalseTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/BoolShould.BeFalseTests.cs
@@ -27,7 +27,7 @@ public sealed partial class BoolShould
 				.WithMessage("""
 				             Expected subject to
 				             be False,
-				             but found True.
+				             but found True
 				             """);
 		}
 
@@ -43,7 +43,7 @@ public sealed partial class BoolShould
 				.WithMessage("""
 				             Expected subject to
 				             be False, because we want to test the failure,
-				             but found True.
+				             but found True
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/BoolShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/BoolShould.BeTests.cs
@@ -17,8 +17,8 @@ public sealed partial class BoolShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -36,8 +36,8 @@ public sealed partial class BoolShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected}, because {reason},
-				              but found {subject}.
+				              be {Formatter.Format(expected)}, because {reason},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -83,8 +83,8 @@ public sealed partial class BoolShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -102,8 +102,8 @@ public sealed partial class BoolShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected}, because {reason},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)}, because {reason},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/BoolShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/BoolShould.BeTests.cs
@@ -18,7 +18,7 @@ public sealed partial class BoolShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -37,7 +37,7 @@ public sealed partial class BoolShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)}, because {reason},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -84,7 +84,7 @@ public sealed partial class BoolShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -103,7 +103,7 @@ public sealed partial class BoolShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)}, because {reason},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/BoolShould.BeTrueTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/BoolShould.BeTrueTests.cs
@@ -16,7 +16,7 @@ public sealed partial class BoolShould
 				.WithMessage("""
 				             Expected subject to
 				             be True,
-				             but found False.
+				             but found False
 				             """);
 		}
 
@@ -32,7 +32,7 @@ public sealed partial class BoolShould
 				.WithMessage("""
 				             Expected subject to
 				             be True, because we want to test the failure,
-				             but found False.
+				             but found False
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/BoolShould.ImplyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/BoolShould.ImplyTests.cs
@@ -17,7 +17,7 @@ public sealed partial class BoolShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected antecedent to
-				              imply {consequent}, because we want to test the failure,
+				              imply {Formatter.Format(consequent)}, because we want to test the failure,
 				              but it did not.
 				              """);
 		}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/BoolShould.ImplyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/BoolShould.ImplyTests.cs
@@ -18,7 +18,7 @@ public sealed partial class BoolShould
 				.WithMessage($"""
 				              Expected antecedent to
 				              imply {Formatter.Format(consequent)}, because we want to test the failure,
-				              but it did not.
+				              but it did not
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeFalseTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeFalseTests.cs
@@ -27,7 +27,7 @@ public sealed partial class NullableBoolShould
 				.WithMessage($"""
 				              Expected subject to
 				              be False, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}
@@ -46,7 +46,7 @@ public sealed partial class NullableBoolShould
 				.WithMessage("""
 				             Expected subject to
 				             not be False, because we want to test the failure,
-				             but found False.
+				             but found False
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeFalseTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeFalseTests.cs
@@ -27,7 +27,7 @@ public sealed partial class NullableBoolShould
 				.WithMessage($"""
 				              Expected subject to
 				              be False, because we want to test the failure,
-				              but found {subject?.ToString() ?? "<null>"}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeNullTests.cs
@@ -27,7 +27,7 @@ public sealed partial class NullableBoolShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>, because we want to test the failure,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeNullTests.cs
@@ -27,7 +27,7 @@ public sealed partial class NullableBoolShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}
@@ -46,7 +46,7 @@ public sealed partial class NullableBoolShould
 				.WithMessage("""
 				             Expected subject to
 				             not be <null>, because we want to test the failure,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeTests.cs
@@ -19,8 +19,8 @@ public sealed partial class NullableBoolShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected?.ToString() ?? "<null>"},
-				              but found {subject?.ToString() ?? "<null>"}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -70,8 +70,8 @@ public sealed partial class NullableBoolShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected?.ToString() ?? "<null>"},
-				              but found {subject?.ToString() ?? "<null>"}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeTests.cs
@@ -20,7 +20,7 @@ public sealed partial class NullableBoolShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -71,7 +71,7 @@ public sealed partial class NullableBoolShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeTrueTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeTrueTests.cs
@@ -16,7 +16,7 @@ public sealed partial class NullableBoolShould
 				.WithMessage($"""
 				              Expected subject to
 				              be True, because we want to test the failure,
-				              but found {subject?.ToString() ?? "<null>"}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeTrueTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Booleans/NullableBoolShould.BeTrueTests.cs
@@ -16,7 +16,7 @@ public sealed partial class NullableBoolShould
 				.WithMessage($"""
 				              Expected subject to
 				              be True, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -57,7 +57,7 @@ public sealed partial class NullableBoolShould
 				.WithMessage("""
 				             Expected subject to
 				             not be True, because we want to test the failure,
-				             but found True.
+				             but found True
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateOnlyShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateOnlyShould.BeTests.cs
@@ -17,8 +17,8 @@ public sealed partial class DateOnlyShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected:O},
-				              but found {subject:O}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -61,8 +61,8 @@ public sealed partial class DateOnlyShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected:O},
-				              but found {subject:O}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateOnlyShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateOnlyShould.BeTests.cs
@@ -18,7 +18,7 @@ public sealed partial class DateOnlyShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -62,7 +62,7 @@ public sealed partial class DateOnlyShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeOffsetShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeOffsetShould.BeTests.cs
@@ -16,8 +16,8 @@ public sealed partial class DateTimeOffsetShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected:O},
-				              but found {subject:O}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -60,8 +60,8 @@ public sealed partial class DateTimeOffsetShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected:O},
-				              but found {subject:O}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeOffsetShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeOffsetShould.BeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class DateTimeOffsetShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -61,7 +61,7 @@ public sealed partial class DateTimeOffsetShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeAfterTests.cs
@@ -17,7 +17,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be after <null>,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -67,8 +67,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be after {expected:O},
-				              but found {subject:O}.
+				              be after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -85,8 +85,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be after {expected:O}, because we want to test the failure,
-				              but found {subject:O}.
+				              be after {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -115,8 +115,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be after {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -134,8 +134,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be after {expected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              be after {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -191,8 +191,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be after {unexpected:O},
-				              but found {subject:O}.
+				              not be after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -234,7 +234,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be after <null>, because we want to test the failure,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -252,8 +252,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be after {unexpected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              not be after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -270,8 +270,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be after {unexpected:O} ± 0:03,
-				              but found {subject:O}.
+				              not be after {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeAfterTests.cs
@@ -17,7 +17,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be after <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -34,7 +34,7 @@ public sealed partial class DateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             be after 9999-12-31T23:59:59.9999999,
-				             but found 9999-12-31T23:59:59.9999999.
+				             but found 9999-12-31T23:59:59.9999999
 				             """);
 		}
 
@@ -51,7 +51,7 @@ public sealed partial class DateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             be after 0001-01-01T00:00:00.0000000,
-				             but found 0001-01-01T00:00:00.0000000.
+				             but found 0001-01-01T00:00:00.0000000
 				             """);
 		}
 
@@ -68,7 +68,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be after {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -86,7 +86,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be after {Formatter.Format(expected)}, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -116,7 +116,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be after {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -135,7 +135,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be after {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -192,7 +192,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be after {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -234,7 +234,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be after <null>, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -253,7 +253,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -271,7 +271,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be after {Formatter.Format(unexpected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeBeforeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be before <null>,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -67,8 +67,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be before {expected:O},
-				              but found {subject:O}.
+				              be before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -84,8 +84,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be before {expected:O},
-				              but found {subject:O}.
+				              be before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -114,8 +114,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be before {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -132,8 +132,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be before {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -189,8 +189,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be before {unexpected:O},
-				              but found {subject:O}.
+				              not be before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -232,7 +232,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be before <null>, because we want to test the failure,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -250,8 +250,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be before {unexpected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              not be before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -268,8 +268,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be before {unexpected:O} ± 0:03,
-				              but found {subject:O}.
+				              not be before {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeBeforeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be before <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -34,7 +34,7 @@ public sealed partial class DateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             be before 9999-12-31T23:59:59.9999999,
-				             but found 9999-12-31T23:59:59.9999999.
+				             but found 9999-12-31T23:59:59.9999999
 				             """);
 		}
 
@@ -51,7 +51,7 @@ public sealed partial class DateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             be before 0001-01-01T00:00:00.0000000,
-				             but found 0001-01-01T00:00:00.0000000.
+				             but found 0001-01-01T00:00:00.0000000
 				             """);
 		}
 
@@ -68,7 +68,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be before {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -85,7 +85,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be before {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -115,7 +115,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be before {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -133,7 +133,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be before {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -190,7 +190,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be before {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -232,7 +232,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be before <null>, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -251,7 +251,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -269,7 +269,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be before {Formatter.Format(unexpected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeOnOrAfterTests.cs
@@ -17,7 +17,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or after <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -58,7 +58,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or after {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -100,7 +100,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or after {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -118,7 +118,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or after {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -151,7 +151,7 @@ public sealed partial class DateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             not be on or after 9999-12-31T23:59:59.9999999,
-				             but found 9999-12-31T23:59:59.9999999.
+				             but found 9999-12-31T23:59:59.9999999
 				             """);
 		}
 
@@ -168,7 +168,7 @@ public sealed partial class DateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             not be on or after 0001-01-01T00:00:00.0000000,
-				             but found 0001-01-01T00:00:00.0000000.
+				             but found 0001-01-01T00:00:00.0000000
 				             """);
 		}
 
@@ -185,7 +185,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or after {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -202,7 +202,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or after {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -232,7 +232,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or after <null>, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -251,7 +251,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -269,7 +269,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or after {Formatter.Format(unexpected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeOnOrAfterTests.cs
@@ -17,7 +17,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or after <null>,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -57,8 +57,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be on or after {expected:O},
-				              but found {subject:O}.
+				              be on or after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -99,8 +99,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be on or after {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be on or after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -117,8 +117,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be on or after {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be on or after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -184,8 +184,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or after {unexpected:O},
-				              but found {subject:O}.
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -201,8 +201,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or after {unexpected:O},
-				              but found {subject:O}.
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -232,7 +232,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or after <null>, because we want to test the failure,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -250,8 +250,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or after {unexpected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              not be on or after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -268,8 +268,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or after {unexpected:O} ± 0:03,
-				              but found {subject:O}.
+				              not be on or after {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeOnOrBeforeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or before <null>,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -57,8 +57,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be on or before {expected:O},
-				              but found {subject:O}.
+				              be on or before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -99,8 +99,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be on or before {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be on or before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -117,8 +117,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be on or before {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be on or before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -184,8 +184,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or before {unexpected:O},
-				              but found {subject:O}.
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -201,8 +201,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or before {unexpected:O},
-				              but found {subject:O}.
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -232,7 +232,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or before <null>, because we want to test the failure,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -250,8 +250,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or before {unexpected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              not be on or before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -268,8 +268,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or before {unexpected:O} ± 0:03,
-				              but found {subject:O}.
+				              not be on or before {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeOnOrBeforeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or before <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -58,7 +58,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or before {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -100,7 +100,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or before {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -118,7 +118,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or before {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -151,7 +151,7 @@ public sealed partial class DateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             not be on or before 9999-12-31T23:59:59.9999999,
-				             but found 9999-12-31T23:59:59.9999999.
+				             but found 9999-12-31T23:59:59.9999999
 				             """);
 		}
 
@@ -168,7 +168,7 @@ public sealed partial class DateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             not be on or before 0001-01-01T00:00:00.0000000,
-				             but found 0001-01-01T00:00:00.0000000.
+				             but found 0001-01-01T00:00:00.0000000
 				             """);
 		}
 
@@ -185,7 +185,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or before {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -202,7 +202,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or before {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -232,7 +232,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or before <null>, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -251,7 +251,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -269,7 +269,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or before {Formatter.Format(unexpected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeTests.cs
@@ -41,7 +41,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)}, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -83,7 +83,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)}, because we also test the kind property,
-				              but it differed in the Kind property.
+				              but it differed in the Kind property
 				              """);
 		}
 
@@ -115,7 +115,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -148,7 +148,7 @@ public sealed partial class DateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             not be 9999-12-31T23:59:59.9999999, because we want to test the failure,
-				             but found 9999-12-31T23:59:59.9999999.
+				             but found 9999-12-31T23:59:59.9999999
 				             """);
 		}
 
@@ -166,7 +166,7 @@ public sealed partial class DateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             not be 0001-01-01T00:00:00.0000000, because we want to test the failure,
-				             but found 0001-01-01T00:00:00.0000000.
+				             but found 0001-01-01T00:00:00.0000000
 				             """);
 		}
 
@@ -196,7 +196,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)}, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -254,7 +254,7 @@ public sealed partial class DateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateTimeShould.BeTests.cs
@@ -40,8 +40,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected:O}, because we want to test the failure,
-				              but found {subject:O}.
+				              be {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -82,7 +82,7 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected:O}, because we also test the kind property,
+				              be {Formatter.Format(expected)}, because we also test the kind property,
 				              but it differed in the Kind property.
 				              """);
 		}
@@ -114,8 +114,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              be {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -195,8 +195,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected:O}, because we want to test the failure,
-				              but found {subject:O}.
+				              not be {Formatter.Format(unexpected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -253,8 +253,8 @@ public sealed partial class DateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {expected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              not be {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeAfterTests.cs
@@ -17,7 +17,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be after <null>,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -67,8 +67,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be after {expected:O},
-				              but found {subject:O}.
+				              be after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -85,8 +85,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be after {expected:O}, because we want to test the failure,
-				              but found {subject:O}.
+				              be after {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -115,8 +115,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be after {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -134,8 +134,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be after {expected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              be after {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -191,8 +191,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be after {unexpected:O},
-				              but found {subject:O}.
+				              not be after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -234,7 +234,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be after <null>, because we want to test the failure,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -252,8 +252,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be after {unexpected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              not be after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -270,8 +270,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be after {unexpected:O} ± 0:03,
-				              but found {subject:O}.
+				              not be after {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeAfterTests.cs
@@ -17,7 +17,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be after <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -34,7 +34,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             be after 9999-12-31T23:59:59.9999999,
-				             but found 9999-12-31T23:59:59.9999999.
+				             but found 9999-12-31T23:59:59.9999999
 				             """);
 		}
 
@@ -51,7 +51,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             be after 0001-01-01T00:00:00.0000000,
-				             but found 0001-01-01T00:00:00.0000000.
+				             but found 0001-01-01T00:00:00.0000000
 				             """);
 		}
 
@@ -68,7 +68,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be after {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -86,7 +86,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be after {Formatter.Format(expected)}, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -116,7 +116,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be after {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -135,7 +135,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be after {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -192,7 +192,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be after {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -234,7 +234,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be after <null>, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -253,7 +253,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -271,7 +271,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be after {Formatter.Format(unexpected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeBeforeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be before <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -34,7 +34,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             be before 9999-12-31T23:59:59.9999999,
-				             but found 9999-12-31T23:59:59.9999999.
+				             but found 9999-12-31T23:59:59.9999999
 				             """);
 		}
 
@@ -51,7 +51,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             be before 0001-01-01T00:00:00.0000000,
-				             but found 0001-01-01T00:00:00.0000000.
+				             but found 0001-01-01T00:00:00.0000000
 				             """);
 		}
 
@@ -68,7 +68,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be before {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -85,7 +85,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be before {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -115,7 +115,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be before {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -133,7 +133,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be before {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -190,7 +190,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be before {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -232,7 +232,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be before <null>, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -251,7 +251,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -269,7 +269,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be before {Formatter.Format(unexpected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeBeforeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be before <null>,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -67,8 +67,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be before {expected:O},
-				              but found {subject:O}.
+				              be before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -84,8 +84,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be before {expected:O},
-				              but found {subject:O}.
+				              be before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -114,8 +114,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be before {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -132,8 +132,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be before {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -189,8 +189,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be before {unexpected:O},
-				              but found {subject:O}.
+				              not be before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -232,7 +232,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be before <null>, because we want to test the failure,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -250,8 +250,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be before {unexpected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              not be before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -268,8 +268,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be before {unexpected:O} ± 0:03,
-				              but found {subject:O}.
+				              not be before {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeOnOrAfterTests.cs
@@ -17,7 +17,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or after <null>,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -57,8 +57,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be on or after {expected:O},
-				              but found {subject:O}.
+				              be on or after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -99,8 +99,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be on or after {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be on or after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -117,8 +117,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be on or after {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be on or after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -184,8 +184,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or after {unexpected:O},
-				              but found {subject:O}.
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -201,8 +201,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or after {unexpected:O},
-				              but found {subject:O}.
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -232,7 +232,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or after <null>, because we want to test the failure,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -250,8 +250,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or after {unexpected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              not be on or after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -268,8 +268,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or after {unexpected:O} ± 0:03,
-				              but found {subject:O}.
+				              not be on or after {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeOnOrAfterTests.cs
@@ -17,7 +17,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or after <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -58,7 +58,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or after {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -100,7 +100,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or after {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -118,7 +118,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or after {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -151,7 +151,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             not be on or after 9999-12-31T23:59:59.9999999,
-				             but found 9999-12-31T23:59:59.9999999.
+				             but found 9999-12-31T23:59:59.9999999
 				             """);
 		}
 
@@ -168,7 +168,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             not be on or after 0001-01-01T00:00:00.0000000,
-				             but found 0001-01-01T00:00:00.0000000.
+				             but found 0001-01-01T00:00:00.0000000
 				             """);
 		}
 
@@ -185,7 +185,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or after {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -202,7 +202,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or after {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -232,7 +232,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or after <null>, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -251,7 +251,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -269,7 +269,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or after {Formatter.Format(unexpected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeOnOrBeforeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or before <null>,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -57,8 +57,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be on or before {expected:O},
-				              but found {subject:O}.
+				              be on or before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -99,8 +99,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be on or before {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be on or before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -117,8 +117,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be on or before {expected:O} ± 0:03,
-				              but found {subject:O}.
+				              be on or before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -184,8 +184,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or before {unexpected:O},
-				              but found {subject:O}.
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -201,8 +201,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or before {unexpected:O},
-				              but found {subject:O}.
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -232,7 +232,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or before <null>, because we want to test the failure,
-				              but found {subject:O}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -250,8 +250,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or before {unexpected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              not be on or before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -268,8 +268,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be on or before {unexpected:O} ± 0:03,
-				              but found {subject:O}.
+				              not be on or before {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeOnOrBeforeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or before <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -58,7 +58,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or before {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -100,7 +100,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or before {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -118,7 +118,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be on or before {Formatter.Format(expected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -151,7 +151,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             not be on or before 9999-12-31T23:59:59.9999999,
-				             but found 9999-12-31T23:59:59.9999999.
+				             but found 9999-12-31T23:59:59.9999999
 				             """);
 		}
 
@@ -168,7 +168,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             not be on or before 0001-01-01T00:00:00.0000000,
-				             but found 0001-01-01T00:00:00.0000000.
+				             but found 0001-01-01T00:00:00.0000000
 				             """);
 		}
 
@@ -185,7 +185,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or before {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -202,7 +202,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or before {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -232,7 +232,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or before <null>, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -251,7 +251,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -269,7 +269,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be on or before {Formatter.Format(unexpected)} ± 0:03,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeTests.cs
@@ -53,7 +53,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)}, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -71,7 +71,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)}, because we also test the kind property,
-				              but it differed in the Kind property.
+				              but it differed in the Kind property
 				              """);
 		}
 
@@ -103,7 +103,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -136,7 +136,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             not be 9999-12-31T23:59:59.9999999, because we want to test the failure,
-				             but found 9999-12-31T23:59:59.9999999.
+				             but found 9999-12-31T23:59:59.9999999
 				             """);
 		}
 
@@ -154,7 +154,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage("""
 				             Expected subject to
 				             not be 0001-01-01T00:00:00.0000000, because we want to test the failure,
-				             but found 0001-01-01T00:00:00.0000000.
+				             but found 0001-01-01T00:00:00.0000000
 				             """);
 		}
 
@@ -184,7 +184,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)}, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -242,7 +242,7 @@ public sealed partial class NullableDateTimeShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateTimeShould.BeTests.cs
@@ -52,8 +52,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected:O}, because we want to test the failure,
-				              but found {subject:O}.
+				              be {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -70,7 +70,7 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected:O}, because we also test the kind property,
+				              be {Formatter.Format(expected)}, because we also test the kind property,
 				              but it differed in the Kind property.
 				              """);
 		}
@@ -102,8 +102,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              be {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -183,8 +183,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected:O}, because we want to test the failure,
-				              but found {subject:O}.
+				              not be {Formatter.Format(unexpected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -241,8 +241,8 @@ public sealed partial class NullableDateTimeShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {expected:O} ± 0:03, because we want to test the failure,
-				              but found {subject:O}.
+				              not be {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeOnlyShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeOnlyShould.BeTests.cs
@@ -18,7 +18,7 @@ public sealed partial class TimeOnlyShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -62,7 +62,7 @@ public sealed partial class TimeOnlyShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeOnlyShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeOnlyShould.BeTests.cs
@@ -17,8 +17,8 @@ public sealed partial class TimeOnlyShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected:O},
-				              but found {subject:O}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -61,8 +61,8 @@ public sealed partial class TimeOnlyShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected:O},
-				              but found {subject:O}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeSpanShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeSpanShould.BeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class TimeSpanShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -61,7 +61,7 @@ public sealed partial class TimeSpanShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeSpanShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeSpanShould.BeTests.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Expectations.Formatting;
-
-namespace Testably.Expectations.Tests.ThatTests.Chronology;
+﻿namespace Testably.Expectations.Tests.ThatTests.Chronology;
 
 public sealed partial class TimeSpanShould
 {

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AllTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AllTests.cs
@@ -24,7 +24,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             all satisfy "x => x < 6",
-				             but could not verify, because it was cancelled early.
+				             but could not verify, because it was cancelled early
 				             """);
 		}
 
@@ -52,7 +52,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have all items equal to 1,
-				             but not all items were equal.
+				             but not all items were equal
 				             """);
 		}
 
@@ -68,7 +68,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have all items equal to 1,
-				             but not all items were equal.
+				             but not all items were equal
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AtLeastTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AtLeastTests.cs
@@ -70,7 +70,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have at least 5 items equal to 1,
-				             but only 4 of 7 items were equal.
+				             but only 4 of 7 items were equal
 				             """);
 		}
 
@@ -86,7 +86,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have at least 5 items equivalent to 1,
-				             but only 4 of 7 items were equivalent.
+				             but only 4 of 7 items were equivalent
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AtMostTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.AtMostTests.cs
@@ -25,7 +25,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             at most 8 satisfy "x => x < 6",
-				             but could not verify, because it was cancelled early.
+				             but could not verify, because it was cancelled early
 				             """);
 		}
 
@@ -53,7 +53,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have at most 1 item equal to 1,
-				             but at least 2 items were equal.
+				             but at least 2 items were equal
 				             """);
 		}
 
@@ -80,7 +80,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have at most 3 items equal to 1,
-				             but at least 4 items were equal.
+				             but at least 4 items were equal
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BeEmptyTests.cs
@@ -24,7 +24,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             be empty,
-				             but could not evaluate it, because it was already cancelled.
+				             but could not evaluate it, because it was already cancelled
 				             """);
 		}
 
@@ -43,7 +43,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             be empty,
-				             but found [0, 1, 2, 3, 4].
+				             but found [0, 1, 2, 3, 4]
 				             """);
 		}
 
@@ -61,7 +61,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             be empty,
-				             but found [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, …].
+				             but found [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, …]
 				             """);
 		}
 
@@ -77,7 +77,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             be empty,
-				             but found [1, 1, 2].
+				             but found [1, 1, 2]
 				             """);
 		}
 
@@ -118,7 +118,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             not be empty,
-				             but it was.
+				             but it was
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BetweenTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.BetweenTests.cs
@@ -25,7 +25,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             between 6 and 8 satisfy "x => x < 6",
-				             but could not verify, because it was cancelled early.
+				             but could not verify, because it was cancelled early
 				             """);
 		}
 
@@ -53,7 +53,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have between 0 and 1 items equal to 1,
-				             but at least 2 items were equal.
+				             but at least 2 items were equal
 				             """);
 		}
 
@@ -80,7 +80,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have between 3 and 4 items equal to 2,
-				             but only 2 items were equal.
+				             but only 2 items were equal
 				             """);
 		}
 
@@ -96,7 +96,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have between 1 and 3 items equal to 1,
-				             but at least 4 items were equal.
+				             but at least 4 items were equal
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.NoneTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/AsyncEnumerableShould.NoneTests.cs
@@ -25,7 +25,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             none satisfy "x => x < 0",
-				             but could not verify, because it was cancelled early.
+				             but could not verify, because it was cancelled early
 				             """);
 		}
 
@@ -53,7 +53,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have no items equal to 5,
-				             but at least one items were equal.
+				             but at least one items were equal
 				             """);
 		}
 
@@ -69,7 +69,7 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have no items equal to 1,
-				             but at least one items were equal.
+				             but at least one items were equal
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.AllTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.AllTests.cs
@@ -16,7 +16,7 @@ public sealed partial class CollectionShould
 				.WithMessage("""
 				             Expected subject to
 				             have all items equal to 1,
-				             but not all of 7 items were equal.
+				             but not all of 7 items were equal
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.AtLeastTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.AtLeastTests.cs
@@ -27,7 +27,7 @@ public sealed partial class CollectionShould
 				.WithMessage("""
 				             Expected subject to
 				             have at least 5 items equal to 1,
-				             but only 4 of 7 items were equal.
+				             but only 4 of 7 items were equal
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.AtMostTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.AtMostTests.cs
@@ -27,7 +27,7 @@ public sealed partial class CollectionShould
 				.WithMessage("""
 				             Expected subject to
 				             have at most 3 items equal to 1,
-				             but at least 4 of 7 items were equal.
+				             but at least 4 of 7 items were equal
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.BeEmptyTests.cs
@@ -16,7 +16,7 @@ public sealed partial class CollectionShould
 				.WithMessage("""
 				             Expected subject to
 				             be empty,
-				             but found [1, 1, 2].
+				             but found [1, 1, 2]
 				             """);
 		}
 
@@ -59,7 +59,7 @@ public sealed partial class CollectionShould
 				.WithMessage("""
 				             Expected subject to
 				             not be empty,
-				             but it was.
+				             but it was
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.BetweenTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.BetweenTests.cs
@@ -27,7 +27,7 @@ public sealed partial class CollectionShould
 				.WithMessage("""
 				             Expected subject to
 				             have between 3 and 4 items equal to 2,
-				             but only 2 items were equal.
+				             but only 2 items were equal
 				             """);
 		}
 
@@ -43,7 +43,7 @@ public sealed partial class CollectionShould
 				.WithMessage("""
 				             Expected subject to
 				             have between 1 and 3 items equal to 1,
-				             but at least 4 of 7 items were equal.
+				             but at least 4 of 7 items were equal
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.ContainTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.ContainTests.cs
@@ -18,7 +18,7 @@ public sealed partial class CollectionShould
 				.WithMessage($"""
 				              Expected subject to
 				              contain {Formatter.Format(expected)},
-				              but found [{string.Join(", ", subject.Select(s => Formatter.Format(s)))}].
+				              but found [{string.Join(", ", subject.Select(s => Formatter.Format(s)))}]
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.ContainTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.ContainTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Testably.Expectations.Tests.ThatTests.Collections;
 
@@ -16,8 +17,8 @@ public sealed partial class CollectionShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              contain "{expected}",
-				              but found ["{string.Join("\", \"", subject)}"].
+				              contain {Formatter.Format(expected)},
+				              but found [{string.Join(", ", subject.Select(s => Formatter.Format(s)))}].
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.NoneTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/CollectionShould.NoneTests.cs
@@ -16,7 +16,7 @@ public sealed partial class CollectionShould
 				.WithMessage("""
 				             Expected subject to
 				             have no items equal to 1,
-				             but at least one items were equal.
+				             but at least one items were equal
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.AllTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.AllTests.cs
@@ -23,7 +23,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             all satisfy "x => x < 6",
-				             but could not verify, because it was cancelled early.
+				             but could not verify, because it was cancelled early
 				             """);
 		}
 
@@ -51,7 +51,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have all items equal to 1,
-				             but not all items were equal.
+				             but not all items were equal
 				             """);
 		}
 
@@ -67,7 +67,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have all items equal to 1,
-				             but not all items were equal.
+				             but not all items were equal
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.AtLeastTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.AtLeastTests.cs
@@ -69,7 +69,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have at least 5 items equal to 1,
-				             but only 4 of 7 items were equal.
+				             but only 4 of 7 items were equal
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.AtMostTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.AtMostTests.cs
@@ -24,7 +24,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             at most 8 satisfy "x => x < 6",
-				             but could not verify, because it was cancelled early.
+				             but could not verify, because it was cancelled early
 				             """);
 		}
 
@@ -52,7 +52,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have at most 1 item equal to 1,
-				             but at least 2 items were equal.
+				             but at least 2 items were equal
 				             """);
 		}
 
@@ -79,7 +79,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have at most 3 items equal to 1,
-				             but at least 4 items were equal.
+				             but at least 4 items were equal
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.BeEmptyTests.cs
@@ -20,7 +20,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             be empty,
-				             but found [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, …].
+				             but found [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, …]
 				             """);
 		}
 
@@ -36,7 +36,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             be empty,
-				             but found [1, 1, 2].
+				             but found [1, 1, 2]
 				             """);
 		}
 
@@ -100,7 +100,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             not be empty,
-				             but it was.
+				             but it was
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.BetweenTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.BetweenTests.cs
@@ -24,7 +24,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             between 6 and 8 satisfy "x => x < 6",
-				             but could not verify, because it was cancelled early.
+				             but could not verify, because it was cancelled early
 				             """);
 		}
 
@@ -52,7 +52,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have between 0 and 1 items equal to 1,
-				             but at least 2 items were equal.
+				             but at least 2 items were equal
 				             """);
 		}
 
@@ -79,7 +79,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have between 3 and 4 items equal to 2,
-				             but only 2 items were equal.
+				             but only 2 items were equal
 				             """);
 		}
 
@@ -95,7 +95,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have between 1 and 3 items equal to 1,
-				             but at least 4 items were equal.
+				             but at least 4 items were equal
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.ContainTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.ContainTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Testably.Expectations.Tests.TestHelpers;
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -55,8 +56,8 @@ public sealed partial class EnumerableShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              contain "{expected}",
-				              but found ["{string.Join("\", \"", subject)}"].
+				              contain {Formatter.Format(expected)},
+				              but found [{string.Join(", ", subject.Select(s => Formatter.Format(s)))}].
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.ContainTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.ContainTests.cs
@@ -57,7 +57,7 @@ public sealed partial class EnumerableShould
 				.WithMessage($"""
 				              Expected subject to
 				              contain {Formatter.Format(expected)},
-				              but found [{string.Join(", ", subject.Select(s => Formatter.Format(s)))}].
+				              but found [{string.Join(", ", subject.Select(s => Formatter.Format(s)))}]
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.NoneTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/EnumerableShould.NoneTests.cs
@@ -24,7 +24,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             none satisfy "x => x < 0",
-				             but could not verify, because it was cancelled early.
+				             but could not verify, because it was cancelled early
 				             """);
 		}
 
@@ -52,7 +52,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have no items equal to 5,
-				             but at least one items were equal.
+				             but at least one items were equal
 				             """);
 		}
 
@@ -68,7 +68,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             have no items equal to 1,
-				             but at least one items were equal.
+				             but at least one items were equal
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiableCollectionItems.AreEquivalentTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiableCollectionItems.AreEquivalentTests.cs
@@ -24,7 +24,7 @@ public sealed partial class QuantifiableCollectionItems
 				.WithMessage("""
 				             Expected subject to
 				             have all items equivalent to expected,
-				             but not all of 4 items were equivalent.
+				             but not all of 4 items were equivalent
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiedCollectionResult.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Collections/QuantifiedCollectionResult.BeTests.cs
@@ -21,7 +21,7 @@ public sealed partial class QuantifiedCollectionResult
 				.WithMessage("""
 				             Expected subject to
 				             have all items of type MyClass,
-				             but not all of 3 items were.
+				             but not all of 3 items were
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ExecuteWithinTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ExecuteWithinTests.cs
@@ -20,7 +20,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              execute within 0:00.500,
 				              but it did throw a MyException:
-				                {nameof(WhenActionThrowsAnException_ShouldFailWithDescriptiveMessage)}.
+				                {nameof(WhenActionThrowsAnException_ShouldFailWithDescriptiveMessage)}
 				              """);
 		}
 
@@ -37,7 +37,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              execute within 0:00.500,
 				              but it did throw a MyException:
-				                {nameof(WhenFuncTaskThrowsAnException_ShouldFailWithDescriptiveMessage)}.
+				                {nameof(WhenFuncTaskThrowsAnException_ShouldFailWithDescriptiveMessage)}
 				              """);
 		}
 
@@ -54,7 +54,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              execute within 0:00.500,
 				              but it did throw a MyException:
-				                {nameof(WhenFuncTaskValueThrowsAnException_ShouldFailWithDescriptiveMessage)}.
+				                {nameof(WhenFuncTaskValueThrowsAnException_ShouldFailWithDescriptiveMessage)}
 				              """);
 		}
 
@@ -71,7 +71,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              execute within 0:00.500,
 				              but it did throw a MyException:
-				                {nameof(WhenFuncValueThrowsAnException_ShouldFailWithDescriptiveMessage)}.
+				                {nameof(WhenFuncValueThrowsAnException_ShouldFailWithDescriptiveMessage)}
 				              """);
 		}
 
@@ -88,7 +88,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              execute within 0:00.500,
 				              but it did throw a MyException:
-				                {nameof(WhenTaskThrowsAnException_ShouldFailWithDescriptiveMessage)}.
+				                {nameof(WhenTaskThrowsAnException_ShouldFailWithDescriptiveMessage)}
 				              """);
 		}
 
@@ -105,7 +105,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              execute within 0:00.500,
 				              but it did throw a MyException:
-				                {nameof(WhenTaskValueThrowsAnException_ShouldFailWithDescriptiveMessage)}.
+				                {nameof(WhenTaskValueThrowsAnException_ShouldFailWithDescriptiveMessage)}
 				              """);
 		}
 
@@ -123,7 +123,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              execute within 0:00.500,
 				              but it did throw a MyException:
-				                {nameof(WhenValueTaskThrowsAnException_ShouldFailWithDescriptiveMessage)}.
+				                {nameof(WhenValueTaskThrowsAnException_ShouldFailWithDescriptiveMessage)}
 				              """);
 		}
 
@@ -143,7 +143,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              execute within 0:00.500,
 				              but it did throw a MyException:
-				                {nameof(WhenValueTaskValueThrowsAnException_ShouldFailWithDescriptiveMessage)}.
+				                {nameof(WhenValueTaskValueThrowsAnException_ShouldFailWithDescriptiveMessage)}
 				              """);
 		}
 #endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.NotThrowTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.NotThrowTests.cs
@@ -30,7 +30,7 @@ public sealed partial class DelegateShould
 				              Expected action to
 				              not throw any exception,
 				              but it did throw a CustomException:
-				                {message}.
+				                {message}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.OnlyIfTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.OnlyIfTests.cs
@@ -60,7 +60,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected action to
 				             not throw any exception,
-				             but it did throw an Exception.
+				             but it did throw an Exception
 				             """);
 		}
 
@@ -87,7 +87,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected action to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowExactlyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowExactlyTests.cs
@@ -42,7 +42,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected action to
 				             throw exactly a CustomException,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 
@@ -61,7 +61,7 @@ public sealed partial class DelegateShould
 				              Expected action to
 				              throw exactly a CustomException,
 				              but it did throw an OtherException:
-				                {message}.
+				                {message}
 				              """);
 		}
 
@@ -80,7 +80,7 @@ public sealed partial class DelegateShould
 				              Expected action to
 				              throw exactly a CustomException,
 				              but it did throw a SubCustomException:
-				                {message}.
+				                {message}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowExceptionTests.cs
@@ -39,7 +39,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected action to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowTests.cs
@@ -42,7 +42,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected action to
 				             throw a CustomException,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 
@@ -61,7 +61,7 @@ public sealed partial class DelegateShould
 				              Expected action to
 				              throw a CustomException,
 				              but it did throw an OtherException:
-				                {message}.
+				                {message}
 				              """);
 		}
 
@@ -92,7 +92,7 @@ public sealed partial class DelegateShould
 				              Expected action to
 				              throw a SubCustomException,
 				              but it did throw a CustomException:
-				                {message}.
+				                {message}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.cs
@@ -66,7 +66,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 
@@ -83,7 +83,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              not throw any exception,
 				              but it did throw a MyException:
-				                {nameof(ShouldSupportDelegate_Action_WhenThrown)}.
+				                {nameof(ShouldSupportDelegate_Action_WhenThrown)}
 				              """);
 		}
 
@@ -114,7 +114,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 
@@ -131,7 +131,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              not throw any exception,
 				              but it did throw a MyException:
-				                {nameof(ShouldSupportDelegate_Action_WithCancellationToken_WhenThrown)}.
+				                {nameof(ShouldSupportDelegate_Action_WithCancellationToken_WhenThrown)}
 				              """);
 		}
 
@@ -147,7 +147,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 
@@ -164,7 +164,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              not throw any exception,
 				              but it did throw a MyException:
-				                {nameof(ShouldSupportDelegate_FuncTask_WhenThrown)}.
+				                {nameof(ShouldSupportDelegate_FuncTask_WhenThrown)}
 				              """);
 		}
 
@@ -195,7 +195,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 
@@ -212,7 +212,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              not throw any exception,
 				              but it did throw a MyException:
-				                {nameof(ShouldSupportDelegate_FuncTask_WithCancellationToken_WhenThrown)}.
+				                {nameof(ShouldSupportDelegate_FuncTask_WithCancellationToken_WhenThrown)}
 				              """);
 		}
 
@@ -228,7 +228,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 
@@ -245,7 +245,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              not throw any exception,
 				              but it did throw a MyException:
-				                {nameof(ShouldSupportDelegate_FuncTaskValue_WhenThrown)}.
+				                {nameof(ShouldSupportDelegate_FuncTaskValue_WhenThrown)}
 				              """);
 		}
 
@@ -276,7 +276,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 
@@ -294,7 +294,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              not throw any exception,
 				              but it did throw a MyException:
-				                {nameof(ShouldSupportDelegate_FuncTaskValue_WithCancellationToken_WhenThrown)}.
+				                {nameof(ShouldSupportDelegate_FuncTaskValue_WithCancellationToken_WhenThrown)}
 				              """);
 		}
 
@@ -310,7 +310,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 
@@ -327,7 +327,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              not throw any exception,
 				              but it did throw a MyException:
-				                {nameof(ShouldSupportDelegate_FuncValue_WhenThrown)}.
+				                {nameof(ShouldSupportDelegate_FuncValue_WhenThrown)}
 				              """);
 		}
 
@@ -361,7 +361,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 
@@ -378,7 +378,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              not throw any exception,
 				              but it did throw a MyException:
-				                {nameof(ShouldSupportDelegate_FuncValue_WithCancellationToken_WhenThrown)}.
+				                {nameof(ShouldSupportDelegate_FuncValue_WithCancellationToken_WhenThrown)}
 				              """);
 		}
 
@@ -394,7 +394,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 
@@ -411,7 +411,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              not throw any exception,
 				              but it did throw a MyException:
-				                {nameof(ShouldSupportDelegate_Task_WhenThrown)}.
+				                {nameof(ShouldSupportDelegate_Task_WhenThrown)}
 				              """);
 		}
 
@@ -427,7 +427,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 
@@ -444,7 +444,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              not throw any exception,
 				              but it did throw a MyException:
-				                {nameof(ShouldSupportDelegate_TaskValue_WhenThrown)}.
+				                {nameof(ShouldSupportDelegate_TaskValue_WhenThrown)}
 				              """);
 		}
 
@@ -461,7 +461,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 #endif
@@ -480,7 +480,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              not throw any exception,
 				              but it did throw a MyException:
-				                {nameof(ShouldSupportDelegate_ValueTask_WhenThrown)}.
+				                {nameof(ShouldSupportDelegate_ValueTask_WhenThrown)}
 				              """);
 		}
 #endif
@@ -498,7 +498,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not.
+				             but it did not
 				             """);
 		}
 #endif
@@ -517,7 +517,7 @@ public sealed partial class DelegateShould
 				              Expected @delegate to
 				              not throw any exception,
 				              but it did throw a MyException:
-				                {nameof(ShouldSupportDelegate_ValueTaskValue_WhenThrown)}.
+				                {nameof(ShouldSupportDelegate_ValueTaskValue_WhenThrown)}
 				              """);
 		}
 #endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithInnerExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithInnerExceptionTests.cs
@@ -50,7 +50,7 @@ public sealed partial class DelegateThrows
 				.WithMessage("""
 				             Expected action to
 				             throw an Exception with an inner exception,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithInnerTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithInnerTests.cs
@@ -43,7 +43,7 @@ public sealed partial class DelegateThrows
 				              Expected action to
 				              throw an Exception with an inner SubCustomException,
 				              but found a CustomException:
-				                {message}.
+				                {message}
 				              """);
 		}
 
@@ -62,7 +62,7 @@ public sealed partial class DelegateThrows
 				              Expected action to
 				              throw an Exception with an inner CustomException,
 				              but found an OtherException:
-				                {message}.
+				                {message}
 				              """);
 		}
 
@@ -101,7 +101,7 @@ public sealed partial class DelegateThrows
 				.WithMessage("""
 				             Expected action to
 				             throw an Exception with an inner CustomException,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithMessageTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithMessageTests.cs
@@ -51,7 +51,7 @@ public sealed partial class DelegateThrows
 				                ↓ (actual)
 				               "FOO"
 				               "foo"
-				                ↑ (expected).
+				                ↑ (expected)
 				             """);
 		}
 
@@ -86,7 +86,7 @@ public sealed partial class DelegateThrows
 				                ↓ (actual)
 				               "actual text"
 				               "expected other text"
-				                ↑ (expected).
+				                ↑ (expected)
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithRecursiveInnerExceptionsTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithRecursiveInnerExceptionsTests.cs
@@ -25,7 +25,7 @@ public sealed partial class DelegateThrows
 				.WithMessage($"""
 				              Expected action to
 				              throw an Exception with recursive inner exceptions which have at least {minimum} items of type CustomException,
-				              but only 1 of 5 items were.
+				              but only 1 of 5 items were
 				              """);
 		}
 
@@ -54,7 +54,7 @@ public sealed partial class DelegateThrows
 				.WithMessage("""
 				             Expected action to
 				             throw an Exception with recursive inner exceptions which all satisfy "_ => false",
-				             but not all did.
+				             but not all did
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.BeDefinedTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.BeDefinedTests.cs
@@ -27,7 +27,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be defined,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}
@@ -46,7 +46,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be defined,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.BeDefinedTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.BeDefinedTests.cs
@@ -27,7 +27,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be defined,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}
@@ -46,7 +46,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be defined,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.BeTests.cs
@@ -16,7 +16,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -46,7 +46,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -76,7 +76,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -92,7 +92,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -137,7 +137,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -168,7 +168,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -198,7 +198,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.BeTests.cs
@@ -15,8 +15,8 @@ public sealed partial class EnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -45,8 +45,8 @@ public sealed partial class EnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -76,7 +76,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -91,8 +91,8 @@ public sealed partial class EnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -136,8 +136,8 @@ public sealed partial class EnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -167,8 +167,8 @@ public sealed partial class EnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -197,8 +197,8 @@ public sealed partial class EnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveFlagTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveFlagTests.cs
@@ -16,7 +16,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              have flag <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -32,7 +32,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              have flag {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -90,7 +90,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not have flag {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -108,7 +108,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not have flag {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveFlagTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveFlagTests.cs
@@ -16,7 +16,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              have flag <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -31,8 +31,8 @@ public sealed partial class EnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              have flag {expected},
-				              but found {subject}.
+				              have flag {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -89,8 +89,8 @@ public sealed partial class EnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not have flag {unexpected},
-				              but found {subject}.
+				              not have flag {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -107,8 +107,8 @@ public sealed partial class EnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not have flag {unexpected},
-				              but found {subject}.
+				              not have flag {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveValueTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveValueTests.cs
@@ -16,7 +16,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              have value <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -33,8 +33,8 @@ public sealed partial class EnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              have value {expected},
-				              but found {subject}.
+				              have value {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -80,8 +80,8 @@ public sealed partial class EnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not have value {unexpected},
-				              but found {subject}.
+				              not have value {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveValueTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/EnumShould.HaveValueTests.cs
@@ -16,7 +16,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              have value <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -34,7 +34,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              have value {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -81,7 +81,7 @@ public sealed partial class EnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not have value {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeDefinedTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeDefinedTests.cs
@@ -27,7 +27,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be defined,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -43,7 +43,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage("""
 				             Expected subject to
 				             be defined,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}
@@ -62,7 +62,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be defined,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -89,7 +89,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage("""
 				             Expected subject to
 				             not be defined,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeDefinedTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeDefinedTests.cs
@@ -27,7 +27,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be defined,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -62,7 +62,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be defined,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeNullTests.cs
@@ -16,7 +16,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeNullTests.cs
@@ -16,7 +16,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -57,7 +57,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage("""
 				             Expected subject to
 				             not be null,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeTests.cs
@@ -16,7 +16,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -46,7 +46,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -76,7 +76,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -107,7 +107,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -123,7 +123,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage("""
 				             Expected subject to
 				             be Red,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -168,7 +168,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -199,7 +199,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -215,7 +215,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage("""
 				             Expected subject to
 				             not be <null>,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -250,7 +250,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.BeTests.cs
@@ -15,8 +15,8 @@ public sealed partial class NullableEnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -45,8 +45,8 @@ public sealed partial class NullableEnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -76,7 +76,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -106,8 +106,8 @@ public sealed partial class NullableEnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected?.ToString() ?? "<null>"},
-				              but found {subject?.ToString() ?? "<null>"}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -167,8 +167,8 @@ public sealed partial class NullableEnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -198,8 +198,8 @@ public sealed partial class NullableEnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -249,8 +249,8 @@ public sealed partial class NullableEnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected?.ToString() ?? "<null>"},
-				              but found {subject?.ToString() ?? "<null>"}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveFlagTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveFlagTests.cs
@@ -16,7 +16,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              have flag <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -44,7 +44,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              have flag {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -89,7 +89,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage("""
 				             Expected subject to
 				             not have flag <null>,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -118,7 +118,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not have flag {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -136,7 +136,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not have flag {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveFlagTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveFlagTests.cs
@@ -16,7 +16,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              have flag <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -43,8 +43,8 @@ public sealed partial class NullableEnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              have flag {expected},
-				              but found {subject}.
+				              have flag {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -117,8 +117,8 @@ public sealed partial class NullableEnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not have flag {unexpected},
-				              but found {subject}.
+				              not have flag {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -135,8 +135,8 @@ public sealed partial class NullableEnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not have flag {unexpected},
-				              but found {subject}.
+				              not have flag {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveValueTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveValueTests.cs
@@ -16,7 +16,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              have value <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -34,7 +34,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              have value {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -81,7 +81,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              not have value {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveValueTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Enums/NullableEnumShould.HaveValueTests.cs
@@ -16,7 +16,7 @@ public sealed partial class NullableEnumShould
 				.WithMessage($"""
 				              Expected subject to
 				              have value <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -33,8 +33,8 @@ public sealed partial class NullableEnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              have value {expected},
-				              but found {subject}.
+				              have value {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -80,8 +80,8 @@ public sealed partial class NullableEnumShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not have value {unexpected},
-				              but found {subject}.
+				              not have value {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Exceptions/ExceptionShould.HaveInnerExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Exceptions/ExceptionShould.HaveInnerExceptionTests.cs
@@ -19,7 +19,7 @@ public sealed partial class ExceptionShould
 				             Expected subject to
 				             have an inner CustomException which should have Message equal to "inner",
 				             but found an Exception:
-				               inner.
+				               inner
 				             """);
 		}
 
@@ -41,7 +41,7 @@ public sealed partial class ExceptionShould
 				                ↓ (actual)
 				               "inner"
 				               "some other message"
-				                ↑ (expected).
+				                ↑ (expected)
 				             """);
 		}
 
@@ -63,7 +63,7 @@ public sealed partial class ExceptionShould
 				                ↓ (actual)
 				               "inner"
 				               "some other message"
-				                ↑ (expected).
+				                ↑ (expected)
 				             """);
 		}
 
@@ -81,7 +81,7 @@ public sealed partial class ExceptionShould
 				             Expected subject to
 				             have an inner CustomException,
 				             but found an Exception:
-				               inner.
+				               inner
 				             """);
 		}
 
@@ -97,7 +97,7 @@ public sealed partial class ExceptionShould
 				.WithMessage("""
 				             Expected subject to
 				             have an inner exception,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Exceptions/ExceptionShould.HaveMessageTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Exceptions/ExceptionShould.HaveMessageTests.cs
@@ -22,7 +22,7 @@ public sealed partial class ExceptionShould
 				                ↓ (actual)
 				               "actual text"
 				               "expected other text"
-				                ↑ (expected).
+				                ↑ (expected)
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Exceptions/ExceptionShould.HaveRecursiveInnerExceptionsTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Exceptions/ExceptionShould.HaveRecursiveInnerExceptionsTests.cs
@@ -37,7 +37,7 @@ public sealed partial class ExceptionShould
 				.WithMessage("""
 				             Expected subject to
 				             have recursive inner exceptions which all satisfy "e => e.Message != "inner3A"",
-				             but not all did.
+				             but not all did
 				             """);
 		}
 
@@ -58,7 +58,7 @@ public sealed partial class ExceptionShould
 				.WithMessage("""
 				             Expected subject to
 				             have recursive inner exceptions which none satisfy "e => e.Message != "inner3A"",
-				             but at least one did.
+				             but at least one did
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/GenericShould.BeSameAsTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/GenericShould.BeSameAsTests.cs
@@ -33,7 +33,7 @@ public sealed partial class GenericShould
 				             },
 				             but found Other {
 				               Value = 1
-				             }.
+				             }
 				             """);
 		}
 
@@ -52,7 +52,7 @@ public sealed partial class GenericShould
 				             refer to expected <null>,
 				             but found Other {
 				               Value = 1
-				             }.
+				             }
 				             """);
 		}
 
@@ -83,7 +83,7 @@ public sealed partial class GenericShould
 				             refer to expected Other {
 				               Value = 1
 				             },
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}
@@ -105,7 +105,7 @@ public sealed partial class GenericShould
 				             not refer to expected Other {
 				               Value = 1
 				             },
-				             but it did.
+				             but it did
 				             """);
 		}
 
@@ -146,7 +146,7 @@ public sealed partial class GenericShould
 				.WithMessage("""
 				             Expected subject to
 				             not refer to expected <null>,
-				             but it did.
+				             but it did
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Guids/GuidShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Guids/GuidShould.BeEmptyTests.cs
@@ -27,7 +27,7 @@ public sealed partial class GuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              be empty,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}
@@ -46,7 +46,7 @@ public sealed partial class GuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be empty,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Guids/GuidShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Guids/GuidShould.BeEmptyTests.cs
@@ -27,7 +27,7 @@ public sealed partial class GuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              be empty,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}
@@ -46,7 +46,7 @@ public sealed partial class GuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be empty,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Guids/GuidShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Guids/GuidShould.BeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class GuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -33,8 +33,8 @@ public sealed partial class GuidShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -77,8 +77,8 @@ public sealed partial class GuidShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Guids/GuidShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Guids/GuidShould.BeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class GuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -34,7 +34,7 @@ public sealed partial class GuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -78,7 +78,7 @@ public sealed partial class GuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Guids/NullableGuidShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Guids/NullableGuidShould.BeEmptyTests.cs
@@ -27,7 +27,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              be empty,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -43,7 +43,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage("""
 				             Expected subject to
 				             be empty,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}
@@ -62,7 +62,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be empty,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -89,7 +89,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage("""
 				             Expected subject to
 				             not be empty,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Guids/NullableGuidShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Guids/NullableGuidShould.BeEmptyTests.cs
@@ -27,7 +27,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              be empty,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -62,7 +62,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be empty,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Guids/NullableGuidShould.BeNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Guids/NullableGuidShould.BeNullTests.cs
@@ -32,7 +32,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Guids/NullableGuidShould.BeNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Guids/NullableGuidShould.BeNullTests.cs
@@ -16,7 +16,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage("""
 				             Expected subject to
 				             be null,
-				             but found 00000000-0000-0000-0000-000000000000.
+				             but found 00000000-0000-0000-0000-000000000000
 				             """);
 		}
 
@@ -32,7 +32,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -84,7 +84,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage("""
 				             Expected subject to
 				             not be null,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Guids/NullableGuidShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Guids/NullableGuidShould.BeTests.cs
@@ -28,7 +28,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -44,7 +44,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {FixedGuid()},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -75,7 +75,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage("""
 				             Expected subject to
 				             not be <null>,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -104,7 +104,7 @@ public sealed partial class NullableGuidShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Guids/NullableGuidShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Guids/NullableGuidShould.BeTests.cs
@@ -27,8 +27,8 @@ public sealed partial class NullableGuidShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected?.ToString() ?? "<null>"},
-				              but found {subject?.ToString() ?? "<null>"}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -103,8 +103,8 @@ public sealed partial class NullableGuidShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected?.ToString() ?? "<null>"},
-				              but found {subject?.ToString() ?? "<null>"}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Http/HttpResponseMessageShould.HaveContentTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Http/HttpResponseMessageShould.HaveContentTests.cs
@@ -25,7 +25,7 @@ public sealed partial class HttpResponseMessageShould
 				                ↓ (actual)
 				               "some content"
 				               "other content"
-				                ↑ (expected).
+				                ↑ (expected)
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Http/HttpResponseMessageShould.HaveStatusCodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Http/HttpResponseMessageShould.HaveStatusCodeTests.cs
@@ -29,7 +29,7 @@ public sealed partial class HttpResponseMessageShould
 				               some content
 				               The originating request was:
 				                 GET https://example.com/ HTTP 1.1
-				                 request content.
+				                 request content
 				             """);
 		}
 
@@ -50,7 +50,7 @@ public sealed partial class HttpResponseMessageShould
 				             but found 400 BadRequest:
 				               HTTP/1.1 400 BadRequest
 				               some content
-				               The originating request was <null>.
+				               The originating request was <null>
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeFiniteTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeFiniteTests.cs
@@ -29,7 +29,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be finite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -73,7 +73,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be finite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -118,7 +118,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be finite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -163,7 +163,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be finite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -224,7 +224,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be finite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -267,7 +267,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be finite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -312,7 +312,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be finite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -357,7 +357,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be finite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeFiniteTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeFiniteTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace Testably.Expectations.Tests.ThatTests.Numbers;
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
 
 public sealed partial class NumberShould
 {
@@ -19,11 +17,11 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(double.PositiveInfinity, "+\u221e")]
-		[InlineData(double.NegativeInfinity, "-\u221e")]
-		[InlineData(double.NaN, "NaN")]
+		[InlineData(double.PositiveInfinity)]
+		[InlineData(double.NegativeInfinity)]
+		[InlineData(double.NaN)]
 		public async Task ForDouble_WhenSubjectIsInfinityOrNaN_ShouldFail(
-			double subject, string format)
+			double subject)
 		{
 			async Task Act() => await That(subject).Should().BeFinite();
 
@@ -31,7 +29,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be finite,
-				              but found {format}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -62,11 +60,11 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(float.PositiveInfinity, "+\u221e")]
-		[InlineData(float.NegativeInfinity, "-\u221e")]
-		[InlineData(float.NaN, "NaN")]
+		[InlineData(float.PositiveInfinity)]
+		[InlineData(float.NegativeInfinity)]
+		[InlineData(float.NaN)]
 		public async Task ForFloat_WhenSubjectIsInfinityOrNaN_ShouldFail(
-			float subject, string format)
+			float subject)
 		{
 			async Task Act()
 				=> await That(subject).Should().BeFinite();
@@ -75,7 +73,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be finite,
-				              but found {format}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -107,12 +105,12 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(double.PositiveInfinity, "+\u221e")]
-		[InlineData(double.NegativeInfinity, "-\u221e")]
-		[InlineData(double.NaN, "NaN")]
-		[InlineData(null, "<null>")]
+		[InlineData(double.PositiveInfinity)]
+		[InlineData(double.NegativeInfinity)]
+		[InlineData(double.NaN)]
+		[InlineData(null)]
 		public async Task ForNullableDouble_WhenSubjectIsInfinityOrNaNOrNull_ShouldFail(
-			double? subject, string format)
+			double? subject)
 		{
 			async Task Act() => await That(subject).Should().BeFinite();
 
@@ -120,7 +118,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be finite,
-				              but found {format}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -151,12 +149,12 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(float.PositiveInfinity, "+\u221e")]
-		[InlineData(float.NegativeInfinity, "-\u221e")]
-		[InlineData(float.NaN, "NaN")]
-		[InlineData(null, "<null>")]
+		[InlineData(float.PositiveInfinity)]
+		[InlineData(float.NegativeInfinity)]
+		[InlineData(float.NaN)]
+		[InlineData(null)]
 		public async Task ForNullableFloat_WhenSubjectIsInfinityOrNaNOrNull_ShouldFail(
-			float? subject, string format)
+			float? subject)
 		{
 			async Task Act()
 				=> await That(subject).Should().BeFinite();
@@ -165,7 +163,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be finite,
-				              but found {format}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -226,7 +224,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be finite,
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -269,7 +267,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be finite,
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -314,7 +312,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be finite,
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -359,7 +357,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be finite,
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeGreaterThanOrEqualToTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeGreaterThanOrEqualToTests.cs
@@ -18,7 +18,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -47,7 +47,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -64,7 +64,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -99,7 +99,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -116,7 +116,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -143,7 +143,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -172,7 +172,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -189,7 +189,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -205,7 +205,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -234,7 +234,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -252,7 +252,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -280,7 +280,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -298,7 +298,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -337,7 +337,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -365,7 +365,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -383,7 +383,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -400,7 +400,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -435,7 +435,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -452,7 +452,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -481,7 +481,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -498,7 +498,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -527,7 +527,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -555,7 +555,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -573,7 +573,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -601,7 +601,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -619,7 +619,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -647,7 +647,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -665,7 +665,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -693,7 +693,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -711,7 +711,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -739,7 +739,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -757,7 +757,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -785,7 +785,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -803,7 +803,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -831,7 +831,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -849,7 +849,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -867,7 +867,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -896,7 +896,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -914,7 +914,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -943,7 +943,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -961,7 +961,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -990,7 +990,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1008,7 +1008,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1037,7 +1037,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1055,7 +1055,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1084,7 +1084,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeGreaterThanOrEqualToTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeGreaterThanOrEqualToTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace Testably.Expectations.Tests.ThatTests.Numbers;
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
 
 public sealed partial class NumberShould
 {
@@ -20,7 +18,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -48,8 +46,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -66,7 +64,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -100,8 +98,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -118,7 +116,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -144,8 +142,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -173,8 +171,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -191,7 +189,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -206,8 +204,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -235,8 +233,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -254,7 +252,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -281,8 +279,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -300,7 +298,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -338,8 +336,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -366,8 +364,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -384,7 +382,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
+				              be greater than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -402,7 +400,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -436,8 +434,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -454,7 +452,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -482,8 +480,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -500,7 +498,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -528,8 +526,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -556,8 +554,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -574,7 +572,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
+				              be greater than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -602,8 +600,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -620,7 +618,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
+				              be greater than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -648,8 +646,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -666,7 +664,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
+				              be greater than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -694,8 +692,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -712,7 +710,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
+				              be greater than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -740,8 +738,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -758,7 +756,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
+				              be greater than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -786,8 +784,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -804,7 +802,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
+				              be greater than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -832,8 +830,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -850,7 +848,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
+				              be greater than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -869,7 +867,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -897,8 +895,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -916,7 +914,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -944,8 +942,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -963,7 +961,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -991,8 +989,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1010,7 +1008,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1038,8 +1036,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1057,7 +1055,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1085,8 +1083,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than or equal to {expected},
-				              but found {subject}.
+				              be greater than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeGreaterThanTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeGreaterThanTests.cs
@@ -18,7 +18,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -46,7 +46,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -63,7 +63,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -98,7 +98,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -115,7 +115,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -142,7 +142,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -171,7 +171,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -188,7 +188,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -204,7 +204,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -233,7 +233,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -251,7 +251,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -279,7 +279,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -297,7 +297,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -335,7 +335,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -363,7 +363,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -381,7 +381,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -398,7 +398,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -433,7 +433,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -450,7 +450,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -479,7 +479,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -496,7 +496,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -525,7 +525,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -553,7 +553,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -571,7 +571,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -599,7 +599,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -617,7 +617,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -645,7 +645,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -663,7 +663,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -691,7 +691,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -709,7 +709,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -737,7 +737,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -755,7 +755,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -783,7 +783,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -801,7 +801,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -829,7 +829,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -847,7 +847,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -865,7 +865,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -893,7 +893,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -911,7 +911,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -939,7 +939,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -957,7 +957,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -985,7 +985,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1003,7 +1003,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1031,7 +1031,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1049,7 +1049,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1077,7 +1077,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeGreaterThanTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeGreaterThanTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace Testably.Expectations.Tests.ThatTests.Numbers;
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
 
 public sealed partial class NumberShould
 {
@@ -20,7 +18,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -47,8 +45,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -65,7 +63,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -99,8 +97,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -117,7 +115,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -143,8 +141,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -172,8 +170,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -190,7 +188,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -205,8 +203,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -234,8 +232,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -253,7 +251,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -280,8 +278,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -299,7 +297,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -336,8 +334,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -364,8 +362,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -382,7 +380,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
+				              be greater than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -400,7 +398,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -434,8 +432,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -452,7 +450,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -480,8 +478,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -498,7 +496,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -526,8 +524,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -554,8 +552,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -572,7 +570,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
+				              be greater than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -600,8 +598,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -618,7 +616,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
+				              be greater than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -646,8 +644,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -664,7 +662,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
+				              be greater than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -692,8 +690,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -710,7 +708,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
+				              be greater than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -738,8 +736,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -756,7 +754,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
+				              be greater than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -784,8 +782,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -802,7 +800,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
+				              be greater than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -830,8 +828,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -848,7 +846,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
+				              be greater than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -867,7 +865,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -894,8 +892,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -913,7 +911,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -940,8 +938,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -959,7 +957,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -986,8 +984,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1005,7 +1003,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1032,8 +1030,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1051,7 +1049,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be greater than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1078,8 +1076,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be greater than {expected},
-				              but found {subject}.
+				              be greater than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeInfiniteTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeInfiniteTests.cs
@@ -43,7 +43,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be infinite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -86,7 +86,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be infinite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -131,7 +131,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be infinite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -174,7 +174,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be infinite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}
@@ -204,7 +204,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be infinite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -247,7 +247,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be infinite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -291,7 +291,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be infinite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -337,7 +337,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be infinite,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeInfiniteTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeInfiniteTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace Testably.Expectations.Tests.ThatTests.Numbers;
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
 
 public sealed partial class NumberShould
 {
@@ -45,7 +43,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be infinite,
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -88,7 +86,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be infinite,
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -133,7 +131,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be infinite,
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -176,7 +174,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be infinite,
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}
@@ -196,9 +194,9 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(double.PositiveInfinity, "+\u221e")]
-		[InlineData(double.NegativeInfinity, "-\u221e")]
-		public async Task ForDouble_WhenSubjectIsInfinity_ShouldFail(double subject, string format)
+		[InlineData(double.PositiveInfinity)]
+		[InlineData(double.NegativeInfinity)]
+		public async Task ForDouble_WhenSubjectIsInfinity_ShouldFail(double subject)
 		{
 			async Task Act() => await That(subject).Should().NotBeInfinite();
 
@@ -206,7 +204,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be infinite,
-				              but found {format}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -238,9 +236,9 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(float.PositiveInfinity, "+\u221e")]
-		[InlineData(float.NegativeInfinity, "-\u221e")]
-		public async Task ForFloat_WhenSubjectIsInfinity_ShouldFail(float subject, string format)
+		[InlineData(float.PositiveInfinity)]
+		[InlineData(float.NegativeInfinity)]
+		public async Task ForFloat_WhenSubjectIsInfinity_ShouldFail(float subject)
 		{
 			async Task Act()
 				=> await That(subject).Should().NotBeInfinite();
@@ -249,7 +247,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be infinite,
-				              but found {format}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -282,10 +280,10 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(double.PositiveInfinity, "+\u221e")]
-		[InlineData(double.NegativeInfinity, "-\u221e")]
-		public async Task ForNullableDouble_WhenSubjectIsInfinity_ShouldFail(double? subject,
-			string format)
+		[InlineData(double.PositiveInfinity)]
+		[InlineData(double.NegativeInfinity)]
+		public async Task ForNullableDouble_WhenSubjectIsInfinity_ShouldFail(
+			double? subject)
 		{
 			async Task Act() => await That(subject).Should().NotBeInfinite();
 
@@ -293,7 +291,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be infinite,
-				              but found {format}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -327,10 +325,10 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(float.PositiveInfinity, "+\u221e")]
-		[InlineData(float.NegativeInfinity, "-\u221e")]
-		public async Task ForNullableFloat_WhenSubjectIsInfinity_ShouldFail(float? subject,
-			string format)
+		[InlineData(float.PositiveInfinity)]
+		[InlineData(float.NegativeInfinity)]
+		public async Task ForNullableFloat_WhenSubjectIsInfinity_ShouldFail(
+			float? subject)
 		{
 			async Task Act()
 				=> await That(subject).Should().NotBeInfinite();
@@ -339,7 +337,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be infinite,
-				              but found {format}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeLessThanOrEqualToTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeLessThanOrEqualToTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace Testably.Expectations.Tests.ThatTests.Numbers;
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
 
 public sealed partial class NumberShould
 {
@@ -20,7 +18,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -35,8 +33,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -65,7 +63,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -84,8 +82,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -128,7 +126,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -143,8 +141,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -160,8 +158,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -190,7 +188,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -205,8 +203,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -222,8 +220,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -253,7 +251,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -268,8 +266,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -309,7 +307,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -324,8 +322,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -352,8 +350,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -382,7 +380,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
+				              be less than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -400,7 +398,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -419,8 +417,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -452,7 +450,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -468,8 +466,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -498,7 +496,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -514,8 +512,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -542,8 +540,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -572,7 +570,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
+				              be less than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -588,8 +586,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -618,7 +616,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
+				              be less than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -634,8 +632,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -664,7 +662,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
+				              be less than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -680,8 +678,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -710,7 +708,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
+				              be less than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -726,8 +724,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -756,7 +754,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
+				              be less than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -772,8 +770,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -802,7 +800,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
+				              be less than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -818,8 +816,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -848,7 +846,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
+				              be less than or equal to {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -867,7 +865,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -882,8 +880,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -913,7 +911,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -928,8 +926,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -959,7 +957,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -974,8 +972,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1005,7 +1003,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1020,8 +1018,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1051,7 +1049,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1066,8 +1064,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than or equal to {expected},
-				              but found {subject}.
+				              be less than or equal to {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeLessThanOrEqualToTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeLessThanOrEqualToTests.cs
@@ -18,7 +18,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -34,7 +34,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -63,7 +63,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -83,7 +83,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -126,7 +126,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -142,7 +142,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -159,7 +159,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -188,7 +188,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -204,7 +204,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -221,7 +221,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -251,7 +251,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -267,7 +267,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -307,7 +307,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -323,7 +323,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -351,7 +351,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -381,7 +381,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -398,7 +398,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -418,7 +418,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -450,7 +450,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -467,7 +467,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -496,7 +496,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -513,7 +513,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -541,7 +541,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -571,7 +571,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -587,7 +587,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -617,7 +617,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -633,7 +633,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -663,7 +663,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -679,7 +679,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -709,7 +709,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -725,7 +725,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -755,7 +755,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -771,7 +771,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -801,7 +801,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -817,7 +817,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -847,7 +847,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -865,7 +865,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -881,7 +881,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -911,7 +911,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -927,7 +927,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -957,7 +957,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -973,7 +973,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1003,7 +1003,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1019,7 +1019,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1049,7 +1049,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1065,7 +1065,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than or equal to {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeLessThanTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeLessThanTests.cs
@@ -18,7 +18,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -35,7 +35,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -63,7 +63,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -84,7 +84,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -126,7 +126,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -142,7 +142,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -160,7 +160,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -188,7 +188,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -204,7 +204,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -222,7 +222,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -251,7 +251,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -268,7 +268,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -307,7 +307,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -324,7 +324,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -352,7 +352,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -381,7 +381,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -398,7 +398,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -419,7 +419,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -450,7 +450,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -468,7 +468,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -496,7 +496,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -514,7 +514,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -542,7 +542,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -571,7 +571,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -588,7 +588,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -617,7 +617,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -634,7 +634,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -663,7 +663,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -680,7 +680,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -709,7 +709,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -726,7 +726,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -755,7 +755,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -772,7 +772,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -801,7 +801,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -818,7 +818,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -847,7 +847,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -865,7 +865,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -882,7 +882,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -911,7 +911,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -928,7 +928,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -957,7 +957,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -974,7 +974,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1003,7 +1003,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1020,7 +1020,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1049,7 +1049,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1067,7 +1067,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeLessThanTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeLessThanTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace Testably.Expectations.Tests.ThatTests.Numbers;
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
 
 public sealed partial class NumberShould
 {
@@ -20,7 +18,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -36,8 +34,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -65,7 +63,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -85,8 +83,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -128,7 +126,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -143,8 +141,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -161,8 +159,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -190,7 +188,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -205,8 +203,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -223,8 +221,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -253,7 +251,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -269,8 +267,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -309,7 +307,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -325,8 +323,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -353,8 +351,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -382,7 +380,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
+				              be less than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -400,7 +398,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -420,8 +418,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -452,7 +450,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -469,8 +467,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -498,7 +496,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -515,8 +513,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -543,8 +541,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -572,7 +570,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
+				              be less than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -589,8 +587,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -618,7 +616,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
+				              be less than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -635,8 +633,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -664,7 +662,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
+				              be less than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -681,8 +679,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -710,7 +708,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
+				              be less than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -727,8 +725,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -756,7 +754,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
+				              be less than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -773,8 +771,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -802,7 +800,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
+				              be less than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -819,8 +817,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -848,7 +846,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
+				              be less than {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -867,7 +865,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -883,8 +881,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -913,7 +911,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -929,8 +927,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -959,7 +957,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -975,8 +973,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1005,7 +1003,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1021,8 +1019,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1051,7 +1049,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be less than <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1068,8 +1066,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be less than {expected},
-				              but found {subject}.
+				              be less than {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeNaNTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeNaNTests.cs
@@ -28,7 +28,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -58,7 +58,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -85,7 +85,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -116,7 +116,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -146,7 +146,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -177,7 +177,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -205,7 +205,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -236,7 +236,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}
@@ -266,7 +266,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be NaN,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -310,7 +310,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be NaN,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -354,7 +354,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be NaN,
-				              but found NaN.
+				              but found NaN
 				              """);
 		}
 
@@ -400,7 +400,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be NaN,
-				              but found NaN.
+				              but found NaN
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeNaNTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeNaNTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace Testably.Expectations.Tests.ThatTests.Numbers;
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
 
 public sealed partial class NumberShould
 {
@@ -19,9 +17,9 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(double.PositiveInfinity, "+\u221e")]
-		[InlineData(double.NegativeInfinity, "-\u221e")]
-		public async Task ForDouble_WhenSubjectIsInfinity_ShouldFail(double subject, string format)
+		[InlineData(double.PositiveInfinity)]
+		[InlineData(double.NegativeInfinity)]
+		public async Task ForDouble_WhenSubjectIsInfinity_ShouldFail(double subject)
 		{
 			async Task Act()
 				=> await That(subject).Should().BeNaN();
@@ -30,7 +28,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {format}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -60,7 +58,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -76,9 +74,9 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(float.PositiveInfinity, "+\u221e")]
-		[InlineData(float.NegativeInfinity, "-\u221e")]
-		public async Task ForFloat_WhenSubjectIsInfinity_ShouldFail(float subject, string format)
+		[InlineData(float.PositiveInfinity)]
+		[InlineData(float.NegativeInfinity)]
+		public async Task ForFloat_WhenSubjectIsInfinity_ShouldFail(float subject)
 		{
 			async Task Act()
 				=> await That(subject).Should().BeNaN();
@@ -87,7 +85,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {format}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -118,7 +116,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -135,11 +133,11 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(double.PositiveInfinity, "+\u221e")]
-		[InlineData(double.NegativeInfinity, "-\u221e")]
-		[InlineData(null, "<null>")]
+		[InlineData(double.PositiveInfinity)]
+		[InlineData(double.NegativeInfinity)]
+		[InlineData(null)]
 		public async Task ForNullableDouble_WhenSubjectIsInfinityOrNull_ShouldFail(
-			double? subject, string format)
+			double? subject)
 		{
 			async Task Act()
 				=> await That(subject).Should().BeNaN();
@@ -148,7 +146,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {format}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -179,7 +177,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -195,10 +193,10 @@ public sealed partial class NumberShould
 		}
 
 		[Theory]
-		[InlineData(float.PositiveInfinity, "+\u221e")]
-		[InlineData(float.NegativeInfinity, "-\u221e")]
-		public async Task ForNullableFloat_WhenSubjectIsInfinity_ShouldFail(float? subject,
-			string format)
+		[InlineData(float.PositiveInfinity)]
+		[InlineData(float.NegativeInfinity)]
+		public async Task ForNullableFloat_WhenSubjectIsInfinity_ShouldFail(
+			float? subject)
 		{
 			async Task Act()
 				=> await That(subject).Should().BeNaN();
@@ -207,7 +205,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {format}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -238,7 +236,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be NaN,
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}
@@ -268,7 +266,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be NaN,
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -312,7 +310,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be NaN,
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeNegativeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeNegativeTests.cs
@@ -16,7 +16,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -42,7 +42,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -68,7 +68,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -111,7 +111,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -137,7 +137,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -180,7 +180,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -206,7 +206,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -235,7 +235,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -281,7 +281,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -308,7 +308,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -368,7 +368,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -394,7 +394,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -454,7 +454,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -497,7 +497,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -540,7 +540,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -583,7 +583,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -625,7 +625,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -651,7 +651,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeNegativeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeNegativeTests.cs
@@ -16,7 +16,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -42,7 +42,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -68,7 +68,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -95,7 +95,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be negative,
-				             but found +∞.
+				             but found +∞
 				             """);
 		}
 
@@ -111,7 +111,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -137,7 +137,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -164,7 +164,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be negative,
-				             but found +∞.
+				             but found +∞
 				             """);
 		}
 
@@ -180,7 +180,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -206,7 +206,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -235,7 +235,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -264,7 +264,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be negative,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -281,7 +281,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -308,7 +308,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -335,7 +335,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be negative,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -351,7 +351,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be negative,
-				             but found +∞.
+				             but found +∞
 				             """);
 		}
 
@@ -368,7 +368,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -394,7 +394,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -421,7 +421,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be negative,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -437,7 +437,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be negative,
-				             but found +∞.
+				             but found +∞
 				             """);
 		}
 
@@ -454,7 +454,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -480,7 +480,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be negative,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -497,7 +497,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -523,7 +523,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be negative,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -540,7 +540,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -566,7 +566,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be negative,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -583,7 +583,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -609,7 +609,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be negative,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -625,7 +625,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -651,7 +651,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be negative,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeOneOfTests.WithinTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeOneOfTests.WithinTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Tests.ThatTests.Numbers;
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeOneOfTests.WithinTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeOneOfTests.WithinTests.cs
@@ -33,7 +33,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -62,7 +62,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -101,7 +101,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -158,7 +158,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -201,7 +201,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -244,7 +244,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -287,7 +287,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -330,7 +330,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -373,7 +373,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -416,7 +416,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -459,7 +459,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -502,7 +502,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -545,7 +545,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -575,7 +575,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -614,7 +614,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -673,7 +673,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -716,7 +716,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -761,7 +761,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -804,7 +804,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -848,7 +848,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -891,7 +891,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -934,7 +934,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -977,7 +977,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1021,7 +1021,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1064,7 +1064,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1108,7 +1108,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1151,7 +1151,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1195,7 +1195,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1238,7 +1238,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1268,7 +1268,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1297,7 +1297,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1327,7 +1327,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1356,7 +1356,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1387,7 +1387,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1416,7 +1416,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1459,7 +1459,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1502,7 +1502,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1545,7 +1545,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1588,7 +1588,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1617,7 +1617,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1646,7 +1646,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1675,7 +1675,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1704,7 +1704,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1733,7 +1733,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be one of {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 		}
@@ -1756,7 +1756,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1785,7 +1785,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1819,7 +1819,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -1875,7 +1875,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -1926,7 +1926,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 0.11,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -1969,7 +1969,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 0.11,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -2012,7 +2012,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 0.11,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -2055,7 +2055,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 0.11,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -2098,7 +2098,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2141,7 +2141,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2184,7 +2184,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2227,7 +2227,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2270,7 +2270,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2299,7 +2299,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2334,7 +2334,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -2391,7 +2391,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -2443,7 +2443,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 0.11,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -2486,7 +2486,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 0.11,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -2530,7 +2530,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 0.11,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -2573,7 +2573,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 0.11,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -2617,7 +2617,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2660,7 +2660,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2704,7 +2704,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2747,7 +2747,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2791,7 +2791,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2834,7 +2834,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2878,7 +2878,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2921,7 +2921,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2965,7 +2965,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -2994,7 +2994,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3024,7 +3024,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3053,7 +3053,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3083,7 +3083,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3112,7 +3112,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3142,7 +3142,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3185,7 +3185,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3228,7 +3228,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3271,7 +3271,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3314,7 +3314,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3343,7 +3343,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3372,7 +3372,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3401,7 +3401,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3430,7 +3430,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -3459,7 +3459,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be one of {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeOneOfTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeOneOfTests.cs
@@ -19,7 +19,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -52,7 +52,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -106,7 +106,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -123,7 +123,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -161,7 +161,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -178,7 +178,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -206,7 +206,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -244,7 +244,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -272,7 +272,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -301,7 +301,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -325,7 +325,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -360,7 +360,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -388,7 +388,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -416,7 +416,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -445,7 +445,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -462,7 +462,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -491,7 +491,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -508,7 +508,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -537,7 +537,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -554,7 +554,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -583,7 +583,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -600,7 +600,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -629,7 +629,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -646,7 +646,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -675,7 +675,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -692,7 +692,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -721,7 +721,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -738,7 +738,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -766,7 +766,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -794,7 +794,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -822,7 +822,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -850,7 +850,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be one of {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -905,7 +905,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -955,7 +955,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -971,7 +971,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             not be one of [NaN],
-				             but found NaN.
+				             but found NaN
 				             """);
 		}
 
@@ -998,7 +998,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of [{Formatter.Format(unexpected)}],
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1038,7 +1038,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1054,7 +1054,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             not be one of [NaN],
-				             but found NaN.
+				             but found NaN
 				             """);
 		}
 
@@ -1105,7 +1105,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1146,7 +1146,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1162,7 +1162,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of [{Formatter.Format(unexpected)}],
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1203,7 +1203,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1231,7 +1231,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1298,7 +1298,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1338,7 +1338,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1378,7 +1378,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1406,7 +1406,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1447,7 +1447,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1488,7 +1488,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1529,7 +1529,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1570,7 +1570,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1611,7 +1611,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1652,7 +1652,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1706,7 +1706,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1747,7 +1747,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1788,7 +1788,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1829,7 +1829,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1871,7 +1871,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be one of {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeOneOfTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeOneOfTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using Testably.Expectations.Formatting;
 
 namespace Testably.Expectations.Tests.ThatTests.Numbers;
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BePositiveTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BePositiveTests.cs
@@ -26,7 +26,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -52,7 +52,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -121,7 +121,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -190,7 +190,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -216,7 +216,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -248,7 +248,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -292,7 +292,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -378,7 +378,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -463,7 +463,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -505,7 +505,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -548,7 +548,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -591,7 +591,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -633,7 +633,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -659,7 +659,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BePositiveTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BePositiveTests.cs
@@ -26,7 +26,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -52,7 +52,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -68,7 +68,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found NaN.
+				             but found NaN
 				             """);
 		}
 
@@ -84,7 +84,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found -∞.
+				             but found -∞
 				             """);
 		}
 
@@ -121,7 +121,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -137,7 +137,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found NaN.
+				             but found NaN
 				             """);
 		}
 
@@ -153,7 +153,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found -∞.
+				             but found -∞
 				             """);
 		}
 
@@ -190,7 +190,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -216,7 +216,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -248,7 +248,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -264,7 +264,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -292,7 +292,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -308,7 +308,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found NaN.
+				             but found NaN
 				             """);
 		}
 
@@ -324,7 +324,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found -∞.
+				             but found -∞
 				             """);
 		}
 
@@ -340,7 +340,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -378,7 +378,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -394,7 +394,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found NaN.
+				             but found NaN
 				             """);
 		}
 
@@ -410,7 +410,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found -∞.
+				             but found -∞
 				             """);
 		}
 
@@ -426,7 +426,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -463,7 +463,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -479,7 +479,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -505,7 +505,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -521,7 +521,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -548,7 +548,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -564,7 +564,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -591,7 +591,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -607,7 +607,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             be positive,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -633,7 +633,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -659,7 +659,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be positive,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeTests.WithinTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeTests.WithinTests.cs
@@ -31,7 +31,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -66,7 +66,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -109,7 +109,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -152,7 +152,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -195,7 +195,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -238,7 +238,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -281,7 +281,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -316,7 +316,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -359,7 +359,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -402,7 +402,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -445,7 +445,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -488,7 +488,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -531,7 +531,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -574,7 +574,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -617,7 +617,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -646,7 +646,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -675,7 +675,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -704,7 +704,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -747,7 +747,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -790,7 +790,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -819,7 +819,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -848,7 +848,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              be {Formatter.Format(expected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 		}
@@ -871,7 +871,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -903,7 +903,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -949,7 +949,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 0.11,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -992,7 +992,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 0.11,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -1035,7 +1035,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1078,7 +1078,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1121,7 +1121,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1153,7 +1153,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 0.1,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -1199,7 +1199,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 0.11,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -1242,7 +1242,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 0.11,
-					              but found 12.5.
+					              but found 12.5
 					              """);
 			}
 
@@ -1285,7 +1285,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1328,7 +1328,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1371,7 +1371,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1414,7 +1414,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1457,7 +1457,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1486,7 +1486,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1515,7 +1515,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1544,7 +1544,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1587,7 +1587,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1630,7 +1630,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1659,7 +1659,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 
@@ -1688,7 +1688,7 @@ public sealed partial class NumberShould
 					.WithMessage($"""
 					              Expected subject to
 					              not be {Formatter.Format(unexpected)} ± 1,
-					              but found 5.
+					              but found 5
 					              """);
 			}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeTests.WithinTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeTests.WithinTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace Testably.Expectations.Tests.ThatTests.Numbers;
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
 
 public sealed partial class NumberShould
 {
@@ -32,7 +30,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -67,7 +65,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              be {Formatter.Format(expected)} ± 0.1,
 					              but found 12.5.
 					              """);
 			}
@@ -110,7 +108,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              be {Formatter.Format(expected)} ± 0.1,
 					              but found 12.5.
 					              """);
 			}
@@ -153,7 +151,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              be {Formatter.Format(expected)} ± 0.1,
 					              but found 12.5.
 					              """);
 			}
@@ -196,7 +194,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -239,7 +237,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -282,7 +280,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -317,7 +315,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              be {Formatter.Format(expected)} ± 0.1,
 					              but found 12.5.
 					              """);
 			}
@@ -360,7 +358,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected?.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              be {Formatter.Format(expected)} ± 0.1,
 					              but found 12.5.
 					              """);
 			}
@@ -403,7 +401,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected?.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              be {Formatter.Format(expected)} ± 0.1,
 					              but found 12.5.
 					              """);
 			}
@@ -446,7 +444,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -489,7 +487,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -532,7 +530,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -575,7 +573,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -618,7 +616,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -647,7 +645,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -676,7 +674,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -705,7 +703,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -748,7 +746,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -791,7 +789,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -820,7 +818,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -849,7 +847,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              be {expected} ± 1,
+					              be {Formatter.Format(expected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -872,7 +870,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -904,7 +902,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              not be {Formatter.Format(unexpected)} ± 0.1,
 					              but found 12.5.
 					              """);
 			}
@@ -950,7 +948,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected.ToString(CultureInfo.InvariantCulture)} ± 0.11,
+					              not be {Formatter.Format(unexpected)} ± 0.11,
 					              but found 12.5.
 					              """);
 			}
@@ -993,7 +991,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected.ToString(CultureInfo.InvariantCulture)} ± 0.11,
+					              not be {Formatter.Format(unexpected)} ± 0.11,
 					              but found 12.5.
 					              """);
 			}
@@ -1036,7 +1034,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1079,7 +1077,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1122,7 +1120,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1154,7 +1152,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected.ToString(CultureInfo.InvariantCulture)} ± 0.1,
+					              not be {Formatter.Format(unexpected)} ± 0.1,
 					              but found 12.5.
 					              """);
 			}
@@ -1200,7 +1198,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected?.ToString(CultureInfo.InvariantCulture)} ± 0.11,
+					              not be {Formatter.Format(unexpected)} ± 0.11,
 					              but found 12.5.
 					              """);
 			}
@@ -1243,7 +1241,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected?.ToString(CultureInfo.InvariantCulture)} ± 0.11,
+					              not be {Formatter.Format(unexpected)} ± 0.11,
 					              but found 12.5.
 					              """);
 			}
@@ -1286,7 +1284,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1329,7 +1327,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1372,7 +1370,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1415,7 +1413,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1458,7 +1456,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1487,7 +1485,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1516,7 +1514,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1545,7 +1543,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1588,7 +1586,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1631,7 +1629,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1660,7 +1658,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}
@@ -1689,7 +1687,7 @@ public sealed partial class NumberShould
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage($"""
 					              Expected subject to
-					              not be {unexpected} ± 1,
+					              not be {Formatter.Format(unexpected)} ± 1,
 					              but found 5.
 					              """);
 			}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace Testably.Expectations.Tests.ThatTests.Numbers;
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
 
 public sealed partial class NumberShould
 {
@@ -20,7 +18,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -36,8 +34,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -65,7 +63,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -84,8 +82,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -127,7 +125,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -153,8 +151,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -170,8 +168,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -199,7 +197,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -225,8 +223,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -242,8 +240,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -272,7 +270,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -288,8 +286,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -328,7 +326,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -344,8 +342,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -372,8 +370,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -401,7 +399,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
+				              be {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -419,7 +417,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -438,8 +436,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -470,7 +468,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -486,8 +484,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -515,7 +513,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -531,8 +529,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected?.ToString(CultureInfo.InvariantCulture) ?? "<null>"},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture) ?? "<null>"}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -559,8 +557,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -588,7 +586,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
+				              be {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -605,8 +603,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -634,7 +632,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
+				              be {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -651,8 +649,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -680,7 +678,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
+				              be {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -697,8 +695,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -726,7 +724,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
+				              be {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -743,8 +741,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -772,7 +770,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
+				              be {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -789,8 +787,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -818,7 +816,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
+				              be {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -835,8 +833,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -864,7 +862,7 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
+				              be {Formatter.Format(expected)},
 				              but found <null>.
 				              """);
 		}
@@ -883,7 +881,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -899,8 +897,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -929,7 +927,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -945,8 +943,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -975,7 +973,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -991,8 +989,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1021,7 +1019,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1037,8 +1035,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1067,7 +1065,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {subject}.
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1083,8 +1081,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected},
-				              but found {subject}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1138,8 +1136,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1184,8 +1182,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1227,8 +1225,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1267,8 +1265,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1334,8 +1332,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1375,8 +1373,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1391,8 +1389,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1432,8 +1430,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1460,8 +1458,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1521,8 +1519,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture)}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1561,8 +1559,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture)}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1601,8 +1599,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected?.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject?.ToString(CultureInfo.InvariantCulture)}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1629,8 +1627,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1670,8 +1668,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1711,8 +1709,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1752,8 +1750,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1793,8 +1791,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1834,8 +1832,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1875,8 +1873,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1929,8 +1927,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -1970,8 +1968,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -2011,8 +2009,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -2052,8 +2050,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -2093,8 +2091,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              not be {unexpected},
-				              but found {subject}.
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.BeTests.cs
@@ -18,7 +18,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -35,7 +35,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -63,7 +63,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -83,7 +83,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -125,7 +125,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -152,7 +152,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -169,7 +169,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -197,7 +197,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -224,7 +224,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -241,7 +241,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -270,7 +270,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -287,7 +287,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -326,7 +326,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -343,7 +343,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -371,7 +371,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -400,7 +400,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -417,7 +417,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -437,7 +437,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -468,7 +468,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -485,7 +485,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -513,7 +513,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -530,7 +530,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -558,7 +558,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -587,7 +587,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -604,7 +604,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -633,7 +633,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -650,7 +650,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -679,7 +679,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -696,7 +696,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -725,7 +725,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -742,7 +742,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -771,7 +771,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -788,7 +788,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -817,7 +817,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -834,7 +834,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -863,7 +863,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found <null>.
+				              but found <null>
 				              """);
 		}
 
@@ -881,7 +881,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -898,7 +898,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -927,7 +927,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -944,7 +944,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -973,7 +973,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -990,7 +990,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1019,7 +1019,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1036,7 +1036,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1065,7 +1065,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be <null>,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1082,7 +1082,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1137,7 +1137,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1183,7 +1183,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1199,7 +1199,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             not be NaN,
-				             but found NaN.
+				             but found NaN
 				             """);
 		}
 
@@ -1226,7 +1226,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1266,7 +1266,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1282,7 +1282,7 @@ public sealed partial class NumberShould
 				.WithMessage("""
 				             Expected subject to
 				             not be NaN,
-				             but found NaN.
+				             but found NaN
 				             """);
 		}
 
@@ -1333,7 +1333,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1374,7 +1374,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1390,7 +1390,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1431,7 +1431,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1459,7 +1459,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1520,7 +1520,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1560,7 +1560,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1600,7 +1600,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1628,7 +1628,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1669,7 +1669,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1710,7 +1710,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1751,7 +1751,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1792,7 +1792,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1833,7 +1833,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1874,7 +1874,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1928,7 +1928,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -1969,7 +1969,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -2010,7 +2010,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -2051,7 +2051,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -2092,7 +2092,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace Testably.Expectations.Tests.ThatTests.Numbers;
+﻿namespace Testably.Expectations.Tests.ThatTests.Numbers;
 
 public sealed partial class NumberShould
 {
@@ -16,8 +14,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -31,8 +29,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -46,8 +44,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -61,8 +59,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -76,8 +74,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -91,8 +89,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -106,8 +104,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -121,8 +119,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -136,8 +134,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -151,8 +149,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 
@@ -166,8 +164,8 @@ public sealed partial class NumberShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              be {expected.ToString(CultureInfo.InvariantCulture)},
-				              but found {subject.ToString(CultureInfo.InvariantCulture)}.
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Numbers/NumberShould.cs
@@ -15,7 +15,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -30,7 +30,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -45,7 +45,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -60,7 +60,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -75,7 +75,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -90,7 +90,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -105,7 +105,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -120,7 +120,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -135,7 +135,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -150,7 +150,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -165,7 +165,7 @@ public sealed partial class NumberShould
 				.WithMessage($"""
 				              Expected subject to
 				              be {Formatter.Format(expected)},
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.Be.EquivalentTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.Be.EquivalentTests.cs
@@ -33,7 +33,7 @@ public sealed partial class ObjectShould
 					             be equivalent to expected,
 					             but Property Value did not match:
 					               Expected: "Foo"
-					               Received: <null>.
+					               Received: <null>
 					             """);
 			}
 
@@ -113,7 +113,7 @@ public sealed partial class ObjectShould
 					             be equivalent to expected,
 					             but EnumerableItem Inner.Inner.Collection.[3] did not match:
 					               Expected: "4"
-					               Received: <null>.
+					               Received: <null>
 					             """);
 			}
 
@@ -196,7 +196,7 @@ public sealed partial class ObjectShould
 					.WithMessage("""
 					             Expected subject to
 					             be equivalent to expected,
-					             but found z.
+					             but found z
 					             """);
 			}
 
@@ -259,7 +259,7 @@ public sealed partial class ObjectShould
 					             be equivalent to expected,
 					             but Property Inner.Inner.Value did not match:
 					               Expected: "Baz"
-					               Received: <null>.
+					               Received: <null>
 					             """);
 			}
 		}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.Be.UsingTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.Be.UsingTests.cs
@@ -24,7 +24,7 @@ public sealed partial class ObjectShould
 					             but found OuterClass {
 					               Inner = <null>,
 					               Value = "Foo"
-					             }.
+					             }
 					             """);
 			}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.BeNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.BeNullTests.cs
@@ -28,7 +28,7 @@ public sealed partial class ObjectShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null, because we want to test the failure,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 	}
@@ -48,7 +48,7 @@ public sealed partial class ObjectShould
 				.WithMessage("""
 				             Expected subject to
 				             not be null, because we want to test the failure,
-				             but it was.
+				             but it was
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.BeNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.BeNullTests.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Expectations.Formatting;
-
-namespace Testably.Expectations.Tests.ThatTests.Objects;
+﻿namespace Testably.Expectations.Tests.ThatTests.Objects;
 
 public sealed partial class ObjectShould
 {

--- a/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.BeTests.cs
@@ -30,7 +30,7 @@ public sealed partial class ObjectShould
 				               be type OtherClass, because we want to test the failure,
 				               but found MyClass {
 				                 Value = {{value}}
-				               }.
+				               }
 				               """);
 		}
 
@@ -61,7 +61,7 @@ public sealed partial class ObjectShould
 				               be type MyClass, because {{reason}},
 				               but found MyBaseClass {
 				                 Value = {{value}}
-				               }.
+				               }
 				               """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.ForTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.ForTests.cs
@@ -18,8 +18,8 @@ public sealed partial class ObjectShould
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage($"""
 				              Expected subject to
-				              for .Value be {expectedValue},
-				              but found {value}.
+				              for .Value be {Formatter.Format(expectedValue)},
+				              but found {Formatter.Format(value)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.ForTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.ForTests.cs
@@ -19,7 +19,7 @@ public sealed partial class ObjectShould
 				.WithMessage($"""
 				              Expected subject to
 				              for .Value be {Formatter.Format(expectedValue)},
-				              but found {Formatter.Format(value)}.
+				              but found {Formatter.Format(value)}
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Streams/BufferedStreamShould.HaveBufferSizeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Streams/BufferedStreamShould.HaveBufferSizeTests.cs
@@ -21,7 +21,7 @@ public sealed partial class BufferedStreamShould
 				.WithMessage($"""
 				                   Expected subject to
 				                   have buffer size {bufferSize},
-				                   but it had buffer size {actualBufferSize}.
+				                   but it had buffer size {actualBufferSize}
 				                   """);
 		}
 
@@ -49,7 +49,7 @@ public sealed partial class BufferedStreamShould
 				.WithMessage("""
 				             Expected subject to
 				             have buffer size 0,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}
@@ -82,7 +82,7 @@ public sealed partial class BufferedStreamShould
 				.WithMessage($"""
 				                   Expected subject to
 				                   not have buffer size {bufferSize},
-				                   but it had.
+				                   but it had
 				                   """);
 		}
 
@@ -98,7 +98,7 @@ public sealed partial class BufferedStreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not have buffer size 0,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.BeReadOnlyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.BeReadOnlyTests.cs
@@ -21,7 +21,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             be read-only,
-				             but it was not.
+				             but it was not
 				             """);
 		}
 
@@ -37,7 +37,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             be read-only,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -81,7 +81,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not be read-only,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -97,7 +97,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not be read-only,
-				             but it was.
+				             but it was
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.BeReadableTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.BeReadableTests.cs
@@ -18,7 +18,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             be readable,
-				             but it was not.
+				             but it was not
 				             """);
 		}
 
@@ -34,7 +34,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             be readable,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -75,7 +75,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not be readable,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -91,7 +91,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not be readable,
-				             but it was.
+				             but it was
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.BeSeekableTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.BeSeekableTests.cs
@@ -18,7 +18,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             be seekable,
-				             but it was not.
+				             but it was not
 				             """);
 		}
 
@@ -34,7 +34,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             be seekable,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -75,7 +75,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not be seekable,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -91,7 +91,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not be seekable,
-				             but it was.
+				             but it was
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.BeWritableTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.BeWritableTests.cs
@@ -18,7 +18,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             be writable,
-				             but it was not.
+				             but it was not
 				             """);
 		}
 
@@ -34,7 +34,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             be writable,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -75,7 +75,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not be writable,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -91,7 +91,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not be writable,
-				             but it was.
+				             but it was
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.BeWriteOnlyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.BeWriteOnlyTests.cs
@@ -21,7 +21,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             be write-only,
-				             but it was not.
+				             but it was not
 				             """);
 		}
 
@@ -37,7 +37,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             be write-only,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -81,7 +81,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not be write-only,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -97,7 +97,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not be write-only,
-				             but it was.
+				             but it was
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.HaveLengthTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.HaveLengthTests.cs
@@ -20,7 +20,7 @@ public sealed partial class StreamShould
 				.WithMessage($"""
 				              Expected subject to
 				              have length {length},
-				              but it had length {actualLength}.
+				              but it had length {actualLength}
 				              """);
 		}
 
@@ -48,7 +48,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             have length 0,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}
@@ -81,7 +81,7 @@ public sealed partial class StreamShould
 				.WithMessage($"""
 				              Expected subject to
 				              not have length {length},
-				              but it had.
+				              but it had
 				              """);
 		}
 
@@ -97,7 +97,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not have length 0,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.HavePositionTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Streams/StreamShould.HavePositionTests.cs
@@ -20,7 +20,7 @@ public sealed partial class StreamShould
 				.WithMessage($"""
 				              Expected subject to
 				              have position {position},
-				              but it had position {actualPosition}.
+				              but it had position {actualPosition}
 				              """);
 		}
 
@@ -48,7 +48,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             have position 0,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}
@@ -81,7 +81,7 @@ public sealed partial class StreamShould
 				.WithMessage($"""
 				              Expected subject to
 				              not have position {position},
-				              but it had.
+				              but it had
 				              """);
 		}
 
@@ -97,7 +97,7 @@ public sealed partial class StreamShould
 				.WithMessage("""
 				             Expected subject to
 				             not have position 0,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeEmptyTests.cs
@@ -26,7 +26,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be empty,
-				              but found "{subject}".
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeEmptyTests.cs
@@ -26,7 +26,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be empty,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -42,7 +42,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be empty,
-				              but found "{StringWith100Characters}…".
+				              but found "{StringWith100Characters}…"
 				              """);
 		}
 
@@ -58,7 +58,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             be empty,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -74,7 +74,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             be empty,
-				             but found " \t ".
+				             but found " \t "
 				             """);
 		}
 	}
@@ -93,7 +93,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be empty,
-				             but it was.
+				             but it was
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeLowerCasedTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeLowerCasedTests.cs
@@ -60,7 +60,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             be lower-cased,
-				             but found "aBc".
+				             but found "aBc"
 				             """);
 		}
 
@@ -76,7 +76,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be lower-cased,
-				              but found "{StringWith100Characters}…".
+				              but found "{StringWith100Characters}…"
 				              """);
 		}
 
@@ -92,7 +92,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             be lower-cased,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -108,7 +108,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             be lower-cased,
-				             but found "ABC".
+				             but found "ABC"
 				             """);
 		}
 
@@ -138,7 +138,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be lower-cased,
-				             but found "".
+				             but found ""
 				             """);
 		}
 
@@ -154,7 +154,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be lower-cased,
-				             but found "abc".
+				             but found "abc"
 				             """);
 		}
 
@@ -170,7 +170,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be lower-cased,
-				             but found "a漢字b".
+				             but found "a漢字b"
 				             """);
 		}
 
@@ -186,7 +186,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be lower-cased,
-				             but found "a-b-c!".
+				             but found "a-b-c!"
 				             """);
 		}
 
@@ -213,7 +213,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be lower-cased,
-				              but found "{StringWith100Characters.ToLowerInvariant()}…".
+				              but found "{StringWith100Characters.ToLowerInvariant()}…"
 				              """);
 		}
 
@@ -251,7 +251,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be lower-cased,
-				             but found " \t ".
+				             but found " \t "
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrEmptyTests.cs
@@ -26,7 +26,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null or empty,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -42,7 +42,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null or empty,
-				              but found "{StringWith100Characters}…".
+				              but found "{StringWith100Characters}…"
 				              """);
 		}
 
@@ -69,7 +69,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             be null or empty,
-				             but found " \t ".
+				             but found " \t "
 				             """);
 		}
 	}
@@ -88,7 +88,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be null or empty,
-				             but found "".
+				             but found ""
 				             """);
 		}
 
@@ -114,7 +114,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be null or empty,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrEmptyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrEmptyTests.cs
@@ -26,7 +26,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null or empty,
-				              but found "{subject}".
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrWhiteSpaceTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrWhiteSpaceTests.cs
@@ -26,7 +26,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null or white-space,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -42,7 +42,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null or white-space,
-				              but found "{StringWith100Characters}…".
+				              but found "{StringWith100Characters}…"
 				              """);
 		}
 
@@ -83,7 +83,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be null or white-space,
-				             but found "".
+				             but found ""
 				             """);
 		}
 
@@ -109,7 +109,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be null or white-space,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -125,7 +125,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be null or white-space,
-				              but found "{new string(' ', 100)}…".
+				              but found "{new string(' ', 100)}…"
 				              """);
 		}
 
@@ -141,7 +141,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be null or white-space,
-				             but found " \t ".
+				             but found " \t "
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrWhiteSpaceTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullOrWhiteSpaceTests.cs
@@ -26,7 +26,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null or white-space,
-				              but found "{subject}".
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullTests.cs
@@ -16,7 +16,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             be null,
-				             but found "".
+				             but found ""
 				             """);
 		}
 
@@ -31,7 +31,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null,
-				              but found {Formatter.Format(subject)}.
+				              but found {Formatter.Format(subject)}
 				              """);
 		}
 
@@ -82,7 +82,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be null,
-				             but it was.
+				             but it was
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeNullTests.cs
@@ -31,7 +31,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be null,
-				              but found "{subject}".
+				              but found {Formatter.Format(subject)}.
 				              """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeTests.cs
@@ -49,7 +49,7 @@ public sealed partial class StringShould
 				                ↓ (actual)
 				               "actual text"
 				               "expected other text"
-				                ↑ (expected).
+				                ↑ (expected)
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeUpperCasedTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.BeUpperCasedTests.cs
@@ -27,7 +27,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             be upper-cased,
-				             but found "abc".
+				             but found "abc"
 				             """);
 		}
 
@@ -43,7 +43,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             be upper-cased,
-				             but found "AbC".
+				             but found "AbC"
 				             """);
 		}
 
@@ -59,7 +59,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              be upper-cased,
-				              but found "{StringWith100Characters}…".
+				              but found "{StringWith100Characters}…"
 				              """);
 		}
 
@@ -75,7 +75,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             be upper-cased,
-				             but found <null>.
+				             but found <null>
 				             """);
 		}
 
@@ -138,7 +138,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be upper-cased,
-				             but found "".
+				             but found ""
 				             """);
 		}
 
@@ -176,7 +176,7 @@ public sealed partial class StringShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be upper-cased,
-				              but found "{StringWith100Characters.ToUpperInvariant()}…".
+				              but found "{StringWith100Characters.ToUpperInvariant()}…"
 				              """);
 		}
 
@@ -203,7 +203,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be upper-cased,
-				             but found "ABC".
+				             but found "ABC"
 				             """);
 		}
 
@@ -219,7 +219,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be upper-cased,
-				             but found "A漢字B".
+				             but found "A漢字B"
 				             """);
 		}
 
@@ -235,7 +235,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be upper-cased,
-				             but found "A-B-C!".
+				             but found "A-B-C!"
 				             """);
 		}
 
@@ -251,7 +251,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not be upper-cased,
-				             but found " \t ".
+				             but found " \t "
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.ContainTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.ContainTests.cs
@@ -31,7 +31,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             contain "in" at least 5 times,
-				             but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -49,7 +49,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             contain "text that does not occur" at least once,
-				             but found it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -82,7 +82,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             contain "in" at most 2 times,
-				             but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -141,7 +141,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             contain "in" between 4 and 9 times,
-				             but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -159,7 +159,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             contain "in" between 1 and 2 times,
-				             but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -276,7 +276,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             contain "in" exactly 4 times,
-				             but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -294,7 +294,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             contain "in" exactly 2 times,
-				             but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -312,7 +312,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             contain "in" at least 7 times ignoring case,
-				             but found it 5 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 5 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -357,7 +357,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not contain "investigator",
-				             but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -388,7 +388,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             contain "detective" exactly once,
-				             but found it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -406,7 +406,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             contain "word" exactly once,
-				             but found it 2 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 2 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -441,7 +441,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             contain "in" exactly 5 times using IgnoreCaseForVocalsComparer,
-				             but found it 4 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 4 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -470,7 +470,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             contain "not" at least once,
-				             but found it 0 times in "some text".
+				             but found it 0 times in "some text"
 				             """);
 		}
 	}
@@ -491,7 +491,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not contain "INVESTIGATOR" ignoring case,
-				             but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -510,7 +510,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not contain "InvEstIgAtOr" using IgnoreCaseForVocalsComparer,
-				             but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times.".
+				             but found it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 				             """);
 		}
 
@@ -527,7 +527,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not contain "me",
-				             but found it 1 times in "some text".
+				             but found it 1 times in "some text"
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.EndWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.EndWithTests.cs
@@ -22,7 +22,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             end with "TEXT",
-				             but found "some arbitrary text".
+				             but found "some arbitrary text"
 				             """);
 		}
 
@@ -40,7 +40,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             end with "SOME" ignoring case,
-				             but found "some arbitrary text".
+				             but found "some arbitrary text"
 				             """);
 		}
 
@@ -59,7 +59,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             end with "TEXT" using IgnoreCaseForVocalsComparer,
-				             but found "some arbitrary text".
+				             but found "some arbitrary text"
 				             """);
 		}
 
@@ -90,7 +90,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             end with "some",
-				             but found "some arbitrary text".
+				             but found "some arbitrary text"
 				             """);
 		}
 
@@ -122,7 +122,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not end with "TEXT" ignoring case,
-				             but found "some text".
+				             but found "some text"
 				             """);
 		}
 
@@ -153,7 +153,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not end with "tExt" using IgnoreCaseForVocalsComparer,
-				             but found "some arbitrary text".
+				             but found "some arbitrary text"
 				             """);
 		}
 
@@ -184,7 +184,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not end with "text",
-				             but found "some text".
+				             but found "some text"
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.StartWithTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Strings/StringShould.StartWithTests.cs
@@ -23,7 +23,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             start with "SOME",
-				             but found "some arbitrary text".
+				             but found "some arbitrary text"
 				             """);
 		}
 
@@ -41,7 +41,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             start with "TEXT" ignoring case,
-				             but found "some arbitrary text".
+				             but found "some arbitrary text"
 				             """);
 		}
 
@@ -60,7 +60,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             start with "SOME" using IgnoreCaseForVocalsComparer,
-				             but found "some arbitrary text".
+				             but found "some arbitrary text"
 				             """);
 		}
 
@@ -91,7 +91,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             start with "text",
-				             but found "some arbitrary text".
+				             but found "some arbitrary text"
 				             """);
 		}
 
@@ -135,7 +135,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not start with "some",
-				             but found "some text".
+				             but found "some text"
 				             """);
 		}
 
@@ -168,7 +168,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not start with "sOmE" using IgnoreCaseForVocalsComparer,
-				             but found "some arbitrary text".
+				             but found "some arbitrary text"
 				             """);
 		}
 
@@ -197,7 +197,7 @@ public sealed partial class StringShould
 				.WithMessage("""
 				             Expected subject to
 				             not start with "SOME" ignoring case,
-				             but found "some text".
+				             but found "some text"
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/Usings.cs
+++ b/Tests/Testably.Expectations.Tests/Usings.cs
@@ -3,4 +3,5 @@ global using System.Threading.Tasks;
 global using AutoFixture.Xunit2;
 global using Xunit;
 global using Xunit.Sdk;
+global using Testably.Expectations.Formatting;
 global using static Testably.Expectations.Expect;


### PR DESCRIPTION
Fixes #141:
- Change default formatting to single-line
- Adapt string formatting to display white-space and limit length to 100 characters in single-line mode
- Remove trailing dot in exception message, as it could cause confusion for multi-line found values