### PR TITLE
feat: add a throw overload that takes a Type parameter

### DIFF
--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.Throw.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.Throw.cs
@@ -15,4 +15,16 @@ public static partial class ThatDelegateShould
 				.AddConstraint(new ThrowsCastConstraint<TException>(throwOptions)),
 			throwOptions);
 	}
+
+	/// <summary>
+	///     Verifies that the delegate throws an exception of type <paramref name="exceptionType" />.
+	/// </summary>
+	public static ThatDelegateThrows<Exception> Throw(this ThatDelegate source,
+		Type exceptionType)
+	{
+		ThrowsOption throwOptions = new();
+		return new ThatDelegateThrows<Exception>(source.ExpectationBuilder
+				.AddConstraint(new ThrowsCastConstraint(exceptionType, throwOptions)),
+			throwOptions);
+	}
 }

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.cs
@@ -39,6 +39,43 @@ public static partial class ThatDelegateShould
 		return new ConstraintResult.Success<TException?>(default, DoesNotThrowExpectation, true);
 	}
 
+	private readonly struct ThrowsCastConstraint(Type exceptionType, ThrowsOption throwOptions)
+		: ICastConstraint<DelegateValue, Exception?>
+	{
+		/// <inheritdoc />
+		public ConstraintResult IsMetBy(DelegateValue? value)
+		{
+			Exception? exception = value?.Exception;
+			if (!throwOptions.DoCheckThrow)
+			{
+				return DoesNotThrowResult<Exception>(exception);
+			}
+
+			if (exceptionType.IsAssignableFrom(exception?.GetType()))
+			{
+				return new ConstraintResult.Success<Exception?>(exception, ToString());
+			}
+
+			if (exception is null)
+			{
+				return new ConstraintResult.Failure<Exception?>(null, ToString(), "it did not");
+			}
+
+			return new ConstraintResult.Failure<Exception?>(null, ToString(),
+				$"it did throw {exception.FormatForMessage()}");
+		}
+
+		public override string ToString()
+		{
+			if (!throwOptions.DoCheckThrow)
+			{
+				return DoesNotThrowExpectation;
+			}
+
+			return $"throw {exceptionType.Name.PrependAOrAn()}";
+		}
+	}
+
 	private readonly struct ThrowsCastConstraint<TException>(ThrowsOption throwOptions)
 		: ICastConstraint<DelegateValue, TException?>
 		where TException : Exception

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithInner.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithInner.cs
@@ -32,4 +32,32 @@ public partial class ThatDelegateThrows<TException>
 					new ThatExceptionShould.HasInnerExceptionValueConstraint<TInnerException>(
 						"with")),
 			this);
+	
+	
+	
+	
+	/// <summary>
+	///     Verifies that the thrown exception has an inner exception of type <paramref name="innerExceptionType" /> which
+	///     satisfies the <paramref name="expectations" />.
+	/// </summary>
+	public AndOrResult<TException, ThatDelegateThrows<TException>> WithInner(
+		Type innerExceptionType,
+		Action<ThatExceptionShould<Exception?>> expectations)
+		=> new(ExpectationBuilder
+				.ForProperty<Exception, Exception?>(e => e.InnerException,
+					$"with an inner {innerExceptionType.Name} which should ")
+				.Validate(new ThatExceptionShould.ExceptionCastConstraint(innerExceptionType))
+				.AddExpectations(e => expectations(new ThatExceptionShould<Exception?>(e))),
+			this);
+
+	/// <summary>
+	///     Verifies that the actual exception has an inner exception of type <paramref name="innerExceptionType" />.
+	/// </summary>
+	public AndOrResult<TException, ThatDelegateThrows<TException>> WithInner(Type innerExceptionType)
+		=> new(ExpectationBuilder
+				.AddConstraint(
+					new ThatExceptionShould.HasInnerExceptionValueConstraint(
+						innerExceptionType,
+						"with")),
+			this);
 }

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithInner.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateThrows.WithInner.cs
@@ -32,10 +32,7 @@ public partial class ThatDelegateThrows<TException>
 					new ThatExceptionShould.HasInnerExceptionValueConstraint<TInnerException>(
 						"with")),
 			this);
-	
-	
-	
-	
+
 	/// <summary>
 	///     Verifies that the thrown exception has an inner exception of type <paramref name="innerExceptionType" /> which
 	///     satisfies the <paramref name="expectations" />.
@@ -53,7 +50,8 @@ public partial class ThatDelegateThrows<TException>
 	/// <summary>
 	///     Verifies that the actual exception has an inner exception of type <paramref name="innerExceptionType" />.
 	/// </summary>
-	public AndOrResult<TException, ThatDelegateThrows<TException>> WithInner(Type innerExceptionType)
+	public AndOrResult<TException, ThatDelegateThrows<TException>> WithInner(
+		Type innerExceptionType)
 		=> new(ExpectationBuilder
 				.AddConstraint(
 					new ThatExceptionShould.HasInnerExceptionValueConstraint(

--- a/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveInner.cs
+++ b/Source/Testably.Expectations/That/Exceptions/ThatExceptionShould.HaveInner.cs
@@ -30,9 +30,32 @@ public partial class ThatExceptionShould<TException>
 	public AndOrResult<TException, ThatExceptionShould<TException>> HaveInner<
 		TInnerException>()
 		where TInnerException : Exception?
+		=> new(ExpectationBuilder.AddConstraint(
+				new ThatExceptionShould.HasInnerExceptionValueConstraint<TInnerException>(
+					"have")),
+			this);
+
+	/// <summary>
+	///     Verifies that the actual exception has an inner exception of type <paramref name="innerExceptionType" /> which
+	///     satisfies the <paramref name="expectations" />.
+	/// </summary>
+	public AndOrResult<TException, ThatExceptionShould<TException>> HaveInner(
+		Type innerExceptionType,
+		Action<ThatExceptionShould<Exception?>> expectations)
 		=> new(ExpectationBuilder
-				.AddConstraint(
-					new ThatExceptionShould.HasInnerExceptionValueConstraint<TInnerException>(
-						"have")),
+				.ForProperty<Exception, Exception?>(e => e.InnerException,
+					$"have an inner {innerExceptionType.Name} which should ")
+				.Validate(new ThatExceptionShould.ExceptionCastConstraint(innerExceptionType))
+				.AddExpectations(e => expectations(new ThatExceptionShould<Exception?>(e))),
+			this);
+
+	/// <summary>
+	///     Verifies that the actual exception has an inner exception of type <paramref name="innerExceptionType" />.
+	/// </summary>
+	public AndOrResult<TException, ThatExceptionShould<TException>> HaveInner(
+		Type innerExceptionType)
+		=> new(ExpectationBuilder.AddConstraint(
+				new ThatExceptionShould.HasInnerExceptionValueConstraint(
+					innerExceptionType, "have")),
 			this);
 }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -171,8 +171,10 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.ExpectationResult<TValue> NotThrow<TValue>(this Testably.Expectations.ThatDelegate.WithValue<TValue> source) { }
         public static Testably.Expectations.ThatDelegate.WithoutValue Should(this Testably.Expectations.Core.IExpectSubject<Testably.Expectations.ThatDelegate.WithoutValue> subject) { }
         public static Testably.Expectations.ThatDelegate.WithValue<TValue> Should<TValue>(this Testably.Expectations.Core.IExpectSubject<Testably.Expectations.ThatDelegate.WithValue<TValue>> subject) { }
+        public static Testably.Expectations.ThatDelegateThrows<System.Exception> Throw(this Testably.Expectations.ThatDelegate source, System.Type exceptionType) { }
         public static Testably.Expectations.ThatDelegateThrows<TException> Throw<TException>(this Testably.Expectations.ThatDelegate source)
             where TException : System.Exception { }
+        public static Testably.Expectations.ThatDelegateThrows<System.Exception> ThrowExactly(this Testably.Expectations.ThatDelegate source, System.Type exceptionType) { }
         public static Testably.Expectations.ThatDelegateThrows<TException> ThrowExactly<TException>(this Testably.Expectations.ThatDelegate source)
             where TException : System.Exception { }
         public static Testably.Expectations.ThatDelegateThrows<System.Exception> ThrowException(this Testably.Expectations.ThatDelegate source) { }
@@ -182,6 +184,8 @@ namespace Testably.Expectations
     {
         public Testably.Expectations.Core.ExpectationBuilder ExpectationBuilder { get; }
         public Testably.Expectations.ThatDelegateThrows<TException?> OnlyIf(bool predicate) { }
+        public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType) { }
+        public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType, System.Action<Testably.Expectations.ThatExceptionShould<System.Exception?>> expectations) { }
         public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInner<TInnerException>()
             where TInnerException : System.Exception? { }
         public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInner<TInnerException>(System.Action<Testably.Expectations.ThatExceptionShould<TInnerException?>> expectations)
@@ -238,6 +242,8 @@ namespace Testably.Expectations
     {
         public ThatExceptionShould(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }
         public Testably.Expectations.Core.ExpectationBuilder ExpectationBuilder { get; }
+        public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInner(System.Type innerExceptionType) { }
+        public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInner(System.Type innerExceptionType, System.Action<Testably.Expectations.ThatExceptionShould<System.Exception?>> expectations) { }
         public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInner<TInnerException>()
             where TInnerException : System.Exception? { }
         public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInner<TInnerException>(System.Action<Testably.Expectations.ThatExceptionShould<TInnerException?>> expectations)
@@ -632,6 +638,7 @@ namespace Testably.Expectations
     }
     public static class ThatObjectShould
     {
+        public static Testably.Expectations.Results.AndOrWhichResult<object?, Testably.Expectations.Core.IThat<object?>> Be(this Testably.Expectations.Core.IThat<object?> source, System.Type type) { }
         public static Testably.Expectations.Results.ObjectEqualityResult<object?, Testably.Expectations.Core.IThat<object?>> Be(this Testably.Expectations.Core.IThat<object?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrWhichResult<TType, Testably.Expectations.Core.IThat<object?>> Be<TType>(this Testably.Expectations.Core.IThat<object?> source) { }
         public static Testably.Expectations.Results.AndOrResult<object?, Testably.Expectations.Core.IThat<object?>> BeNull(this Testably.Expectations.Core.IThat<object?> source) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -171,8 +171,10 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.ExpectationResult<TValue> NotThrow<TValue>(this Testably.Expectations.ThatDelegate.WithValue<TValue> source) { }
         public static Testably.Expectations.ThatDelegate.WithoutValue Should(this Testably.Expectations.Core.IExpectSubject<Testably.Expectations.ThatDelegate.WithoutValue> subject) { }
         public static Testably.Expectations.ThatDelegate.WithValue<TValue> Should<TValue>(this Testably.Expectations.Core.IExpectSubject<Testably.Expectations.ThatDelegate.WithValue<TValue>> subject) { }
+        public static Testably.Expectations.ThatDelegateThrows<System.Exception> Throw(this Testably.Expectations.ThatDelegate source, System.Type exceptionType) { }
         public static Testably.Expectations.ThatDelegateThrows<TException> Throw<TException>(this Testably.Expectations.ThatDelegate source)
             where TException : System.Exception { }
+        public static Testably.Expectations.ThatDelegateThrows<System.Exception> ThrowExactly(this Testably.Expectations.ThatDelegate source, System.Type exceptionType) { }
         public static Testably.Expectations.ThatDelegateThrows<TException> ThrowExactly<TException>(this Testably.Expectations.ThatDelegate source)
             where TException : System.Exception { }
         public static Testably.Expectations.ThatDelegateThrows<System.Exception> ThrowException(this Testably.Expectations.ThatDelegate source) { }
@@ -182,6 +184,8 @@ namespace Testably.Expectations
     {
         public Testably.Expectations.Core.ExpectationBuilder ExpectationBuilder { get; }
         public Testably.Expectations.ThatDelegateThrows<TException?> OnlyIf(bool predicate) { }
+        public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType) { }
+        public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType, System.Action<Testably.Expectations.ThatExceptionShould<System.Exception?>> expectations) { }
         public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInner<TInnerException>()
             where TInnerException : System.Exception? { }
         public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInner<TInnerException>(System.Action<Testably.Expectations.ThatExceptionShould<TInnerException?>> expectations)
@@ -238,6 +242,8 @@ namespace Testably.Expectations
     {
         public ThatExceptionShould(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }
         public Testably.Expectations.Core.ExpectationBuilder ExpectationBuilder { get; }
+        public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInner(System.Type innerExceptionType) { }
+        public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInner(System.Type innerExceptionType, System.Action<Testably.Expectations.ThatExceptionShould<System.Exception?>> expectations) { }
         public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInner<TInnerException>()
             where TInnerException : System.Exception? { }
         public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInner<TInnerException>(System.Action<Testably.Expectations.ThatExceptionShould<TInnerException?>> expectations)
@@ -632,6 +638,7 @@ namespace Testably.Expectations
     }
     public static class ThatObjectShould
     {
+        public static Testably.Expectations.Results.AndOrWhichResult<object?, Testably.Expectations.Core.IThat<object?>> Be(this Testably.Expectations.Core.IThat<object?> source, System.Type type) { }
         public static Testably.Expectations.Results.ObjectEqualityResult<object?, Testably.Expectations.Core.IThat<object?>> Be(this Testably.Expectations.Core.IThat<object?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrWhichResult<TType, Testably.Expectations.Core.IThat<object?>> Be<TType>(this Testably.Expectations.Core.IThat<object?> source) { }
         public static Testably.Expectations.Results.AndOrResult<object?, Testably.Expectations.Core.IThat<object?>> BeNull(this Testably.Expectations.Core.IThat<object?> source) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -137,8 +137,10 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.ExpectationResult<TValue> NotThrow<TValue>(this Testably.Expectations.ThatDelegate.WithValue<TValue> source) { }
         public static Testably.Expectations.ThatDelegate.WithoutValue Should(this Testably.Expectations.Core.IExpectSubject<Testably.Expectations.ThatDelegate.WithoutValue> subject) { }
         public static Testably.Expectations.ThatDelegate.WithValue<TValue> Should<TValue>(this Testably.Expectations.Core.IExpectSubject<Testably.Expectations.ThatDelegate.WithValue<TValue>> subject) { }
+        public static Testably.Expectations.ThatDelegateThrows<System.Exception> Throw(this Testably.Expectations.ThatDelegate source, System.Type exceptionType) { }
         public static Testably.Expectations.ThatDelegateThrows<TException> Throw<TException>(this Testably.Expectations.ThatDelegate source)
             where TException : System.Exception { }
+        public static Testably.Expectations.ThatDelegateThrows<System.Exception> ThrowExactly(this Testably.Expectations.ThatDelegate source, System.Type exceptionType) { }
         public static Testably.Expectations.ThatDelegateThrows<TException> ThrowExactly<TException>(this Testably.Expectations.ThatDelegate source)
             where TException : System.Exception { }
         public static Testably.Expectations.ThatDelegateThrows<System.Exception> ThrowException(this Testably.Expectations.ThatDelegate source) { }
@@ -148,6 +150,8 @@ namespace Testably.Expectations
     {
         public Testably.Expectations.Core.ExpectationBuilder ExpectationBuilder { get; }
         public Testably.Expectations.ThatDelegateThrows<TException?> OnlyIf(bool predicate) { }
+        public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType) { }
+        public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType, System.Action<Testably.Expectations.ThatExceptionShould<System.Exception?>> expectations) { }
         public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInner<TInnerException>()
             where TInnerException : System.Exception? { }
         public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatDelegateThrows<TException>> WithInner<TInnerException>(System.Action<Testably.Expectations.ThatExceptionShould<TInnerException?>> expectations)
@@ -204,6 +208,8 @@ namespace Testably.Expectations
     {
         public ThatExceptionShould(Testably.Expectations.Core.ExpectationBuilder expectationBuilder) { }
         public Testably.Expectations.Core.ExpectationBuilder ExpectationBuilder { get; }
+        public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInner(System.Type innerExceptionType) { }
+        public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInner(System.Type innerExceptionType, System.Action<Testably.Expectations.ThatExceptionShould<System.Exception?>> expectations) { }
         public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInner<TInnerException>()
             where TInnerException : System.Exception? { }
         public Testably.Expectations.Results.AndOrResult<TException, Testably.Expectations.ThatExceptionShould<TException>> HaveInner<TInnerException>(System.Action<Testably.Expectations.ThatExceptionShould<TInnerException?>> expectations)
@@ -586,6 +592,7 @@ namespace Testably.Expectations
     }
     public static class ThatObjectShould
     {
+        public static Testably.Expectations.Results.AndOrWhichResult<object?, Testably.Expectations.Core.IThat<object?>> Be(this Testably.Expectations.Core.IThat<object?> source, System.Type type) { }
         public static Testably.Expectations.Results.ObjectEqualityResult<object?, Testably.Expectations.Core.IThat<object?>> Be(this Testably.Expectations.Core.IThat<object?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static Testably.Expectations.Results.AndOrWhichResult<TType, Testably.Expectations.Core.IThat<object?>> Be<TType>(this Testably.Expectations.Core.IThat<object?> source) { }
         public static Testably.Expectations.Results.AndOrResult<object?, Testably.Expectations.Core.IThat<object?>> BeNull(this Testably.Expectations.Core.IThat<object?> source) { }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowExactlyTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowExactlyTests.cs
@@ -6,7 +6,7 @@ public sealed partial class DelegateShould
 	{
 		[Theory]
 		[AutoData]
-		public async Task WhenAwaited_ShouldReturnThrownException(string value)
+		public async Task ForGeneric_WhenAwaited_ShouldReturnThrownException(string value)
 		{
 			Exception exception = new CustomException { Value = value };
 			Action action = () => throw exception;
@@ -19,7 +19,7 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
-		public async Task WhenCorrectExceptionTypeIsThrown_ShouldSucceed()
+		public async Task ForGeneric_WhenCorrectExceptionTypeIsThrown_ShouldSucceed()
 		{
 			Exception exception = new CustomException();
 			Action action = () => throw exception;
@@ -31,7 +31,7 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
-		public async Task WhenNoExceptionIsThrown_ShouldFail()
+		public async Task ForGeneric_WhenNoExceptionIsThrown_ShouldFail()
 		{
 			Action action = () => { };
 
@@ -48,7 +48,7 @@ public sealed partial class DelegateShould
 
 		[Theory]
 		[AutoData]
-		public async Task WhenOtherExceptionIsThrown_ShouldFail(string message)
+		public async Task ForGeneric_WhenOtherExceptionIsThrown_ShouldFail(string message)
 		{
 			Exception exception = new OtherException(message);
 			Action action = () => throw exception;
@@ -67,13 +67,92 @@ public sealed partial class DelegateShould
 
 		[Theory]
 		[AutoData]
-		public async Task WhenSubCustomExceptionIsThrown_ShouldFail(string message)
+		public async Task ForGeneric_WhenSubCustomExceptionIsThrown_ShouldFail(string message)
 		{
 			Exception exception = new SubCustomException(message);
 			Action action = () => throw exception;
 
 			async Task<CustomException> Act()
 				=> await That(action).Should().ThrowExactly<CustomException>();
+
+			await That(Act).Should().ThrowException()
+				.WithMessage($"""
+				              Expected action to
+				              throw exactly a CustomException,
+				              but it did throw a SubCustomException:
+				                {message}
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenAwaited_ShouldReturnThrownException(string value)
+		{
+			Exception exception = new CustomException { Value = value };
+			Action action = () => throw exception;
+
+			Exception result =
+				await That(action).Should().ThrowExactly(typeof(CustomException));
+
+			await That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
+		public async Task ForType_WhenCorrectExceptionTypeIsThrown_ShouldSucceed()
+		{
+			Exception exception = new CustomException();
+			Action action = () => throw exception;
+
+			async Task<Exception> Act()
+				=> await That(action).Should().ThrowExactly(typeof(CustomException));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForType_WhenNoExceptionIsThrown_ShouldFail()
+		{
+			Action action = () => { };
+
+			async Task<Exception> Act()
+				=> await That(action).Should().ThrowExactly(typeof(CustomException));
+
+			await That(Act).Should().ThrowException()
+				.WithMessage("""
+				             Expected action to
+				             throw exactly a CustomException,
+				             but it did not
+				             """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenOtherExceptionIsThrown_ShouldFail(string message)
+		{
+			Exception exception = new OtherException(message);
+			Action action = () => throw exception;
+
+			async Task<Exception> Act()
+				=> await That(action).Should().ThrowExactly(typeof(CustomException));
+
+			await That(Act).Should().ThrowException()
+				.WithMessage($"""
+				              Expected action to
+				              throw exactly a CustomException,
+				              but it did throw an OtherException:
+				                {message}
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenSubCustomExceptionIsThrown_ShouldFail(string message)
+		{
+			Exception exception = new SubCustomException(message);
+			Action action = () => throw exception;
+
+			async Task<Exception> Act()
+				=> await That(action).Should().ThrowExactly(typeof(CustomException));
 
 			await That(Act).Should().ThrowException()
 				.WithMessage($"""

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowTests.cs
@@ -6,7 +6,7 @@ public sealed partial class DelegateShould
 	{
 		[Theory]
 		[AutoData]
-		public async Task WhenAwaited_ShouldReturnThrownException(string value)
+		public async Task ForGeneric_WhenAwaited_ShouldReturnThrownException(string value)
 		{
 			Exception exception = new CustomException { Value = value };
 			Action action = () => throw exception;
@@ -19,7 +19,7 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
-		public async Task WhenExactExceptionTypeIsThrown_ShouldSucceed()
+		public async Task ForGeneric_WhenExactExceptionTypeIsThrown_ShouldSucceed()
 		{
 			Exception exception = new CustomException();
 			Action action = () => throw exception;
@@ -31,7 +31,7 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
-		public async Task WhenNoExceptionIsThrown_ShouldFail()
+		public async Task ForGeneric_WhenNoExceptionIsThrown_ShouldFail()
 		{
 			Action action = () => { };
 
@@ -48,7 +48,7 @@ public sealed partial class DelegateShould
 
 		[Theory]
 		[AutoData]
-		public async Task WhenOtherExceptionIsThrown_ShouldFail(string message)
+		public async Task ForGeneric_WhenOtherExceptionIsThrown_ShouldFail(string message)
 		{
 			Exception exception = new OtherException(message);
 			Action action = () => throw exception;
@@ -66,7 +66,7 @@ public sealed partial class DelegateShould
 		}
 
 		[Fact]
-		public async Task WhenSubCustomExceptionIsThrown_ShouldSucceed()
+		public async Task ForGeneric_WhenSubCustomExceptionIsThrown_ShouldSucceed()
 		{
 			Exception exception = new SubCustomException();
 			Action action = () => throw exception;
@@ -79,13 +79,104 @@ public sealed partial class DelegateShould
 
 		[Theory]
 		[AutoData]
-		public async Task WhenSupertypeExceptionIsThrown_ShouldFail(string message)
+		public async Task ForGeneric_WhenSupertypeExceptionIsThrown_ShouldFail(string message)
 		{
 			Exception exception = new CustomException(message);
 			Action action = () => throw exception;
 
 			async Task<SubCustomException> Act()
 				=> await That(action).Should().Throw<SubCustomException>();
+
+			await That(Act).Should().ThrowException()
+				.WithMessage($"""
+				              Expected action to
+				              throw a SubCustomException,
+				              but it did throw a CustomException:
+				                {message}
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenAwaited_ShouldReturnThrownException(string value)
+		{
+			Exception exception = new CustomException { Value = value };
+			Action action = () => throw exception;
+
+			Exception result =
+				await That(action).Should().Throw(typeof(CustomException));
+
+			await That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
+		public async Task ForType_WhenExactExceptionTypeIsThrown_ShouldSucceed()
+		{
+			Exception exception = new CustomException();
+			Action action = () => throw exception;
+
+			async Task<Exception> Act()
+				=> await That(action).Should().Throw(typeof(CustomException));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForType_WhenNoExceptionIsThrown_ShouldFail()
+		{
+			Action action = () => { };
+
+			async Task<Exception> Act()
+				=> await That(action).Should().Throw(typeof(CustomException));
+
+			await That(Act).Should().ThrowException()
+				.WithMessage("""
+				             Expected action to
+				             throw a CustomException,
+				             but it did not
+				             """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenOtherExceptionIsThrown_ShouldFail(string message)
+		{
+			Exception exception = new OtherException(message);
+			Action action = () => throw exception;
+
+			async Task<Exception> Act()
+				=> await That(action).Should().Throw(typeof(CustomException));
+
+			await That(Act).Should().ThrowException()
+				.WithMessage($"""
+				              Expected action to
+				              throw a CustomException,
+				              but it did throw an OtherException:
+				                {message}
+				              """);
+		}
+
+		[Fact]
+		public async Task ForType_WhenSubCustomExceptionIsThrown_ShouldSucceed()
+		{
+			Exception exception = new SubCustomException();
+			Action action = () => throw exception;
+
+			async Task<Exception> Act()
+				=> await That(action).Should().Throw(typeof(CustomException));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenSupertypeExceptionIsThrown_ShouldFail(string message)
+		{
+			Exception exception = new CustomException(message);
+			Action action = () => throw exception;
+
+			async Task<Exception> Act()
+				=> await That(action).Should().Throw(typeof(SubCustomException));
 
 			await That(Act).Should().ThrowException()
 				.WithMessage($"""

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithInnerTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateThrows.WithInnerTests.cs
@@ -6,7 +6,8 @@ public sealed partial class DelegateThrows
 	{
 		[Theory]
 		[AutoData]
-		public async Task WhenAwaited_WithExpectations_ShouldReturnThrownException(string message)
+		public async Task ForGeneric_WhenAwaited_WithExpectations_ShouldReturnThrownException(
+			string message)
 		{
 			Exception exception = new OuterException(innerException: new CustomException(message));
 
@@ -18,7 +19,7 @@ public sealed partial class DelegateThrows
 		}
 
 		[Fact]
-		public async Task WhenAwaited_WithoutExpectations_ShouldReturnThrownException()
+		public async Task ForGeneric_WhenAwaited_WithoutExpectations_ShouldReturnThrownException()
 		{
 			Exception exception = new OuterException(innerException: new CustomException());
 
@@ -30,7 +31,7 @@ public sealed partial class DelegateThrows
 
 		[Theory]
 		[AutoData]
-		public async Task WhenInnerExceptionHasSuperType_ShouldFail(string message)
+		public async Task ForGeneric_WhenInnerExceptionHasSuperType_ShouldFail(string message)
 		{
 			Action action = ()
 				=> throw new OuterException(innerException: new CustomException(message));
@@ -49,7 +50,7 @@ public sealed partial class DelegateThrows
 
 		[Theory]
 		[AutoData]
-		public async Task WhenInnerExceptionHasWrongType_ShouldFail(string message)
+		public async Task ForGeneric_WhenInnerExceptionHasWrongType_ShouldFail(string message)
 		{
 			Action action = ()
 				=> throw new OuterException(innerException: new OtherException(message));
@@ -67,7 +68,7 @@ public sealed partial class DelegateThrows
 		}
 
 		[Fact]
-		public async Task WhenInnerExceptionIsPresent_ShouldSucceed()
+		public async Task ForGeneric_WhenInnerExceptionIsPresent_ShouldSucceed()
 		{
 			Action action = () => throw new OuterException(innerException: new CustomException());
 
@@ -78,7 +79,7 @@ public sealed partial class DelegateThrows
 		}
 
 		[Fact]
-		public async Task WhenInnerExceptionIsSubType_ShouldSucceed()
+		public async Task ForGeneric_WhenInnerExceptionIsSubType_ShouldSucceed()
 		{
 			Action action = ()
 				=> throw new OuterException(innerException: new SubCustomException());
@@ -90,12 +91,115 @@ public sealed partial class DelegateThrows
 		}
 
 		[Fact]
-		public async Task WhenNoInnerExceptionIsPresent_ShouldFail()
+		public async Task ForGeneric_WhenNoInnerExceptionIsPresent_ShouldFail()
 		{
 			Action action = () => throw new OuterException();
 
 			async Task Act()
 				=> await That(action).Should().ThrowException().WithInner<CustomException>();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected action to
+				             throw an Exception with an inner CustomException,
+				             but found <null>
+				             """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenAwaited_WithExpectations_ShouldReturnThrownException(
+			string message)
+		{
+			Exception exception = new OuterException(innerException: new CustomException(message));
+
+			Exception result = await That(() => throw exception)
+				.Should().ThrowException().WithInner(typeof(CustomException),
+					e => e.HaveMessage(message));
+
+			await That(result).Should().BeSameAs(exception);
+		}
+
+		[Fact]
+		public async Task ForType_WhenAwaited_WithoutExpectations_ShouldReturnThrownException()
+		{
+			Exception exception = new OuterException(innerException: new CustomException());
+
+			Exception result = await That(() => throw exception)
+				.Should().ThrowException().WithInner(typeof(CustomException));
+
+			await That(result).Should().BeSameAs(exception);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenInnerExceptionHasSuperType_ShouldFail(string message)
+		{
+			Action action = ()
+				=> throw new OuterException(innerException: new CustomException(message));
+
+			async Task Act()
+				=> await That(action).Should().ThrowException()
+					.WithInner(typeof(SubCustomException));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected action to
+				              throw an Exception with an inner SubCustomException,
+				              but found a CustomException:
+				                {message}
+				              """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenInnerExceptionHasWrongType_ShouldFail(string message)
+		{
+			Action action = ()
+				=> throw new OuterException(innerException: new OtherException(message));
+
+			async Task Act()
+				=> await That(action).Should().ThrowException().WithInner(typeof(CustomException));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected action to
+				              throw an Exception with an inner CustomException,
+				              but found an OtherException:
+				                {message}
+				              """);
+		}
+
+		[Fact]
+		public async Task ForType_WhenInnerExceptionIsPresent_ShouldSucceed()
+		{
+			Action action = () => throw new OuterException(innerException: new CustomException());
+
+			async Task Act()
+				=> await That(action).Should().ThrowException().WithInner(typeof(CustomException));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForType_WhenInnerExceptionIsSubType_ShouldSucceed()
+		{
+			Action action = ()
+				=> throw new OuterException(innerException: new SubCustomException());
+
+			async Task Act()
+				=> await That(action).Should().ThrowException().WithInner(typeof(CustomException));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForType_WhenNoInnerExceptionIsPresent_ShouldFail()
+		{
+			Action action = () => throw new OuterException();
+
+			async Task Act()
+				=> await That(action).Should().ThrowException().WithInner(typeof(CustomException));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Objects/ObjectShould.BeTests.cs
@@ -6,9 +6,9 @@ public sealed partial class ObjectShould
 	{
 		[Theory]
 		[AutoData]
-		public async Task WhenAwaited_ShouldReturnTypedResult(int value)
+		public async Task ForGeneric_WhenAwaited_ShouldReturnTypedResult(int value)
 		{
-			object? subject = new MyClass { Value = value };
+			object subject = new MyClass { Value = value };
 
 			MyClass result = await That(subject).Should().Be<MyClass>();
 			await That(result.Value).Should().Be(value);
@@ -16,7 +16,7 @@ public sealed partial class ObjectShould
 
 		[Theory]
 		[AutoData]
-		public async Task WhenTypeDoesNotMatch_ShouldFail(int value)
+		public async Task ForGeneric_WhenTypeDoesNotMatch_ShouldFail(int value)
 		{
 			object subject = new MyClass { Value = value };
 
@@ -35,7 +35,7 @@ public sealed partial class ObjectShould
 		}
 
 		[Fact]
-		public async Task WhenTypeIsSubtype_ShouldSucceed()
+		public async Task ForGeneric_WhenTypeIsSubtype_ShouldSucceed()
 		{
 			object subject = new MyClass();
 
@@ -47,7 +47,7 @@ public sealed partial class ObjectShould
 
 		[Theory]
 		[AutoData]
-		public async Task WhenTypeIsSupertype_ShouldFail(int value, string reason)
+		public async Task ForGeneric_WhenTypeIsSupertype_ShouldFail(int value, string reason)
 		{
 			object subject = new MyBaseClass { Value = value };
 
@@ -66,12 +66,85 @@ public sealed partial class ObjectShould
 		}
 
 		[Fact]
-		public async Task WhenTypeMatches_ShouldSucceed()
+		public async Task ForGeneric_WhenTypeMatches_ShouldSucceed()
 		{
 			object subject = new MyClass();
 
 			async Task Act()
 				=> await That(subject).Should().Be<MyClass>();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenAwaited_ShouldReturnTypedResult(int value)
+		{
+			object subject = new MyClass { Value = value };
+
+			object? result = await That(subject).Should().Be(typeof(MyClass));
+
+			await That(result).Should().BeSameAs(subject);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenTypeDoesNotMatch_ShouldFail(int value)
+		{
+			object subject = new MyClass { Value = value };
+
+			async Task Act()
+				=> await That(subject).Should().Be(typeof(OtherClass))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($$"""
+				               Expected subject to
+				               be type OtherClass, because we want to test the failure,
+				               but found MyClass {
+				                 Value = {{value}}
+				               }
+				               """);
+		}
+
+		[Fact]
+		public async Task ForType_WhenTypeIsSubtype_ShouldSucceed()
+		{
+			object subject = new MyClass();
+
+			async Task Act()
+				=> await That(subject).Should().Be(typeof(MyBaseClass));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenTypeIsSupertype_ShouldFail(int value, string reason)
+		{
+			object subject = new MyBaseClass { Value = value };
+
+			async Task Act()
+				=> await That(subject).Should().Be(typeof(MyClass))
+					.Because(reason);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($$"""
+				               Expected subject to
+				               be type MyClass, because {{reason}},
+				               but found MyBaseClass {
+				                 Value = {{value}}
+				               }
+				               """);
+		}
+
+		[Fact]
+		public async Task ForType_WhenTypeMatches_ShouldSucceed()
+		{
+			object subject = new MyClass();
+
+			async Task Act()
+				=> await That(subject).Should().Be(typeof(MyClass));
 
 			await That(Act).Should().NotThrow();
 		}


### PR DESCRIPTION
Fixes #123 
Add an overloads for delegates:
- `Throw(Type)`
- `ThrowExactly(Type)`
- `WithInner(Type)
and for object:
- `Be(Type)`