### PR TITLE
feat: add `DateOnly` expectations

### DIFF
--- a/Source/Testably.Expectations/Options/TimeTolerance.cs
+++ b/Source/Testably.Expectations/Options/TimeTolerance.cs
@@ -27,6 +27,21 @@ public class TimeTolerance
 		Tolerance = tolerance;
 	}
 
+	/// <summary>
+	///     A string representation in total days.
+	/// </summary>
+	public string ToDayString()
+	{
+		if (Tolerance == null)
+		{
+			return "";
+		}
+
+		int days = (int)Tolerance.Value.TotalDays;
+		const char plusMinus = '\u00b1';
+		return $" {plusMinus} {days} days";
+	}
+
 	/// <inheritdoc />
 	public override string ToString()
 	{

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.Be.cs
@@ -12,7 +12,7 @@ public static partial class ThatDateOnlyShould
 	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
 	public static AndOrResult<DateOnly, IThat<DateOnly>> Be(this IThat<DateOnly> source,
-		DateOnly expected)
+		DateOnly? expected)
 	{
 		return new AndOrResult<DateOnly, IThat<DateOnly>>(source.ExpectationBuilder
 				.AddConstraint(new ConditionConstraint(

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeAfter.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatDateOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> BeAfter(
+		this IThat<DateOnly> source,
+		DateOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be after {Formatter.Format(e)}{t.ToDayString()}",
+					(a, e, t) => a.AddDays((int)t.TotalDays) > e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not after the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> NotBeAfter(
+		this IThat<DateOnly> source,
+		DateOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be after {Formatter.Format(u)}{t.ToDayString()}",
+					(a, e, t) => a.AddDays((int)t.TotalDays) <= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeBefore.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatDateOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> BeBefore(
+		this IThat<DateOnly> source,
+		DateOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be before {Formatter.Format(e)}{t.ToDayString()}",
+					(a, e, t) => a.AddDays(-1 * (int)t.TotalDays) < e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not before the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> NotBeBefore(
+		this IThat<DateOnly> source,
+		DateOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be before {Formatter.Format(u)}{t.ToDayString()}",
+					(a, e, t) => a.AddDays(-1 * (int)t.TotalDays) >= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeOnOrAfter.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatDateOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is on or after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> BeOnOrAfter(
+		this IThat<DateOnly> source,
+		DateOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be on or after {Formatter.Format(e)}{t.ToDayString()}",
+					(a, e, t) => a.AddDays((int)t.TotalDays) >= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or after the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> NotBeOnOrAfter(
+		this IThat<DateOnly> source,
+		DateOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be on or after {Formatter.Format(u)}{t.ToDayString()}",
+					(a, e, t) => a.AddDays((int)t.TotalDays) < e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeOnOrBefore.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatDateOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is on or before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> BeOnOrBefore(
+		this IThat<DateOnly> source,
+		DateOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be on or before {Formatter.Format(e)}{t.ToDayString()}",
+					(a, e, t) => a.AddDays(-1 * (int)t.TotalDays) <= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or before the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> NotBeOnOrBefore(
+		this IThat<DateOnly> source,
+		DateOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be on or before {Formatter.Format(u)}{t.ToDayString()}",
+					(a, e, t) => a.AddDays(-1 * (int)t.TotalDays) > e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeAfter.cs
@@ -29,18 +29,18 @@ public static partial class ThatDateTimeShould
 	}
 
 	/// <summary>
-	///     Verifies that the subject is not after the <paramref name="expected" /> value.
+	///     Verifies that the subject is not after the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static TimeToleranceResult<DateTime, IThat<DateTime>> NotBeAfter(
 		this IThat<DateTime> source,
-		DateTime? expected)
+		DateTime? unexpected)
 	{
 		TimeTolerance tolerance = new();
 		return new TimeToleranceResult<DateTime, IThat<DateTime>>(
 			source.ExpectationBuilder
 				.AddConstraint(new ConditionConstraint(
-					expected,
-					$"not be after {Formatter.Format(expected)}",
+					unexpected,
+					$"not be after {Formatter.Format(unexpected)}",
 					(a, e, t) => a - t <= e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),

--- a/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeBefore.cs
@@ -29,18 +29,18 @@ public static partial class ThatDateTimeShould
 	}
 
 	/// <summary>
-	///     Verifies that the subject is not before the <paramref name="expected" /> value.
+	///     Verifies that the subject is not before the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static TimeToleranceResult<DateTime, IThat<DateTime>> NotBeBefore(
 		this IThat<DateTime> source,
-		DateTime? expected)
+		DateTime? unexpected)
 	{
 		TimeTolerance tolerance = new();
 		return new TimeToleranceResult<DateTime, IThat<DateTime>>(
 			source.ExpectationBuilder
 				.AddConstraint(new ConditionConstraint(
-					expected,
-					$"not be before {Formatter.Format(expected)}",
+					unexpected,
+					$"not be before {Formatter.Format(unexpected)}",
 					(a, e, t) => a + t >= e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),

--- a/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeOnOrAfter.cs
@@ -29,18 +29,18 @@ public static partial class ThatDateTimeShould
 	}
 
 	/// <summary>
-	///     Verifies that the subject is not on or after the <paramref name="expected" /> value.
+	///     Verifies that the subject is not on or after the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static TimeToleranceResult<DateTime, IThat<DateTime>> NotBeOnOrAfter(
 		this IThat<DateTime> source,
-		DateTime? expected)
+		DateTime? unexpected)
 	{
 		TimeTolerance tolerance = new();
 		return new TimeToleranceResult<DateTime, IThat<DateTime>>(
 			source.ExpectationBuilder
 				.AddConstraint(new ConditionConstraint(
-					expected,
-					$"not be on or after {Formatter.Format(expected)}",
+					unexpected,
+					$"not be on or after {Formatter.Format(unexpected)}",
 					(a, e, t) => a - t < e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),

--- a/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateTimeShould.BeOnOrBefore.cs
@@ -29,18 +29,18 @@ public static partial class ThatDateTimeShould
 	}
 
 	/// <summary>
-	///     Verifies that the subject is not on or before the <paramref name="expected" /> value.
+	///     Verifies that the subject is not on or before the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static TimeToleranceResult<DateTime, IThat<DateTime>> NotBeOnOrBefore(
 		this IThat<DateTime> source,
-		DateTime? expected)
+		DateTime? unexpected)
 	{
 		TimeTolerance tolerance = new();
 		return new TimeToleranceResult<DateTime, IThat<DateTime>>(
 			source.ExpectationBuilder
 				.AddConstraint(new ConditionConstraint(
-					expected,
-					$"not be on or before {Formatter.Format(expected)}",
+					unexpected,
+					$"not be on or before {Formatter.Format(unexpected)}",
 					(a, e, t) => a + t > e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.Be.cs
@@ -1,0 +1,38 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableDateOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrResult<DateOnly?, IThat<DateOnly?>> Be(this IThat<DateOnly?> source,
+		DateOnly? expected)
+	{
+		return new AndOrResult<DateOnly?, IThat<DateOnly?>>(source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					expected,
+					(a, e) => a.Equals(e),
+					$"be {Formatter.Format(expected)}")),
+			source);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static AndOrResult<DateOnly?, IThat<DateOnly?>> NotBe(
+		this IThat<DateOnly?> source,
+		DateOnly? unexpected)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					unexpected,
+					(a, e) => !a.Equals(e),
+					$"not be {Formatter.Format(unexpected)}")),
+			source);
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeAfter.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableDateOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> BeAfter(
+		this IThat<DateOnly?> source,
+		DateOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be after {Formatter.Format(e)}{t.ToDayString()}",
+					(a, e, t) => a?.AddDays((int)t.TotalDays) > e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not after the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> NotBeAfter(
+		this IThat<DateOnly?> source,
+		DateOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be after {Formatter.Format(u)}{t.ToDayString()}",
+					(a, e, t) => a?.AddDays((int)t.TotalDays) <= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeBefore.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableDateOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> BeBefore(
+		this IThat<DateOnly?> source,
+		DateOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be before {Formatter.Format(e)}{t.ToDayString()}",
+					(a, e, t) => a?.AddDays(-1 * (int)t.TotalDays) < e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not before the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> NotBeBefore(
+		this IThat<DateOnly?> source,
+		DateOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be before {Formatter.Format(u)}{t.ToDayString()}",
+					(a, e, t) => a?.AddDays(-1 * (int)t.TotalDays) >= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeOnOrAfter.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableDateOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is on or after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> BeOnOrAfter(
+		this IThat<DateOnly?> source,
+		DateOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be on or after {Formatter.Format(e)}{t.ToDayString()}",
+					(a, e, t) => a?.AddDays((int)t.TotalDays) >= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or after the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> NotBeOnOrAfter(
+		this IThat<DateOnly?> source,
+		DateOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be on or after {Formatter.Format(u)}{t.ToDayString()}",
+					(a, e, t) => a?.AddDays((int)t.TotalDays) < e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeOnOrBefore.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableDateOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is on or before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> BeOnOrBefore(
+		this IThat<DateOnly?> source,
+		DateOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be on or before {Formatter.Format(e)}{t.ToDayString()}",
+					(a, e, t) => a?.AddDays(-1 * (int)t.TotalDays) <= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or before the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> NotBeOnOrBefore(
+		this IThat<DateOnly?> source,
+		DateOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be on or before {Formatter.Format(u)}{t.ToDayString()}",
+					(a, e, t) => a?.AddDays(-1 * (int)t.TotalDays) > e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.cs
@@ -1,0 +1,69 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Core.Constraints;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+
+namespace Testably.Expectations;
+
+/// <summary>
+///     Expectations on <see cref="DateOnly" /> values.
+/// </summary>
+public static partial class ThatNullableDateOnlyShould
+{
+	/// <summary>
+	///     Start expectations for current <see cref="DateOnly" />? <paramref name="subject" />.
+	/// </summary>
+	public static IThat<DateOnly?> Should(this IExpectSubject<DateOnly?> subject)
+		=> subject.Should(_ => { });
+
+	private readonly struct ConditionConstraint(
+		DateOnly? expected,
+		Func<DateOnly?, DateOnly?, bool> condition,
+		string expectation) : IValueConstraint<DateOnly?>
+	{
+		public ConstraintResult IsMetBy(DateOnly? actual)
+		{
+			if (condition(actual, expected))
+			{
+				return new ConstraintResult.Success<DateOnly?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> expectation;
+	}
+
+	private readonly struct ConditionConstraintWithTolerance(
+		DateOnly? expected,
+		Func<DateOnly?, TimeTolerance, string> expectation,
+		Func<DateOnly?, DateOnly?, TimeSpan, bool> condition,
+		Func<DateOnly?, DateOnly?, string> failureMessageFactory,
+		TimeTolerance tolerance)
+		: IValueConstraint<DateOnly?>
+	{
+		public ConstraintResult IsMetBy(DateOnly? actual)
+		{
+			if (expected is null)
+			{
+				return new ConstraintResult.Failure(ToString(),
+					failureMessageFactory(actual, expected));
+			}
+
+			if (condition(actual, expected.Value, tolerance.Tolerance ?? TimeSpan.Zero))
+			{
+				return new ConstraintResult.Success<DateOnly?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(),
+				failureMessageFactory(actual, expected.Value));
+		}
+
+		public override string ToString()
+			=> expectation(expected, tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeAfter.cs
@@ -29,18 +29,18 @@ public static partial class ThatNullableDateTimeShould
 	}
 
 	/// <summary>
-	///     Verifies that the subject is not after the <paramref name="expected" /> value.
+	///     Verifies that the subject is not after the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static TimeToleranceResult<DateTime?, IThat<DateTime?>> NotBeAfter(
 		this IThat<DateTime?> source,
-		DateTime? expected)
+		DateTime? unexpected)
 	{
 		TimeTolerance tolerance = new();
 		return new TimeToleranceResult<DateTime?, IThat<DateTime?>>(
 			source.ExpectationBuilder
 				.AddConstraint(new ConditionConstraint(
-					expected,
-					$"not be after {Formatter.Format(expected)}",
+					unexpected,
+					$"not be after {Formatter.Format(unexpected)}",
 					(a, e, t) => a - t <= e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeBefore.cs
@@ -29,18 +29,18 @@ public static partial class ThatNullableDateTimeShould
 	}
 
 	/// <summary>
-	///     Verifies that the subject is not before the <paramref name="expected" /> value.
+	///     Verifies that the subject is not before the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static TimeToleranceResult<DateTime?, IThat<DateTime?>> NotBeBefore(
 		this IThat<DateTime?> source,
-		DateTime? expected)
+		DateTime? unexpected)
 	{
 		TimeTolerance tolerance = new();
 		return new TimeToleranceResult<DateTime?, IThat<DateTime?>>(
 			source.ExpectationBuilder
 				.AddConstraint(new ConditionConstraint(
-					expected,
-					$"not be before {Formatter.Format(expected)}",
+					unexpected,
+					$"not be before {Formatter.Format(unexpected)}",
 					(a, e, t) => a + t >= e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeOnOrAfter.cs
@@ -29,18 +29,18 @@ public static partial class ThatNullableDateTimeShould
 	}
 
 	/// <summary>
-	///     Verifies that the subject is not on or after the <paramref name="expected" /> value.
+	///     Verifies that the subject is not on or after the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static TimeToleranceResult<DateTime?, IThat<DateTime?>> NotBeOnOrAfter(
 		this IThat<DateTime?> source,
-		DateTime? expected)
+		DateTime? unexpected)
 	{
 		TimeTolerance tolerance = new();
 		return new TimeToleranceResult<DateTime?, IThat<DateTime?>>(
 			source.ExpectationBuilder
 				.AddConstraint(new ConditionConstraint(
-					expected,
-					$"not be on or after {Formatter.Format(expected)}",
+					unexpected,
+					$"not be on or after {Formatter.Format(unexpected)}",
 					(a, e, t) => a - t < e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateTimeShould.BeOnOrBefore.cs
@@ -29,18 +29,18 @@ public static partial class ThatNullableDateTimeShould
 	}
 
 	/// <summary>
-	///     Verifies that the subject is not on or before the <paramref name="expected" /> value.
+	///     Verifies that the subject is not on or before the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static TimeToleranceResult<DateTime?, IThat<DateTime?>> NotBeOnOrBefore(
 		this IThat<DateTime?> source,
-		DateTime? expected)
+		DateTime? unexpected)
 	{
 		TimeTolerance tolerance = new();
 		return new TimeToleranceResult<DateTime?, IThat<DateTime?>>(
 			source.ExpectationBuilder
 				.AddConstraint(new ConditionConstraint(
-					expected,
-					$"not be on or before {Formatter.Format(expected)}",
+					unexpected,
+					$"not be on or before {Formatter.Format(unexpected)}",
 					(a, e, t) => a + t > e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -128,10 +128,17 @@ namespace Testably.Expectations
     }
     public static class ThatDateOnlyShould
     {
-        public static Testably.Expectations.Results.AndOrResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> Be(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly expected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> Be(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> BeAfter(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> BeBefore(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
         public static Testably.Expectations.Results.AndOrResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> NotBe(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateOnly> Should(this Testably.Expectations.Core.IExpectSubject<System.DateOnly> subject) { }
-        public static Testably.Expectations.Core.IThat<System.DateOnly?> Should(this Testably.Expectations.Core.IExpectSubject<System.DateOnly?> subject) { }
     }
     public static class ThatDateTimeOffsetShould
     {
@@ -148,10 +155,10 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBe(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateTime> Should(this Testably.Expectations.Core.IExpectSubject<System.DateTime> subject) { }
     }
     public abstract class ThatDelegate
@@ -290,6 +297,20 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.AndOrResult<bool?, Testably.Expectations.Core.IThat<bool?>> NotBeTrue(this Testably.Expectations.Core.IThat<bool?> source) { }
         public static Testably.Expectations.Core.IThat<bool?> Should(this Testably.Expectations.Core.IExpectSubject<bool?> subject) { }
     }
+    public static class ThatNullableDateOnlyShould
+    {
+        public static Testably.Expectations.Results.AndOrResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> Be(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> BeAfter(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> BeBefore(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> NotBe(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Core.IThat<System.DateOnly?> Should(this Testably.Expectations.Core.IExpectSubject<System.DateOnly?> subject) { }
+    }
     public static class ThatNullableDateTimeShould
     {
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> Be(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
@@ -298,10 +319,10 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBe(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateTime?> Should(this Testably.Expectations.Core.IExpectSubject<System.DateTime?> subject) { }
     }
     public static class ThatNullableEnumShould
@@ -941,6 +962,7 @@ namespace Testably.Expectations.Options
         public TimeTolerance() { }
         public System.TimeSpan? Tolerance { get; }
         public void SetTolerance(System.TimeSpan tolerance) { }
+        public string ToDayString() { }
         public override string ToString() { }
     }
 }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -128,10 +128,17 @@ namespace Testably.Expectations
     }
     public static class ThatDateOnlyShould
     {
-        public static Testably.Expectations.Results.AndOrResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> Be(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly expected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> Be(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> BeAfter(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> BeBefore(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
         public static Testably.Expectations.Results.AndOrResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> NotBe(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly, Testably.Expectations.Core.IThat<System.DateOnly>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateOnly> Should(this Testably.Expectations.Core.IExpectSubject<System.DateOnly> subject) { }
-        public static Testably.Expectations.Core.IThat<System.DateOnly?> Should(this Testably.Expectations.Core.IExpectSubject<System.DateOnly?> subject) { }
     }
     public static class ThatDateTimeOffsetShould
     {
@@ -148,10 +155,10 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBe(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateTime> Should(this Testably.Expectations.Core.IExpectSubject<System.DateTime> subject) { }
     }
     public abstract class ThatDelegate
@@ -290,6 +297,20 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.AndOrResult<bool?, Testably.Expectations.Core.IThat<bool?>> NotBeTrue(this Testably.Expectations.Core.IThat<bool?> source) { }
         public static Testably.Expectations.Core.IThat<bool?> Should(this Testably.Expectations.Core.IExpectSubject<bool?> subject) { }
     }
+    public static class ThatNullableDateOnlyShould
+    {
+        public static Testably.Expectations.Results.AndOrResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> Be(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> BeAfter(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> BeBefore(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> NotBe(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateOnly?, Testably.Expectations.Core.IThat<System.DateOnly?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static Testably.Expectations.Core.IThat<System.DateOnly?> Should(this Testably.Expectations.Core.IExpectSubject<System.DateOnly?> subject) { }
+    }
     public static class ThatNullableDateTimeShould
     {
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> Be(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
@@ -298,10 +319,10 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBe(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateTime?> Should(this Testably.Expectations.Core.IExpectSubject<System.DateTime?> subject) { }
     }
     public static class ThatNullableEnumShould
@@ -941,6 +962,7 @@ namespace Testably.Expectations.Options
         public TimeTolerance() { }
         public System.TimeSpan? Tolerance { get; }
         public void SetTolerance(System.TimeSpan tolerance) { }
+        public string ToDayString() { }
         public override string ToString() { }
     }
 }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -114,10 +114,10 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBe(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime, Testably.Expectations.Core.IThat<System.DateTime>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateTime> Should(this Testably.Expectations.Core.IExpectSubject<System.DateTime> subject) { }
     }
     public abstract class ThatDelegate
@@ -252,10 +252,10 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBe(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
-        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTime?, Testably.Expectations.Core.IThat<System.DateTime?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateTime?> Should(this Testably.Expectations.Core.IExpectSubject<System.DateTime?> subject) { }
     }
     public static class ThatNullableEnumShould
@@ -879,6 +879,7 @@ namespace Testably.Expectations.Options
         public TimeTolerance() { }
         public System.TimeSpan? Tolerance { get; }
         public void SetTolerance(System.TimeSpan tolerance) { }
+        public string ToDayString() { }
         public override string ToString() { }
     }
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateOnlyShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateOnlyShould.BeAfterTests.cs
@@ -1,0 +1,288 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class DateOnlyShould
+{
+	public sealed class BeAfterTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateOnly subject = DateOnly.MaxValue;
+			DateOnly expected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be after 9999-12-31,
+				             but found 9999-12-31
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateOnly subject = DateOnly.MinValue;
+			DateOnly expected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be after 0001-01-01,
+				             but found 0001-01-01
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateOnly subject = EarlierTime();
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateOnly subject = LaterTime();
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? expected = LaterTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly subject = EarlierTime(3);
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = EarlierTime(2);
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeAfterTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateOnly subject = DateOnly.MaxValue;
+			DateOnly unexpected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateOnly subject = DateOnly.MinValue;
+			DateOnly unexpected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateOnly subject = LaterTime();
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateOnly subject = EarlierTime();
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? unexpected = LaterTime(3);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = EarlierTime(3);
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			DateOnly subject = EarlierTime(2);
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateOnlyShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateOnlyShould.BeBeforeTests.cs
@@ -1,0 +1,288 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class DateOnlyShould
+{
+	public sealed class BeBeforeTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateOnly subject = DateOnly.MaxValue;
+			DateOnly expected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be before 9999-12-31,
+				             but found 9999-12-31
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateOnly subject = DateOnly.MinValue;
+			DateOnly expected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be before 0001-01-01,
+				             but found 0001-01-01
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateOnly subject = LaterTime();
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateOnly subject = EarlierTime();
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? expected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly subject = LaterTime(3);
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = LaterTime(2);
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeBeforeTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateOnly subject = DateOnly.MaxValue;
+			DateOnly unexpected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateOnly subject = DateOnly.MinValue;
+			DateOnly unexpected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateOnly subject = EarlierTime();
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateOnly subject = LaterTime();
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? unexpected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = LaterTime(3);
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			DateOnly subject = EarlierTime(2);
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateOnlyShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateOnlyShould.BeOnOrAfterTests.cs
@@ -1,0 +1,287 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class DateOnlyShould
+{
+	public sealed class BeOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateOnly subject = DateOnly.MaxValue;
+			DateOnly expected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateOnly subject = DateOnly.MinValue;
+			DateOnly expected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateOnly subject = EarlierTime();
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateOnly subject = LaterTime();
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? expected = EarlierTime(-4);
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly subject = EarlierTime(4);
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = EarlierTime(3);
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateOnly subject = DateOnly.MaxValue;
+			DateOnly unexpected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateOnly subject = DateOnly.MinValue;
+			DateOnly unexpected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateOnly subject = LaterTime();
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateOnly subject = EarlierTime();
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? unexpected = LaterTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = EarlierTime(4);
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			DateOnly subject = EarlierTime(3);
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateOnlyShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/DateOnlyShould.BeOnOrBeforeTests.cs
@@ -1,0 +1,287 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class DateOnlyShould
+{
+	public sealed class BeOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateOnly subject = DateOnly.MaxValue;
+			DateOnly expected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateOnly subject = DateOnly.MinValue;
+			DateOnly expected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateOnly subject = LaterTime();
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateOnly subject = EarlierTime();
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? expected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly subject = LaterTime(4);
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = LaterTime(3);
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateOnly subject = DateOnly.MaxValue;
+			DateOnly unexpected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateOnly subject = DateOnly.MinValue;
+			DateOnly unexpected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateOnly subject = EarlierTime();
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateOnly subject = LaterTime();
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? unexpected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = LaterTime(4);
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			DateOnly subject = EarlierTime(3);
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateOnlyShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateOnlyShould.BeAfterTests.cs
@@ -1,0 +1,288 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class NullableDateOnlyShould
+{
+	public sealed class BeAfterTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateOnly? subject = DateOnly.MaxValue;
+			DateOnly expected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be after 9999-12-31,
+				             but found 9999-12-31
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateOnly? subject = DateOnly.MinValue;
+			DateOnly expected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be after 0001-01-01,
+				             but found 0001-01-01
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateOnly? subject = EarlierTime();
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateOnly? subject = LaterTime();
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = LaterTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly? subject = EarlierTime(3);
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = EarlierTime(2);
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeAfterTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateOnly? subject = DateOnly.MaxValue;
+			DateOnly unexpected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateOnly? subject = DateOnly.MinValue;
+			DateOnly unexpected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateOnly? subject = LaterTime();
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateOnly? subject = EarlierTime();
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = LaterTime(3);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = EarlierTime(3);
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			DateOnly? subject = EarlierTime(2);
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateOnlyShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateOnlyShould.BeBeforeTests.cs
@@ -1,0 +1,288 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class NullableDateOnlyShould
+{
+	public sealed class BeBeforeTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateOnly? subject = DateOnly.MaxValue;
+			DateOnly expected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be before 9999-12-31,
+				             but found 9999-12-31
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateOnly? subject = DateOnly.MinValue;
+			DateOnly expected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be before 0001-01-01,
+				             but found 0001-01-01
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateOnly? subject = LaterTime();
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateOnly? subject = EarlierTime();
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly? subject = LaterTime(3);
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = LaterTime(2);
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeBeforeTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateOnly? subject = DateOnly.MaxValue;
+			DateOnly? unexpected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateOnly? subject = DateOnly.MinValue;
+			DateOnly? unexpected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateOnly? subject = EarlierTime();
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateOnly? subject = LaterTime();
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = LaterTime(3);
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			DateOnly? subject = EarlierTime(2);
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateOnlyShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateOnlyShould.BeOnOrAfterTests.cs
@@ -1,0 +1,287 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class NullableDateOnlyShould
+{
+	public sealed class BeOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateOnly? subject = DateOnly.MaxValue;
+			DateOnly expected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateOnly? subject = DateOnly.MinValue;
+			DateOnly expected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateOnly? subject = EarlierTime();
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateOnly? subject = LaterTime();
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = EarlierTime(-4);
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly? subject = EarlierTime(4);
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = EarlierTime(3);
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateOnly? subject = DateOnly.MaxValue;
+			DateOnly unexpected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateOnly? subject = DateOnly.MinValue;
+			DateOnly unexpected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateOnly? subject = LaterTime();
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateOnly? subject = EarlierTime();
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = LaterTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = EarlierTime(4);
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			DateOnly? subject = EarlierTime(3);
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateOnlyShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateOnlyShould.BeOnOrBeforeTests.cs
@@ -1,0 +1,287 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class NullableDateOnlyShould
+{
+	public sealed class BeOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateOnly? subject = DateOnly.MaxValue;
+			DateOnly expected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateOnly? subject = DateOnly.MinValue;
+			DateOnly expected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateOnly? subject = LaterTime();
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateOnly? subject = EarlierTime();
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateOnly? subject = LaterTime(4);
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = LaterTime(3);
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateOnly? subject = DateOnly.MaxValue;
+			DateOnly unexpected = DateOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateOnly? subject = DateOnly.MinValue;
+			DateOnly unexpected = DateOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateOnly? subject = EarlierTime();
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateOnly? subject = LaterTime();
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromDays(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = LaterTime(4);
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			DateOnly? subject = EarlierTime(3);
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)} ± 3 days,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateOnlyShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateOnlyShould.BeTests.cs
@@ -1,0 +1,70 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class NullableDateOnlyShould
+{
+	public sealed class BeTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsDifferent_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = LaterTime();
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsTheSame_ShouldSucceed()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsDifferent_ShouldSucceed()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = LaterTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsTheSame_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateOnlyShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableDateOnlyShould.cs
@@ -1,0 +1,21 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class NullableDateOnlyShould
+{
+	/// <summary>
+	///     Use a fixed random time in each test run to ensure, that the tests don't rely on special times.
+	/// </summary>
+	private static readonly Lazy<DateOnly?> CurrentTimeLazy = new(
+		() => DateOnly.MinValue.AddDays(new Random().Next(10000)));
+
+	private static DateOnly? CurrentTime()
+		=> CurrentTimeLazy.Value;
+
+	private static DateOnly? EarlierTime(int days = 1)
+		=> CurrentTime()?.AddDays(-1 * days);
+
+	private static DateOnly? LaterTime(int days = 1)
+		=> CurrentTime()?.AddDays(days);
+}
+#endif


### PR DESCRIPTION
From #127:
Add `DateOnly` expectations:
- `BeAfter` / `NotBeAfter`
- `BeOnOrAfter` / `NotBeOnOrAfter`
- `BeBefore` / `NotBeBefore`
- `BeOnOrBefore` / `NotBeOnOrBefore`