### PR TITLE
feat: add `TimeOnly` expectation

### DIFF
--- a/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.Be.cs
@@ -1,0 +1,38 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableTimeOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrResult<TimeOnly?, IThat<TimeOnly?>> Be(this IThat<TimeOnly?> source,
+		TimeOnly? expected)
+	{
+		return new AndOrResult<TimeOnly?, IThat<TimeOnly?>>(source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					expected,
+					(a, e) => a.Equals(e),
+					$"be {Formatter.Format(expected)}")),
+			source);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static AndOrResult<TimeOnly?, IThat<TimeOnly?>> NotBe(
+		this IThat<TimeOnly?> source,
+		TimeOnly? unexpected)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					unexpected,
+					(a, e) => !a.Equals(e),
+					$"not be {Formatter.Format(unexpected)}")),
+			source);
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeAfter.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableTimeOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> BeAfter(
+		this IThat<TimeOnly?> source,
+		TimeOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be after {Formatter.Format(e)}{t}",
+					(a, e, t) => a?.Add(t) > e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not after the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> NotBeAfter(
+		this IThat<TimeOnly?> source,
+		TimeOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be after {Formatter.Format(u)}{t}",
+					(a, e, t) => a?.Add(t) <= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeBefore.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableTimeOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> BeBefore(
+		this IThat<TimeOnly?> source,
+		TimeOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be before {Formatter.Format(e)}{t}",
+					(a, e, t) => a?.Add(t.Negate()) < e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not before the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> NotBeBefore(
+		this IThat<TimeOnly?> source,
+		TimeOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be before {Formatter.Format(u)}{t}",
+					(a, e, t) => a?.Add(t.Negate()) >= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeOnOrAfter.cs
@@ -1,0 +1,53 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using System.Net.Sockets;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableTimeOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is on or after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> BeOnOrAfter(
+		this IThat<TimeOnly?> source,
+		TimeOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be on or after {Formatter.Format(e)}{t}",
+					(a, e, t) => a?.Add(t) >= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or after the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> NotBeOnOrAfter(
+		this IThat<TimeOnly?> source,
+		TimeOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be on or after {Formatter.Format(u)}{t}",
+					(a, e, t) => a?.Add(t) < e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeOnOrBefore.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableTimeOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is on or before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> BeOnOrBefore(
+		this IThat<TimeOnly?> source,
+		TimeOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be on or before {Formatter.Format(e)}{t}",
+					(a, e, t) => a?.Add(t.Negate()) <= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or before the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> NotBeOnOrBefore(
+		this IThat<TimeOnly?> source,
+		TimeOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be on or before {Formatter.Format(u)}{t}",
+					(a, e, t) => a?.Add(t.Negate()) > e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.cs
@@ -10,24 +10,24 @@ namespace Testably.Expectations;
 /// <summary>
 ///     Expectations on <see cref="TimeOnly" /> values.
 /// </summary>
-public static partial class ThatTimeOnlyShould
+public static partial class ThatNullableTimeOnlyShould
 {
 	/// <summary>
-	///     Start expectations for current <see cref="TimeOnly" /> <paramref name="subject" />.
+	///     Start expectations for current <see cref="TimeOnly" />? <paramref name="subject" />.
 	/// </summary>
-	public static IThat<TimeOnly> Should(this IExpectSubject<TimeOnly> subject)
+	public static IThat<TimeOnly?> Should(this IExpectSubject<TimeOnly?> subject)
 		=> subject.Should(_ => { });
 
 	private readonly struct ConditionConstraint(
-		TimeOnly expected,
-		Func<TimeOnly, TimeOnly, bool> condition,
-		string expectation) : IValueConstraint<TimeOnly>
+		TimeOnly? expected,
+		Func<TimeOnly?, TimeOnly?, bool> condition,
+		string expectation) : IValueConstraint<TimeOnly?>
 	{
-		public ConstraintResult IsMetBy(TimeOnly actual)
+		public ConstraintResult IsMetBy(TimeOnly? actual)
 		{
 			if (condition(actual, expected))
 			{
-				return new ConstraintResult.Success<TimeOnly>(actual, ToString());
+				return new ConstraintResult.Success<TimeOnly?>(actual, ToString());
 			}
 
 			return new ConstraintResult.Failure(ToString(), $"found {Formatter.Format(actual)}");
@@ -40,12 +40,12 @@ public static partial class ThatTimeOnlyShould
 	private readonly struct ConditionConstraintWithTolerance(
 		TimeOnly? expected,
 		Func<TimeOnly?, TimeTolerance, string> expectation,
-		Func<TimeOnly, TimeOnly?, TimeSpan, bool> condition,
-		Func<TimeOnly, TimeOnly?, string> failureMessageFactory,
+		Func<TimeOnly?, TimeOnly?, TimeSpan, bool> condition,
+		Func<TimeOnly?, TimeOnly?, string> failureMessageFactory,
 		TimeTolerance tolerance)
-		: IValueConstraint<TimeOnly>
+		: IValueConstraint<TimeOnly?>
 	{
-		public ConstraintResult IsMetBy(TimeOnly actual)
+		public ConstraintResult IsMetBy(TimeOnly? actual)
 		{
 			if (expected is null)
 			{
@@ -55,7 +55,7 @@ public static partial class ThatTimeOnlyShould
 
 			if (condition(actual, expected.Value, tolerance.Tolerance ?? TimeSpan.Zero))
 			{
-				return new ConstraintResult.Success<TimeOnly>(actual, ToString());
+				return new ConstraintResult.Success<TimeOnly?>(actual, ToString());
 			}
 
 			return new ConstraintResult.Failure(ToString(),

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeAfter.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatTimeOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> BeAfter(
+		this IThat<TimeOnly> source,
+		TimeOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be after {Formatter.Format(e)}{t}",
+					(a, e, t) => a.Add(t) > e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not after the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> NotBeAfter(
+		this IThat<TimeOnly> source,
+		TimeOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be after {Formatter.Format(u)}{t}",
+					(a, e, t) => a.Add(t) <= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeBefore.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatTimeOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> BeBefore(
+		this IThat<TimeOnly> source,
+		TimeOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be before {Formatter.Format(e)}{t}",
+					(a, e, t) => a.Add(t.Negate()) < e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not before the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> NotBeBefore(
+		this IThat<TimeOnly> source,
+		TimeOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be before {Formatter.Format(u)}{t}",
+					(a, e, t) => a.Add(t.Negate()) >= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeOnOrAfter.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatTimeOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is on or after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> BeOnOrAfter(
+		this IThat<TimeOnly> source,
+		TimeOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be on or after {Formatter.Format(e)}{t}",
+					(a, e, t) => a.Add(t) >= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or after the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> NotBeOnOrAfter(
+		this IThat<TimeOnly> source,
+		TimeOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be on or after {Formatter.Format(u)}{t}",
+					(a, e, t) => a.Add(t) < e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeOnOrBefore.cs
@@ -1,0 +1,52 @@
+﻿#if !NETSTANDARD2_0
+using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatTimeOnlyShould
+{
+	/// <summary>
+	///     Verifies that the subject is on or before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> BeOnOrBefore(
+		this IThat<TimeOnly> source,
+		TimeOnly? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					expected,
+					(e, t) => $"be on or before {Formatter.Format(e)}{t}",
+					(a, e, t) => a.Add(t.Negate()) <= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or before the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> NotBeOnOrBefore(
+		this IThat<TimeOnly> source,
+		TimeOnly? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraintWithTolerance(
+					unexpected,
+					(u, t) => $"not be on or before {Formatter.Format(u)}{t}",
+					(a, e, t) => a.Add(t.Negate()) > e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}
+#endif

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -360,6 +360,20 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.AndOrResult<System.Guid?, Testably.Expectations.Core.IThat<System.Guid?>> NotBeNull(this Testably.Expectations.Core.IThat<System.Guid?> source) { }
         public static Testably.Expectations.Core.IThat<System.Guid?> Should(this Testably.Expectations.Core.IExpectSubject<System.Guid?> subject) { }
     }
+    public static class ThatNullableTimeOnlyShould
+    {
+        public static Testably.Expectations.Results.AndOrResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> Be(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> BeAfter(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> BeBefore(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> NotBe(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Core.IThat<System.TimeOnly?> Should(this Testably.Expectations.Core.IExpectSubject<System.TimeOnly?> subject) { }
+    }
     public static class ThatNumberShould
     {
         public static Testably.Expectations.Results.NumberToleranceResult<byte, Testably.Expectations.Core.IThat<byte>> Be(this Testably.Expectations.Core.IThat<byte> source, byte? expected) { }
@@ -741,9 +755,16 @@ namespace Testably.Expectations
     public static class ThatTimeOnlyShould
     {
         public static Testably.Expectations.Results.AndOrResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> Be(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> BeAfter(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> BeBefore(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
         public static Testably.Expectations.Results.AndOrResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> NotBe(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> NotBeAfter(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> NotBeBefore(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.TimeOnly> Should(this Testably.Expectations.Core.IExpectSubject<System.TimeOnly> subject) { }
-        public static Testably.Expectations.Core.IThat<System.TimeOnly?> Should(this Testably.Expectations.Core.IExpectSubject<System.TimeOnly?> subject) { }
     }
     public static class ThatTimeSpanShould
     {

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -360,6 +360,20 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.AndOrResult<System.Guid?, Testably.Expectations.Core.IThat<System.Guid?>> NotBeNull(this Testably.Expectations.Core.IThat<System.Guid?> source) { }
         public static Testably.Expectations.Core.IThat<System.Guid?> Should(this Testably.Expectations.Core.IExpectSubject<System.Guid?> subject) { }
     }
+    public static class ThatNullableTimeOnlyShould
+    {
+        public static Testably.Expectations.Results.AndOrResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> Be(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> BeAfter(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> BeBefore(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> NotBe(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly?, Testably.Expectations.Core.IThat<System.TimeOnly?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Core.IThat<System.TimeOnly?> Should(this Testably.Expectations.Core.IExpectSubject<System.TimeOnly?> subject) { }
+    }
     public static class ThatNumberShould
     {
         public static Testably.Expectations.Results.NumberToleranceResult<byte, Testably.Expectations.Core.IThat<byte>> Be(this Testably.Expectations.Core.IThat<byte> source, byte? expected) { }
@@ -741,9 +755,16 @@ namespace Testably.Expectations
     public static class ThatTimeOnlyShould
     {
         public static Testably.Expectations.Results.AndOrResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> Be(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> BeAfter(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> BeBefore(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
         public static Testably.Expectations.Results.AndOrResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> NotBe(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> NotBeAfter(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> NotBeBefore(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.TimeOnly, Testably.Expectations.Core.IThat<System.TimeOnly>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.TimeOnly> Should(this Testably.Expectations.Core.IExpectSubject<System.TimeOnly> subject) { }
-        public static Testably.Expectations.Core.IThat<System.TimeOnly?> Should(this Testably.Expectations.Core.IExpectSubject<System.TimeOnly?> subject) { }
     }
     public static class ThatTimeSpanShould
     {

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableTimeOnlyShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableTimeOnlyShould.BeAfterTests.cs
@@ -1,0 +1,288 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class NullableTimeOnlyShould
+{
+	public sealed class BeAfterTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			TimeOnly? subject = TimeOnly.MaxValue;
+			TimeOnly expected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be after 23:59:59.9999999,
+				             but found 23:59:59.9999999
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			TimeOnly? subject = TimeOnly.MinValue;
+			TimeOnly expected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be after 00:00:00.0000000,
+				             but found 00:00:00.0000000
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			TimeOnly? subject = EarlierTime();
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			TimeOnly? subject = LaterTime();
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = LaterTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly? subject = EarlierTime(3);
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = EarlierTime(2);
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeAfterTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			TimeOnly? subject = TimeOnly.MaxValue;
+			TimeOnly unexpected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			TimeOnly? subject = TimeOnly.MinValue;
+			TimeOnly unexpected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			TimeOnly? subject = LaterTime();
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			TimeOnly? subject = EarlierTime();
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = LaterTime(3);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = EarlierTime(3);
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			TimeOnly? subject = EarlierTime(2);
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableTimeOnlyShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableTimeOnlyShould.BeBeforeTests.cs
@@ -1,0 +1,288 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class NullableTimeOnlyShould
+{
+	public sealed class BeBeforeTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			TimeOnly? subject = TimeOnly.MaxValue;
+			TimeOnly expected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be before 23:59:59.9999999,
+				             but found 23:59:59.9999999
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			TimeOnly? subject = TimeOnly.MinValue;
+			TimeOnly expected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be before 00:00:00.0000000,
+				             but found 00:00:00.0000000
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			TimeOnly? subject = LaterTime();
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			TimeOnly? subject = EarlierTime();
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly? subject = LaterTime(3);
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = LaterTime(2);
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeBeforeTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			TimeOnly? subject = TimeOnly.MaxValue;
+			TimeOnly? unexpected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			TimeOnly? subject = TimeOnly.MinValue;
+			TimeOnly? unexpected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			TimeOnly? subject = EarlierTime();
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			TimeOnly? subject = LaterTime();
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = LaterTime(3);
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			TimeOnly? subject = EarlierTime(2);
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableTimeOnlyShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableTimeOnlyShould.BeOnOrAfterTests.cs
@@ -1,0 +1,287 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class NullableTimeOnlyShould
+{
+	public sealed class BeOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			TimeOnly? subject = TimeOnly.MaxValue;
+			TimeOnly expected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			TimeOnly? subject = TimeOnly.MinValue;
+			TimeOnly expected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			TimeOnly? subject = EarlierTime();
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			TimeOnly? subject = LaterTime();
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = EarlierTime(-4);
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly? subject = EarlierTime(4);
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = EarlierTime(3);
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			TimeOnly? subject = TimeOnly.MaxValue;
+			TimeOnly unexpected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			TimeOnly? subject = TimeOnly.MinValue;
+			TimeOnly unexpected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			TimeOnly? subject = LaterTime();
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			TimeOnly? subject = EarlierTime();
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = LaterTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = EarlierTime(4);
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			TimeOnly? subject = EarlierTime(3);
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableTimeOnlyShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableTimeOnlyShould.BeOnOrBeforeTests.cs
@@ -1,0 +1,287 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class NullableTimeOnlyShould
+{
+	public sealed class BeOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			TimeOnly? subject = TimeOnly.MaxValue;
+			TimeOnly expected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			TimeOnly? subject = TimeOnly.MinValue;
+			TimeOnly expected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			TimeOnly? subject = LaterTime();
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			TimeOnly? subject = EarlierTime();
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly? subject = LaterTime(4);
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = LaterTime(3);
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			TimeOnly? subject = TimeOnly.MaxValue;
+			TimeOnly unexpected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			TimeOnly? subject = TimeOnly.MinValue;
+			TimeOnly unexpected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			TimeOnly? subject = EarlierTime();
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			TimeOnly? subject = LaterTime();
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = LaterTime(4);
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			TimeOnly? subject = EarlierTime(3);
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableTimeOnlyShould.BeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableTimeOnlyShould.BeTests.cs
@@ -1,0 +1,70 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class NullableTimeOnlyShould
+{
+	public sealed class BeTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsDifferent_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = LaterTime();
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsTheSame_ShouldSucceed()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsDifferent_ShouldSucceed()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = LaterTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsTheSame_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableTimeOnlyShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/NullableTimeOnlyShould.cs
@@ -1,0 +1,21 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class NullableTimeOnlyShould
+{
+	/// <summary>
+	///     Use a fixed random time in each test run to ensure, that the tests don't rely on special times.
+	/// </summary>
+	private static readonly Lazy<TimeOnly?> CurrentTimeLazy = new(
+		() => TimeOnly.MinValue.Add(TimeSpan.FromSeconds(new Random().Next(86400))));
+
+	private static TimeOnly? CurrentTime()
+		=> CurrentTimeLazy.Value;
+
+	private static TimeOnly? EarlierTime(int seconds = 1)
+		=> CurrentTime()?.Add(TimeSpan.FromSeconds(-1 * seconds));
+
+	private static TimeOnly? LaterTime(int seconds = 1)
+		=> CurrentTime()?.Add(TimeSpan.FromSeconds(seconds));
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeOnlyShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeOnlyShould.BeAfterTests.cs
@@ -1,0 +1,288 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class TimeOnlyShould
+{
+	public sealed class BeAfterTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			TimeOnly subject = TimeOnly.MaxValue;
+			TimeOnly expected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be after 23:59:59.9999999,
+				             but found 23:59:59.9999999
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			TimeOnly subject = TimeOnly.MinValue;
+			TimeOnly expected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be after 00:00:00.0000000,
+				             but found 00:00:00.0000000
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			TimeOnly subject = EarlierTime();
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			TimeOnly subject = LaterTime();
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? expected = LaterTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly subject = EarlierTime(3);
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = EarlierTime(2);
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeAfterTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			TimeOnly subject = TimeOnly.MaxValue;
+			TimeOnly unexpected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			TimeOnly subject = TimeOnly.MinValue;
+			TimeOnly unexpected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			TimeOnly subject = LaterTime();
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			TimeOnly subject = EarlierTime();
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? unexpected = LaterTime(3);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = EarlierTime(3);
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			TimeOnly subject = EarlierTime(2);
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeOnlyShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeOnlyShould.BeBeforeTests.cs
@@ -1,0 +1,288 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class TimeOnlyShould
+{
+	public sealed class BeBeforeTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			TimeOnly subject = TimeOnly.MaxValue;
+			TimeOnly expected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be before 23:59:59.9999999,
+				             but found 23:59:59.9999999
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			TimeOnly subject = TimeOnly.MinValue;
+			TimeOnly expected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be before 00:00:00.0000000,
+				             but found 00:00:00.0000000
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			TimeOnly subject = LaterTime();
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			TimeOnly subject = EarlierTime();
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? expected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly subject = LaterTime(3);
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = LaterTime(2);
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeBeforeTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			TimeOnly subject = TimeOnly.MaxValue;
+			TimeOnly unexpected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			TimeOnly subject = TimeOnly.MinValue;
+			TimeOnly unexpected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			TimeOnly subject = EarlierTime();
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			TimeOnly subject = LaterTime();
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? unexpected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = LaterTime(3);
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			TimeOnly subject = EarlierTime(2);
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeOnlyShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeOnlyShould.BeOnOrAfterTests.cs
@@ -1,0 +1,287 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class TimeOnlyShould
+{
+	public sealed class BeOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			TimeOnly subject = TimeOnly.MaxValue;
+			TimeOnly expected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			TimeOnly subject = TimeOnly.MinValue;
+			TimeOnly expected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			TimeOnly subject = EarlierTime();
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			TimeOnly subject = LaterTime();
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? expected = EarlierTime(-4);
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly subject = EarlierTime(4);
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = EarlierTime(3);
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			TimeOnly subject = TimeOnly.MaxValue;
+			TimeOnly unexpected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			TimeOnly subject = TimeOnly.MinValue;
+			TimeOnly unexpected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			TimeOnly subject = LaterTime();
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			TimeOnly subject = EarlierTime();
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? unexpected = LaterTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = EarlierTime(4);
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			TimeOnly subject = EarlierTime(3);
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif

--- a/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeOnlyShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Chronology/TimeOnlyShould.BeOnOrBeforeTests.cs
@@ -1,0 +1,287 @@
+﻿#if NET6_0_OR_GREATER
+namespace Testably.Expectations.Tests.ThatTests.Chronology;
+
+public sealed partial class TimeOnlyShould
+{
+	public sealed class BeOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			TimeOnly subject = TimeOnly.MaxValue;
+			TimeOnly expected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			TimeOnly subject = TimeOnly.MinValue;
+			TimeOnly expected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			TimeOnly subject = LaterTime();
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			TimeOnly subject = EarlierTime();
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? expected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			TimeOnly subject = LaterTime(4);
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = LaterTime(3);
+			TimeOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			TimeOnly subject = TimeOnly.MaxValue;
+			TimeOnly unexpected = TimeOnly.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			TimeOnly subject = TimeOnly.MinValue;
+			TimeOnly unexpected = TimeOnly.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			TimeOnly subject = EarlierTime();
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			TimeOnly subject = LaterTime();
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? unexpected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = LaterTime(4);
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		{
+			TimeOnly subject = EarlierTime(3);
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+}
+#endif


### PR DESCRIPTION
From #127:
Add `TimeOnly` expectations:
- `BeAfter` / `NotBeAfter`
- `BeOnOrAfter` / `NotBeOnOrAfter`
- `BeBefore` / `NotBeBefore`
- `BeOnOrBefore` / `NotBeOnOrBefore`