### PR TITLE
refactor: consolidate `#if` statements

### DIFF
--- a/Source/Testably.Expectations/Core/ExpectationBuilder.cs
+++ b/Source/Testably.Expectations/Core/ExpectationBuilder.cs
@@ -85,7 +85,7 @@ public abstract class ExpectationBuilder
 	/// <summary>
 	///     Adds a <paramref name="reason" /> to the current expectation constraint.
 	/// </summary>
-	public void AddReason(string reason)
+	internal void AddReason(string reason)
 	{
 		BecauseReason becauseReason = new(reason);
 		_tree.GetCurrent().SetReason(becauseReason);
@@ -115,7 +115,7 @@ public abstract class ExpectationBuilder
 	/// <summary>
 	///     Adds a <paramref name="cancellationToken" /> to be used by the constraints.
 	/// </summary>
-	internal void AddCancellation(CancellationToken cancellationToken)
+	public void AddCancellation(CancellationToken cancellationToken)
 	{
 		_cancellationToken = cancellationToken;
 	}

--- a/Source/Testably.Expectations/Core/ExpectationBuilder.cs
+++ b/Source/Testably.Expectations/Core/ExpectationBuilder.cs
@@ -115,7 +115,7 @@ public abstract class ExpectationBuilder
 	/// <summary>
 	///     Adds a <paramref name="cancellationToken" /> to be used by the constraints.
 	/// </summary>
-	public void AddCancellation(CancellationToken cancellationToken)
+	public void WithCancellation(CancellationToken cancellationToken)
 	{
 		_cancellationToken = cancellationToken;
 	}

--- a/Source/Testably.Expectations/Formatting/Formatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatter.cs
@@ -25,7 +25,7 @@ public class Formatter
 		new DateTimeFormatter(),
 		new DateTimeOffsetFormatter(),
 		new TimeSpanFormatter(),
-#if !NETSTANDARD2_0
+#if NET6_0_OR_GREATER
 		new DateOnlyFormatter(),
 		new TimeOnlyFormatter(),
 #endif

--- a/Source/Testably.Expectations/Formatting/Formatters/DateOnlyFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/DateOnlyFormatter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using System.Text;
 

--- a/Source/Testably.Expectations/Formatting/Formatters/TimeOnlyFormatter.cs
+++ b/Source/Testably.Expectations/Formatting/Formatters/TimeOnlyFormatter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using System.Text;
 

--- a/Source/Testably.Expectations/Results/ExpectationResult.cs
+++ b/Source/Testably.Expectations/Results/ExpectationResult.cs
@@ -40,7 +40,7 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder) : Expectat
 	/// </summary>
 	public ExpectationResult WithCancellation(CancellationToken cancellationToken)
 	{
-		expectationBuilder.AddCancellation(cancellationToken);
+		expectationBuilder.WithCancellation(cancellationToken);
 		return this;
 	}
 
@@ -117,7 +117,7 @@ public class ExpectationResult<TType, TSelf>(ExpectationBuilder expectationBuild
 	/// </summary>
 	public TSelf WithCancellation(CancellationToken cancellationToken)
 	{
-		expectationBuilder.AddCancellation(cancellationToken);
+		expectationBuilder.WithCancellation(cancellationToken);
 		return (TSelf)this;
 	}
 

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.Be.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeAfter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeBefore.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeOnOrAfter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.BeOnOrBefore.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatDateOnlyShould.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.Be.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeAfter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeBefore.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeOnOrAfter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.BeOnOrBefore.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableDateOnlyShould.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.Be.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeAfter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeBefore.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeOnOrAfter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using System.Net.Sockets;
 using Testably.Expectations.Core;

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.BeOnOrBefore.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatNullableTimeOnlyShould.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.Be.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.Be.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeAfter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeBefore.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeOnOrAfter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.BeOnOrBefore.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;

--- a/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.cs
+++ b/Source/Testably.Expectations/That/Chronology/ThatTimeOnlyShould.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET6_0_OR_GREATER
 using System;
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -846,12 +846,12 @@ namespace Testably.Expectations.Core
     public abstract class ExpectationBuilder
     {
         protected ExpectationBuilder(string subjectExpression) { }
+        public void AddCancellation(System.Threading.CancellationToken cancellationToken) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IAsyncConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IAsyncContextConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IContextConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IValueConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TSource, TTarget>(Testably.Expectations.Core.Constraints.ICastConstraint<TSource, TTarget> constraint) { }
-        public void AddReason(string reason) { }
         public Testably.Expectations.Core.ExpectationBuilder.PropertyExpectationBuilder<TSource, TTarget> ForProperty<TSource, TTarget>(Testably.Expectations.Core.PropertyAccessor<TSource, TTarget?> propertyAccessor, System.Func<Testably.Expectations.Core.PropertyAccessor, string, string>? expectationTextGenerator = null) { }
         public class PropertyExpectationBuilder<TSource, TProperty>
         {

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -846,13 +846,13 @@ namespace Testably.Expectations.Core
     public abstract class ExpectationBuilder
     {
         protected ExpectationBuilder(string subjectExpression) { }
-        public void AddCancellation(System.Threading.CancellationToken cancellationToken) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IAsyncConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IAsyncContextConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IContextConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IValueConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TSource, TTarget>(Testably.Expectations.Core.Constraints.ICastConstraint<TSource, TTarget> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder.PropertyExpectationBuilder<TSource, TTarget> ForProperty<TSource, TTarget>(Testably.Expectations.Core.PropertyAccessor<TSource, TTarget?> propertyAccessor, System.Func<Testably.Expectations.Core.PropertyAccessor, string, string>? expectationTextGenerator = null) { }
+        public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public class PropertyExpectationBuilder<TSource, TProperty>
         {
             public Testably.Expectations.Core.ExpectationBuilder AddExpectations(System.Action<Testably.Expectations.Core.ExpectationBuilder> expectation) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -846,12 +846,12 @@ namespace Testably.Expectations.Core
     public abstract class ExpectationBuilder
     {
         protected ExpectationBuilder(string subjectExpression) { }
+        public void AddCancellation(System.Threading.CancellationToken cancellationToken) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IAsyncConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IAsyncContextConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IContextConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IValueConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TSource, TTarget>(Testably.Expectations.Core.Constraints.ICastConstraint<TSource, TTarget> constraint) { }
-        public void AddReason(string reason) { }
         public Testably.Expectations.Core.ExpectationBuilder.PropertyExpectationBuilder<TSource, TTarget> ForProperty<TSource, TTarget>(Testably.Expectations.Core.PropertyAccessor<TSource, TTarget?> propertyAccessor, System.Func<Testably.Expectations.Core.PropertyAccessor, string, string>? expectationTextGenerator = null) { }
         public class PropertyExpectationBuilder<TSource, TProperty>
         {

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -846,13 +846,13 @@ namespace Testably.Expectations.Core
     public abstract class ExpectationBuilder
     {
         protected ExpectationBuilder(string subjectExpression) { }
-        public void AddCancellation(System.Threading.CancellationToken cancellationToken) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IAsyncConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IAsyncContextConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IContextConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IValueConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TSource, TTarget>(Testably.Expectations.Core.Constraints.ICastConstraint<TSource, TTarget> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder.PropertyExpectationBuilder<TSource, TTarget> ForProperty<TSource, TTarget>(Testably.Expectations.Core.PropertyAccessor<TSource, TTarget?> propertyAccessor, System.Func<Testably.Expectations.Core.PropertyAccessor, string, string>? expectationTextGenerator = null) { }
+        public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public class PropertyExpectationBuilder<TSource, TProperty>
         {
             public Testably.Expectations.Core.ExpectationBuilder AddExpectations(System.Action<Testably.Expectations.Core.ExpectationBuilder> expectation) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -742,12 +742,12 @@ namespace Testably.Expectations.Core
     public abstract class ExpectationBuilder
     {
         protected ExpectationBuilder(string subjectExpression) { }
+        public void AddCancellation(System.Threading.CancellationToken cancellationToken) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IAsyncConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IAsyncContextConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IContextConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IValueConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TSource, TTarget>(Testably.Expectations.Core.Constraints.ICastConstraint<TSource, TTarget> constraint) { }
-        public void AddReason(string reason) { }
         public Testably.Expectations.Core.ExpectationBuilder.PropertyExpectationBuilder<TSource, TTarget> ForProperty<TSource, TTarget>(Testably.Expectations.Core.PropertyAccessor<TSource, TTarget?> propertyAccessor, System.Func<Testably.Expectations.Core.PropertyAccessor, string, string>? expectationTextGenerator = null) { }
         public class PropertyExpectationBuilder<TSource, TProperty>
         {

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -742,13 +742,13 @@ namespace Testably.Expectations.Core
     public abstract class ExpectationBuilder
     {
         protected ExpectationBuilder(string subjectExpression) { }
-        public void AddCancellation(System.Threading.CancellationToken cancellationToken) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IAsyncConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IAsyncContextConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IContextConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TValue>(Testably.Expectations.Core.Constraints.IValueConstraint<TValue> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder AddConstraint<TSource, TTarget>(Testably.Expectations.Core.Constraints.ICastConstraint<TSource, TTarget> constraint) { }
         public Testably.Expectations.Core.ExpectationBuilder.PropertyExpectationBuilder<TSource, TTarget> ForProperty<TSource, TTarget>(Testably.Expectations.Core.PropertyAccessor<TSource, TTarget?> propertyAccessor, System.Func<Testably.Expectations.Core.PropertyAccessor, string, string>? expectationTextGenerator = null) { }
+        public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public class PropertyExpectationBuilder<TSource, TProperty>
         {
             public Testably.Expectations.Core.ExpectationBuilder AddExpectations(System.Action<Testably.Expectations.Core.ExpectationBuilder> expectation) { }

--- a/Tests/Testably.Expectations.Tests/ExpectTests.cs
+++ b/Tests/Testably.Expectations.Tests/ExpectTests.cs
@@ -338,6 +338,7 @@ public class ExpectTests
 				.WithMessage("You must provide at least one expectation*").AsWildcard();
 		}
 	}
+	
 #if NET6_0_OR_GREATER
 	/// <summary>
 	///     Returns an <see cref="IAsyncEnumerable{T}" /> with incrementing numbers, starting with 0, which cancels the
@@ -370,7 +371,7 @@ public class ExpectTests
 			subject = GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 		async Task Act()
-			=> await That(subject).Should(b => b.AddCancellation(token)).All().Satisfy(x => x < 6);
+			=> await That(subject).Should(b => b.WithCancellation(token)).All().Satisfy(x => x < 6);
 
 		await That(Act).Should().Throw<XunitException>()
 			.WithMessage("""

--- a/Tests/Testably.Expectations.Tests/ExpectTests.cs
+++ b/Tests/Testably.Expectations.Tests/ExpectTests.cs
@@ -1,169 +1,11 @@
-﻿namespace Testably.Expectations.Tests;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Testably.Expectations.Tests;
 
 public class ExpectTests
 {
-	public class ThatAnyTests
-	{
-		[Fact]
-		public async Task ShouldEvaluateAndDisplayAllExpectations()
-		{
-			bool subjectA = false;
-			bool subjectB = false;
-
-			async Task Act()
-				=> await ThatAny(
-					That(subjectA).Should().BeTrue(),
-					That(subjectB).Should().BeTrue());
-
-			await That(Act).Should().Throw<XunitException>()
-				.WithMessage("""
-				             Expected any of the following to succeed:
-				              [01] Expected subjectA to be True
-				              [02] Expected subjectB to be True
-				             but
-				              [01] found False
-				              [02] found False
-				             """);
-		}
-
-		[Fact]
-		public async Task ShouldIncludeProperIndentationForMultilineResults()
-		{
-			string subjectA = "subject X";
-			string subjectB = "subject Y";
-			string subjectC = "subject Z";
-
-			async Task Act()
-				=> await ThatAny(
-					That(subjectA).Should().Be("subject A"),
-					That(subjectB).Should().Be("subject B"),
-					That(subjectC).Should().Be("subject C"));
-
-			await That(Act).Should().Throw<XunitException>()
-				.WithMessage("""
-				             Expected any of the following to succeed:
-				              [01] Expected subjectA to be equal to "subject A"
-				              [02] Expected subjectB to be equal to "subject B"
-				              [03] Expected subjectC to be equal to "subject C"
-				             but
-				              [01] found "subject X" which differs at index 8:
-				                              ↓ (actual)
-				                     "subject X"
-				                     "subject A"
-				                              ↑ (expected)
-				              [02] found "subject Y" which differs at index 8:
-				                              ↓ (actual)
-				                     "subject Y"
-				                     "subject B"
-				                              ↑ (expected)
-				              [03] found "subject Z" which differs at index 8:
-				                              ↓ (actual)
-				                     "subject Z"
-				                     "subject C"
-				                              ↑ (expected)
-				             """);
-		}
-
-		[Theory]
-		[InlineData(true, true)]
-		[InlineData(true, false)]
-		[InlineData(false, true)]
-		public async Task WhenAnyConditionIsMet_ShouldSucceed(bool subjectA, bool subjectB)
-		{
-			async Task Act()
-				=> await ThatAny(
-					That(subjectA).Should().BeTrue(),
-					That(subjectB).Should().BeTrue());
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task WhenNested_ShouldIncludeProperIndentationForMultilineResults()
-		{
-			string subjectA = "subject X";
-			string subjectB = "some unexpected value";
-			string subjectC = "subject Z";
-
-			async Task Act()
-				=> await ThatAny(
-					That(false).Should().BeTrue(),
-					ThatAny(
-						That(subjectA).Should().Be("subject A"),
-						That(subjectB).Should().Be("subject B"),
-						That(subjectC).Should().Be("subject C")));
-
-			await That(Act).Should().Throw<XunitException>()
-				.WithMessage("""
-				             Expected any of the following to succeed:
-				              [01] Expected false to be True
-				               Expected any of the following to succeed:
-				                [02] Expected subjectA to be equal to "subject A"
-				                [03] Expected subjectB to be equal to "subject B"
-				                [04] Expected subjectC to be equal to "subject C"
-				             but
-				              [01] found False
-				                [02] found "subject X" which differs at index 8:
-				                                ↓ (actual)
-				                       "subject X"
-				                       "subject A"
-				                                ↑ (expected)
-				                [03] found "some unexpected value" which differs at index 1:
-				                         ↓ (actual)
-				                       "some unexpected value"
-				                       "subject B"
-				                         ↑ (expected)
-				                [04] found "subject Z" which differs at index 8:
-				                                ↓ (actual)
-				                       "subject Z"
-				                       "subject C"
-				                                ↑ (expected)
-				             """);
-		}
-
-		[Fact]
-		public async Task WhenNested_ShouldUseIncrementingNumber()
-		{
-			bool subjectA = false;
-			bool subjectB = true;
-			bool subjectC = false;
-			bool subjectD = false;
-
-			async Task Act()
-				=> await ThatAny(
-					ThatAll(
-						That(subjectA).Should().BeTrue(),
-						That(subjectB).Should().BeTrue()),
-					That(subjectC).Should().BeTrue(),
-					That(subjectD).Should().BeTrue());
-
-			await That(Act).Should().Throw<XunitException>()
-				.WithMessage("""
-				             Expected any of the following to succeed:
-				               Expected all of the following to succeed:
-				                [01] Expected subjectA to be True
-				                [02] Expected subjectB to be True
-				              [03] Expected subjectC to be True
-				              [04] Expected subjectD to be True
-				             but
-				                [01] found False
-				              [03] found False
-				              [04] found False
-				             """);
-		}
-
-		[Fact]
-		public async Task WhenNoExpectationWasProvided_ShouldThrowArgumentException()
-		{
-			async Task Act()
-				=> await ThatAny();
-
-			await That(Act).Should().Throw<ArgumentException>()
-				.WithParamName("expectations").And
-				.WithMessage("You must provide at least one expectation*").AsWildcard();
-		}
-	}
-
 	public class ThatAllTests
 	{
 		[Theory]
@@ -334,4 +176,208 @@ public class ExpectTests
 				.WithMessage("You must provide at least one expectation*").AsWildcard();
 		}
 	}
+
+	public class ThatAnyTests
+	{
+		[Fact]
+		public async Task ShouldEvaluateAndDisplayAllExpectations()
+		{
+			bool subjectA = false;
+			bool subjectB = false;
+
+			async Task Act()
+				=> await ThatAny(
+					That(subjectA).Should().BeTrue(),
+					That(subjectB).Should().BeTrue());
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected any of the following to succeed:
+				              [01] Expected subjectA to be True
+				              [02] Expected subjectB to be True
+				             but
+				              [01] found False
+				              [02] found False
+				             """);
+		}
+
+		[Fact]
+		public async Task ShouldIncludeProperIndentationForMultilineResults()
+		{
+			string subjectA = "subject X";
+			string subjectB = "subject Y";
+			string subjectC = "subject Z";
+
+			async Task Act()
+				=> await ThatAny(
+					That(subjectA).Should().Be("subject A"),
+					That(subjectB).Should().Be("subject B"),
+					That(subjectC).Should().Be("subject C"));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected any of the following to succeed:
+				              [01] Expected subjectA to be equal to "subject A"
+				              [02] Expected subjectB to be equal to "subject B"
+				              [03] Expected subjectC to be equal to "subject C"
+				             but
+				              [01] found "subject X" which differs at index 8:
+				                              ↓ (actual)
+				                     "subject X"
+				                     "subject A"
+				                              ↑ (expected)
+				              [02] found "subject Y" which differs at index 8:
+				                              ↓ (actual)
+				                     "subject Y"
+				                     "subject B"
+				                              ↑ (expected)
+				              [03] found "subject Z" which differs at index 8:
+				                              ↓ (actual)
+				                     "subject Z"
+				                     "subject C"
+				                              ↑ (expected)
+				             """);
+		}
+
+		[Theory]
+		[InlineData(true, true)]
+		[InlineData(true, false)]
+		[InlineData(false, true)]
+		public async Task WhenAnyConditionIsMet_ShouldSucceed(bool subjectA, bool subjectB)
+		{
+			async Task Act()
+				=> await ThatAny(
+					That(subjectA).Should().BeTrue(),
+					That(subjectB).Should().BeTrue());
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenNested_ShouldIncludeProperIndentationForMultilineResults()
+		{
+			string subjectA = "subject X";
+			string subjectB = "some unexpected value";
+			string subjectC = "subject Z";
+
+			async Task Act()
+				=> await ThatAny(
+					That(false).Should().BeTrue(),
+					ThatAny(
+						That(subjectA).Should().Be("subject A"),
+						That(subjectB).Should().Be("subject B"),
+						That(subjectC).Should().Be("subject C")));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected any of the following to succeed:
+				              [01] Expected false to be True
+				               Expected any of the following to succeed:
+				                [02] Expected subjectA to be equal to "subject A"
+				                [03] Expected subjectB to be equal to "subject B"
+				                [04] Expected subjectC to be equal to "subject C"
+				             but
+				              [01] found False
+				                [02] found "subject X" which differs at index 8:
+				                                ↓ (actual)
+				                       "subject X"
+				                       "subject A"
+				                                ↑ (expected)
+				                [03] found "some unexpected value" which differs at index 1:
+				                         ↓ (actual)
+				                       "some unexpected value"
+				                       "subject B"
+				                         ↑ (expected)
+				                [04] found "subject Z" which differs at index 8:
+				                                ↓ (actual)
+				                       "subject Z"
+				                       "subject C"
+				                                ↑ (expected)
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenNested_ShouldUseIncrementingNumber()
+		{
+			bool subjectA = false;
+			bool subjectB = true;
+			bool subjectC = false;
+			bool subjectD = false;
+
+			async Task Act()
+				=> await ThatAny(
+					ThatAll(
+						That(subjectA).Should().BeTrue(),
+						That(subjectB).Should().BeTrue()),
+					That(subjectC).Should().BeTrue(),
+					That(subjectD).Should().BeTrue());
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected any of the following to succeed:
+				               Expected all of the following to succeed:
+				                [01] Expected subjectA to be True
+				                [02] Expected subjectB to be True
+				              [03] Expected subjectC to be True
+				              [04] Expected subjectD to be True
+				             but
+				                [01] found False
+				              [03] found False
+				              [04] found False
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenNoExpectationWasProvided_ShouldThrowArgumentException()
+		{
+			async Task Act()
+				=> await ThatAny();
+
+			await That(Act).Should().Throw<ArgumentException>()
+				.WithParamName("expectations").And
+				.WithMessage("You must provide at least one expectation*").AsWildcard();
+		}
+	}
+#if NET6_0_OR_GREATER
+	/// <summary>
+	///     Returns an <see cref="IAsyncEnumerable{T}" /> with incrementing numbers, starting with 0, which cancels the
+	///     <paramref name="cancellationTokenSource" /> after <paramref name="cancelAfter" /> iteration.
+	/// </summary>
+	private static async IAsyncEnumerable<int> GetCancellingAsyncEnumerable(
+		int cancelAfter,
+		CancellationTokenSource cancellationTokenSource,
+		[EnumeratorCancellation] CancellationToken cancellationToken = default)
+	{
+		int index = 0;
+		while (!cancellationToken.IsCancellationRequested)
+		{
+			if (index == cancelAfter)
+			{
+				cancellationTokenSource.Cancel();
+			}
+
+			await Task.Yield();
+			yield return index++;
+		}
+	}
+
+	[Fact]
+	public async Task ShouldWithExpressionBuilder_ShouldApplyMethods()
+	{
+		using CancellationTokenSource cts = new();
+		CancellationToken token = cts.Token;
+		IAsyncEnumerable<int>
+			subject = GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
+
+		async Task Act()
+			=> await That(subject).Should(b => b.AddCancellation(token)).All().Satisfy(x => x < 6);
+
+		await That(Act).Should().Throw<XunitException>()
+			.WithMessage("""
+			             Expected subject to
+			             all satisfy "x => x < 6",
+			             but could not verify, because it was cancelled early
+			             """);
+	}
+#endif
 }


### PR DESCRIPTION
Consolidate the `#if` statements to only use positive statements.
Add test for `Expect.Should()` with expectationbuilder callback