### PR TITLE
feat: add `EditorBrowsable` attribute

### DIFF
--- a/Source/Testably.Expectations/Core/IExpectSubject.cs
+++ b/Source/Testably.Expectations/Core/IExpectSubject.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace Testably.Expectations.Core;
 
@@ -7,8 +8,24 @@ namespace Testably.Expectations.Core;
 /// </summary>
 public interface IExpectSubject<out T>
 {
+	/// <inheritdoc cref="object.Equals(object?)" />
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	bool Equals(object? obj);
+
+	/// <inheritdoc cref="object.GetHashCode()" />
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	int GetHashCode();
+
+	/// <inheritdoc cref="object.GetType()" />
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	Type GetType();
+
 	/// <summary>
 	///     Applies the <paramref name="builderOptions" /> to the <see cref="ExpectationBuilder" />.
 	/// </summary>
 	IThat<T> Should(Action<ExpectationBuilder> builderOptions);
+
+	/// <inheritdoc cref="object.ToString()" />
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	string? ToString();
 }

--- a/Source/Testably.Expectations/Core/IThat.cs
+++ b/Source/Testably.Expectations/Core/IThat.cs
@@ -1,12 +1,33 @@
-﻿namespace Testably.Expectations.Core;
+﻿using System;
+using System.ComponentModel;
+
+namespace Testably.Expectations.Core;
 
 /// <summary>
 ///     Base class for expectations, containing an <see cref="ExpectationBuilder" />.
 /// </summary>
+// ReSharper disable once UnusedTypeParameter
 public interface IThat<out T>
 {
 	/// <summary>
 	///     The expectation builder.
 	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Advanced)]
 	ExpectationBuilder ExpectationBuilder { get; }
+
+	/// <inheritdoc cref="object.Equals(object?)" />
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	bool Equals(object? obj);
+
+	/// <inheritdoc cref="object.GetHashCode()" />
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	int GetHashCode();
+
+	/// <inheritdoc cref="object.GetType()" />
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	Type GetType();
+
+	/// <inheritdoc cref="object.ToString()" />
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	string? ToString();
 }

--- a/Source/Testably.Expectations/Results/Expectation.cs
+++ b/Source/Testably.Expectations/Results/Expectation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -17,6 +18,26 @@ namespace Testably.Expectations.Results;
 [StackTraceHidden]
 public abstract class Expectation
 {
+	/// <inheritdoc cref="object.Equals(object?)" />
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public override bool Equals(object? obj)
+		=> throw new NotSupportedException("Equals is not supported. Did you mean Be() instead?");
+
+	/// <inheritdoc cref="object.GetHashCode()" />
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public override int GetHashCode()
+		=> throw new NotSupportedException("GetHashCode is not supported.");
+
+	/// <inheritdoc cref="object.GetType()" />
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public new Type GetType()
+		=> base.GetType();
+
+	/// <inheritdoc cref="object.ToString()" />
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public override string? ToString()
+		=> base.ToString();
+
 	internal abstract Task<Result> GetResult(int index);
 
 	internal struct Result(int index, string subjectLine, ConstraintResult result)

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -865,11 +865,19 @@ namespace Testably.Expectations.Core
     }
     public interface IExpectSubject<out T>
     {
+        bool Equals(object? obj);
+        int GetHashCode();
+        System.Type GetType();
         Testably.Expectations.Core.IThat<T> Should(System.Action<Testably.Expectations.Core.ExpectationBuilder> builderOptions);
+        string? ToString();
     }
     public interface IThat<out T>
     {
         Testably.Expectations.Core.ExpectationBuilder ExpectationBuilder { get; }
+        bool Equals(object? obj);
+        int GetHashCode();
+        System.Type GetType();
+        string? ToString();
     }
     public abstract class PropertyAccessor
     {
@@ -1034,6 +1042,10 @@ namespace Testably.Expectations.Results
     public abstract class Expectation
     {
         protected Expectation() { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public new System.Type GetType() { }
+        public override string? ToString() { }
         public abstract class Combination : Testably.Expectations.Results.Expectation
         {
             protected Combination(Testably.Expectations.Results.Expectation[] expectations) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -865,11 +865,19 @@ namespace Testably.Expectations.Core
     }
     public interface IExpectSubject<out T>
     {
+        bool Equals(object? obj);
+        int GetHashCode();
+        System.Type GetType();
         Testably.Expectations.Core.IThat<T> Should(System.Action<Testably.Expectations.Core.ExpectationBuilder> builderOptions);
+        string? ToString();
     }
     public interface IThat<out T>
     {
         Testably.Expectations.Core.ExpectationBuilder ExpectationBuilder { get; }
+        bool Equals(object? obj);
+        int GetHashCode();
+        System.Type GetType();
+        string? ToString();
     }
     public abstract class PropertyAccessor
     {
@@ -1034,6 +1042,10 @@ namespace Testably.Expectations.Results
     public abstract class Expectation
     {
         protected Expectation() { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public new System.Type GetType() { }
+        public override string? ToString() { }
         public abstract class Combination : Testably.Expectations.Results.Expectation
         {
             protected Combination(Testably.Expectations.Results.Expectation[] expectations) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -761,11 +761,19 @@ namespace Testably.Expectations.Core
     }
     public interface IExpectSubject<out T>
     {
+        bool Equals(object? obj);
+        int GetHashCode();
+        System.Type GetType();
         Testably.Expectations.Core.IThat<T> Should(System.Action<Testably.Expectations.Core.ExpectationBuilder> builderOptions);
+        string? ToString();
     }
     public interface IThat<out T>
     {
         Testably.Expectations.Core.ExpectationBuilder ExpectationBuilder { get; }
+        bool Equals(object? obj);
+        int GetHashCode();
+        System.Type GetType();
+        string? ToString();
     }
     public abstract class PropertyAccessor
     {
@@ -930,6 +938,10 @@ namespace Testably.Expectations.Results
     public abstract class Expectation
     {
         protected Expectation() { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public new System.Type GetType() { }
+        public override string? ToString() { }
         public abstract class Combination : Testably.Expectations.Results.Expectation
         {
             protected Combination(Testably.Expectations.Results.Expectation[] expectations) { }

--- a/Tests/Testably.Expectations.Tests/Results/ExpectationTests.cs
+++ b/Tests/Testably.Expectations.Tests/Results/ExpectationTests.cs
@@ -1,0 +1,26 @@
+﻿using Testably.Expectations.Results;
+
+namespace Testably.Expectations.Tests.Results;
+
+public class ExpectationTests
+{
+	[Fact]
+	public async Task Equals_ShouldThrowNotSupportedException()
+	{
+		Expectation sut = That(true).Should().BeTrue();
+
+		bool Act() => sut.Equals(That(true).Should().BeTrue());
+
+		await That(Act).Should().Throw<NotSupportedException>();
+	}
+
+	[Fact]
+	public async Task GetHashCode_ShouldThrowNotSupportedException()
+	{
+		Expectation sut = That(true).Should().BeTrue();
+
+		int Act() => sut.GetHashCode();
+
+		await That(Act).Should().Throw<NotSupportedException>();
+	}
+}

--- a/Tests/Testably.Expectations.Tests/Results/ExpectationTests.cs
+++ b/Tests/Testably.Expectations.Tests/Results/ExpectationTests.cs
@@ -11,7 +11,8 @@ public class ExpectationTests
 
 		bool Act() => sut.Equals(That(true).Should().BeTrue());
 
-		await That(Act).Should().Throw<NotSupportedException>();
+		await That(Act).Should().Throw<NotSupportedException>()
+			.WithMessage("Equals is not supported. Did you mean Be() instead?");
 	}
 
 	[Fact]
@@ -21,6 +22,7 @@ public class ExpectationTests
 
 		int Act() => sut.GetHashCode();
 
-		await That(Act).Should().Throw<NotSupportedException>();
+		await That(Act).Should().Throw<NotSupportedException>()
+			.WithMessage("GetHashCode is not supported.");
 	}
 }


### PR DESCRIPTION
Fixes #119 
Exclude `Equals`, `GetHashCode`, `ToString()`, ... from IntelliSense via the [`EditorBrowsable`](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.editorbrowsableattribute?view=net-8.0) attribute.