### PR TITLE
docs: add link to benchmarks in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ By adding `global using static Testably.Expectations.Expect;` anywhere in the te
 	  .Because("we tested the null edge case");
   }
   ```
+
+## Benchmarks
+Some simple [benchmarks](https://github.com/Testably/Testably.Expectations/tree/main/Tests/Testably.Expectations.Benchmarks) are available [here](https://testably.github.io/Testably.Expectations).


### PR DESCRIPTION
Add a link to the benchmark page in the README.md.