### PR TITLE
feat: add `BeAfter`/`BeBefore` for `DateTimeOffset`

### DIFF
--- a/Source/Testably.Expectations/That/DateTimeOffsets/ThatDateTimeOffsetShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/DateTimeOffsets/ThatDateTimeOffsetShould.BeAfter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatDateTimeOffsetShould
+{
+	/// <summary>
+	///     Verifies that the subject is after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> BeAfter(
+		this IThat<DateTimeOffset> source,
+		DateTimeOffset? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					expected,
+					$"be after {Formatter.Format(expected)}",
+					(a, e, t) => a + t > e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not after the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> NotBeAfter(
+		this IThat<DateTimeOffset> source,
+		DateTimeOffset? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					unexpected,
+					$"not be after {Formatter.Format(unexpected)}",
+					(a, e, t) => a - t <= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}

--- a/Source/Testably.Expectations/That/DateTimeOffsets/ThatDateTimeOffsetShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/DateTimeOffsets/ThatDateTimeOffsetShould.BeBefore.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatDateTimeOffsetShould
+{
+	/// <summary>
+	///     Verifies that the subject is before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> BeBefore(
+		this IThat<DateTimeOffset> source,
+		DateTimeOffset? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					expected,
+					$"be before {Formatter.Format(expected)}",
+					(a, e, t) => a - t < e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not before the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> NotBeBefore(
+		this IThat<DateTimeOffset> source,
+		DateTimeOffset? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					unexpected,
+					$"not be before {Formatter.Format(unexpected)}",
+					(a, e, t) => a + t >= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}

--- a/Source/Testably.Expectations/That/DateTimeOffsets/ThatDateTimeOffsetShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/DateTimeOffsets/ThatDateTimeOffsetShould.BeOnOrAfter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatDateTimeOffsetShould
+{
+	/// <summary>
+	///     Verifies that the subject is on or after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> BeOnOrAfter(
+		this IThat<DateTimeOffset> source,
+		DateTimeOffset? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					expected,
+					$"be on or after {Formatter.Format(expected)}",
+					(a, e, t) => a + t >= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or after the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> NotBeOnOrAfter(
+		this IThat<DateTimeOffset> source,
+		DateTimeOffset? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					unexpected,
+					$"not be on or after {Formatter.Format(unexpected)}",
+					(a, e, t) => a - t < e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}

--- a/Source/Testably.Expectations/That/DateTimeOffsets/ThatDateTimeOffsetShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/DateTimeOffsets/ThatDateTimeOffsetShould.BeOnOrBefore.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatDateTimeOffsetShould
+{
+	/// <summary>
+	///     Verifies that the subject is on or before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> BeOnOrBefore(
+		this IThat<DateTimeOffset> source,
+		DateTimeOffset? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					expected,
+					$"be on or before {Formatter.Format(expected)}",
+					(a, e, t) => a - t <= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or before the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> NotBeOnOrBefore(
+		this IThat<DateTimeOffset> source,
+		DateTimeOffset? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					unexpected,
+					$"not be on or before {Formatter.Format(unexpected)}",
+					(a, e, t) => a + t > e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}

--- a/Source/Testably.Expectations/That/DateTimeOffsets/ThatNullableDateTimeOffsetShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/DateTimeOffsets/ThatNullableDateTimeOffsetShould.BeAfter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableDateTimeOffsetShould
+{
+	/// <summary>
+	///     Verifies that the subject is after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> BeAfter(
+		this IThat<DateTimeOffset?> source,
+		DateTimeOffset? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					expected,
+					$"be after {Formatter.Format(expected)}",
+					(a, e, t) => a + t > e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not after the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> NotBeAfter(
+		this IThat<DateTimeOffset?> source,
+		DateTimeOffset? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					unexpected,
+					$"not be after {Formatter.Format(unexpected)}",
+					(a, e, t) => a - t <= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}

--- a/Source/Testably.Expectations/That/DateTimeOffsets/ThatNullableDateTimeOffsetShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/DateTimeOffsets/ThatNullableDateTimeOffsetShould.BeBefore.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableDateTimeOffsetShould
+{
+	/// <summary>
+	///     Verifies that the subject is before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> BeBefore(
+		this IThat<DateTimeOffset?> source,
+		DateTimeOffset? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					expected,
+					$"be before {Formatter.Format(expected)}",
+					(a, e, t) => a - t < e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not before the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> NotBeBefore(
+		this IThat<DateTimeOffset?> source,
+		DateTimeOffset? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					unexpected,
+					$"not be before {Formatter.Format(unexpected)}",
+					(a, e, t) => a + t >= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}

--- a/Source/Testably.Expectations/That/DateTimeOffsets/ThatNullableDateTimeOffsetShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/DateTimeOffsets/ThatNullableDateTimeOffsetShould.BeOnOrAfter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableDateTimeOffsetShould
+{
+	/// <summary>
+	///     Verifies that the subject is on or after the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> BeOnOrAfter(
+		this IThat<DateTimeOffset?> source,
+		DateTimeOffset? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					expected,
+					$"be on or after {Formatter.Format(expected)}",
+					(a, e, t) => a + t >= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or after the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> NotBeOnOrAfter(
+		this IThat<DateTimeOffset?> source,
+		DateTimeOffset? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					unexpected,
+					$"not be on or after {Formatter.Format(unexpected)}",
+					(a, e, t) => a - t < e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}

--- a/Source/Testably.Expectations/That/DateTimeOffsets/ThatNullableDateTimeOffsetShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/DateTimeOffsets/ThatNullableDateTimeOffsetShould.BeOnOrBefore.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Options;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableDateTimeOffsetShould
+{
+	/// <summary>
+	///     Verifies that the subject is on or before the <paramref name="expected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> BeOnOrBefore(
+		this IThat<DateTimeOffset?> source,
+		DateTimeOffset? expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					expected,
+					$"be on or before {Formatter.Format(expected)}",
+					(a, e, t) => a - t <= e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not on or before the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> NotBeOnOrBefore(
+		this IThat<DateTimeOffset?> source,
+		DateTimeOffset? unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(
+			source.ExpectationBuilder
+				.AddConstraint(new ConditionConstraint(
+					unexpected,
+					$"not be on or before {Formatter.Format(unexpected)}",
+					(a, e, t) => a + t > e,
+					(a, _) => $"found {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
+}

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -143,7 +143,15 @@ namespace Testably.Expectations
     public static class ThatDateTimeOffsetShould
     {
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> Be(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> BeAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> BeBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBe(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateTimeOffset> Should(this Testably.Expectations.Core.IExpectSubject<System.DateTimeOffset> subject) { }
     }
     public static class ThatDateTimeShould
@@ -313,7 +321,15 @@ namespace Testably.Expectations
     public static class ThatNullableDateTimeOffsetShould
     {
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> Be(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> BeAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> BeBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBe(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateTimeOffset?> Should(this Testably.Expectations.Core.IExpectSubject<System.DateTimeOffset?> subject) { }
     }
     public static class ThatNullableDateTimeShould

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -143,7 +143,15 @@ namespace Testably.Expectations
     public static class ThatDateTimeOffsetShould
     {
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> Be(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> BeAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> BeBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBe(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateTimeOffset> Should(this Testably.Expectations.Core.IExpectSubject<System.DateTimeOffset> subject) { }
     }
     public static class ThatDateTimeShould
@@ -313,7 +321,15 @@ namespace Testably.Expectations
     public static class ThatNullableDateTimeOffsetShould
     {
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> Be(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> BeAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> BeBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBe(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateTimeOffset?> Should(this Testably.Expectations.Core.IExpectSubject<System.DateTimeOffset?> subject) { }
     }
     public static class ThatNullableDateTimeShould

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -102,7 +102,15 @@ namespace Testably.Expectations
     public static class ThatDateTimeOffsetShould
     {
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> Be(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> BeAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> BeBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBe(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset, Testably.Expectations.Core.IThat<System.DateTimeOffset>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateTimeOffset> Should(this Testably.Expectations.Core.IExpectSubject<System.DateTimeOffset> subject) { }
     }
     public static class ThatDateTimeShould
@@ -246,7 +254,15 @@ namespace Testably.Expectations
     public static class ThatNullableDateTimeOffsetShould
     {
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> Be(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> BeAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> BeBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> BeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> BeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBe(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBeAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBeBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBeOnOrAfter(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static Testably.Expectations.Results.TimeToleranceResult<System.DateTimeOffset?, Testably.Expectations.Core.IThat<System.DateTimeOffset?>> NotBeOnOrBefore(this Testably.Expectations.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
         public static Testably.Expectations.Core.IThat<System.DateTimeOffset?> Should(this Testably.Expectations.Core.IExpectSubject<System.DateTimeOffset?> subject) { }
     }
     public static class ThatNullableDateTimeShould

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/DateTimeOffsetShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/DateTimeOffsetShould.BeAfterTests.cs
@@ -1,0 +1,291 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.DateTimeOffsets;
+
+public sealed partial class DateTimeOffsetShould
+{
+	public sealed class BeAfterTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateTimeOffset subject = DateTimeOffset.MaxValue;
+			DateTimeOffset expected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be after 9999-12-31T23:59:59.9999999+00:00,
+				             but found 9999-12-31T23:59:59.9999999+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateTimeOffset subject = DateTimeOffset.MinValue;
+			DateTimeOffset expected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be after 0001-01-01T00:00:00.0000000+00:00,
+				             but found 0001-01-01T00:00:00.0000000+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateTimeOffset subject = EarlierTime();
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateTimeOffset subject = LaterTime();
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? expected = EarlierTime(-3);
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = EarlierTime(3);
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset subject = EarlierTime(2);
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeAfterTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateTimeOffset subject = DateTimeOffset.MaxValue;
+			DateTimeOffset unexpected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateTimeOffset subject = DateTimeOffset.MinValue;
+			DateTimeOffset unexpected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateTimeOffset subject = LaterTime();
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateTimeOffset subject = EarlierTime();
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? unexpected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = LaterTime(4);
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset subject = LaterTime(3);
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/DateTimeOffsetShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/DateTimeOffsetShould.BeBeforeTests.cs
@@ -1,0 +1,289 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.DateTimeOffsets;
+
+public sealed partial class DateTimeOffsetShould
+{
+	public sealed class BeBeforeTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateTimeOffset subject = DateTimeOffset.MaxValue;
+			DateTimeOffset expected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be before 9999-12-31T23:59:59.9999999+00:00,
+				             but found 9999-12-31T23:59:59.9999999+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateTimeOffset subject = DateTimeOffset.MinValue;
+			DateTimeOffset expected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be before 0001-01-01T00:00:00.0000000+00:00,
+				             but found 0001-01-01T00:00:00.0000000+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateTimeOffset subject = LaterTime();
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateTimeOffset subject = EarlierTime();
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? expected = LaterTime(-3);
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = LaterTime(3);
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset subject = LaterTime(2);
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeBeforeTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateTimeOffset subject = DateTimeOffset.MaxValue;
+			DateTimeOffset unexpected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateTimeOffset subject = DateTimeOffset.MinValue;
+			DateTimeOffset unexpected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateTimeOffset subject = EarlierTime();
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateTimeOffset subject = LaterTime();
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? unexpected = LaterTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = EarlierTime(4);
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset subject = EarlierTime(3);
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/DateTimeOffsetShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/DateTimeOffsetShould.BeOnOrAfterTests.cs
@@ -1,0 +1,289 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.DateTimeOffsets;
+
+public sealed partial class DateTimeOffsetShould
+{
+	public sealed class BeOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateTimeOffset subject = DateTimeOffset.MaxValue;
+			DateTimeOffset expected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateTimeOffset subject = DateTimeOffset.MinValue;
+			DateTimeOffset expected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateTimeOffset subject = EarlierTime();
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateTimeOffset subject = LaterTime();
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? expected = EarlierTime(-4);
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = EarlierTime(4);
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset subject = EarlierTime(3);
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateTimeOffset subject = DateTimeOffset.MaxValue;
+			DateTimeOffset unexpected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be on or after 9999-12-31T23:59:59.9999999+00:00,
+				             but found 9999-12-31T23:59:59.9999999+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateTimeOffset subject = DateTimeOffset.MinValue;
+			DateTimeOffset unexpected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be on or after 0001-01-01T00:00:00.0000000+00:00,
+				             but found 0001-01-01T00:00:00.0000000+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateTimeOffset subject = LaterTime();
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateTimeOffset subject = EarlierTime();
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? unexpected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = LaterTime(3);
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset subject = LaterTime(2);
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/DateTimeOffsetShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/DateTimeOffsetShould.BeOnOrBeforeTests.cs
@@ -1,0 +1,289 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.DateTimeOffsets;
+
+public sealed partial class DateTimeOffsetShould
+{
+	public sealed class BeOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateTimeOffset subject = DateTimeOffset.MaxValue;
+			DateTimeOffset expected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateTimeOffset subject = DateTimeOffset.MinValue;
+			DateTimeOffset expected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateTimeOffset subject = LaterTime();
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateTimeOffset subject = EarlierTime();
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? expected = LaterTime(-4);
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = LaterTime(4);
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset subject = LaterTime(3);
+			DateTimeOffset expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateTimeOffset subject = DateTimeOffset.MaxValue;
+			DateTimeOffset unexpected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be on or before 9999-12-31T23:59:59.9999999+00:00,
+				             but found 9999-12-31T23:59:59.9999999+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateTimeOffset subject = DateTimeOffset.MinValue;
+			DateTimeOffset unexpected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be on or before 0001-01-01T00:00:00.0000000+00:00,
+				             but found 0001-01-01T00:00:00.0000000+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateTimeOffset subject = EarlierTime();
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateTimeOffset subject = LaterTime();
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = CurrentTime();
+			DateTimeOffset? unexpected = LaterTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset subject = EarlierTime(3);
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset subject = EarlierTime(2);
+			DateTimeOffset unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/NullableDateTimeOffsetShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/NullableDateTimeOffsetShould.BeAfterTests.cs
@@ -1,0 +1,291 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.DateTimeOffsets;
+
+public sealed partial class NullableDateTimeOffsetShould
+{
+	public sealed class BeAfterTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MaxValue;
+			DateTimeOffset? expected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be after 9999-12-31T23:59:59.9999999+00:00,
+				             but found 9999-12-31T23:59:59.9999999+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MinValue;
+			DateTimeOffset? expected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be after 0001-01-01T00:00:00.0000000+00:00,
+				             but found 0001-01-01T00:00:00.0000000+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateTimeOffset? subject = EarlierTime();
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)}, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateTimeOffset? subject = LaterTime();
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? expected = EarlierTime(-3);
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = EarlierTime(3);
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be after {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset? subject = EarlierTime(2);
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeAfterTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MaxValue;
+			DateTimeOffset? unexpected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MinValue;
+			DateTimeOffset? unexpected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateTimeOffset? subject = LaterTime();
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateTimeOffset? subject = EarlierTime();
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenUnexpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? unexpected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = LaterTime(4);
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset? subject = LaterTime(3);
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/NullableDateTimeOffsetShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/NullableDateTimeOffsetShould.BeBeforeTests.cs
@@ -1,0 +1,289 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.DateTimeOffsets;
+
+public sealed partial class NullableDateTimeOffsetShould
+{
+	public sealed class BeBeforeTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MaxValue;
+			DateTimeOffset? expected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be before 9999-12-31T23:59:59.9999999+00:00,
+				             but found 9999-12-31T23:59:59.9999999+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MinValue;
+			DateTimeOffset? expected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be before 0001-01-01T00:00:00.0000000+00:00,
+				             but found 0001-01-01T00:00:00.0000000+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateTimeOffset? subject = LaterTime();
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateTimeOffset? subject = EarlierTime();
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? expected = LaterTime(-3);
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = LaterTime(3);
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset? subject = LaterTime(2);
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeBeforeTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MaxValue;
+			DateTimeOffset? unexpected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MinValue;
+			DateTimeOffset? unexpected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateTimeOffset? subject = EarlierTime();
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateTimeOffset? subject = LaterTime();
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenUnexpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? unexpected = LaterTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = EarlierTime(4);
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset? subject = EarlierTime(3);
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/NullableDateTimeOffsetShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/NullableDateTimeOffsetShould.BeOnOrAfterTests.cs
@@ -1,0 +1,289 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.DateTimeOffsets;
+
+public sealed partial class NullableDateTimeOffsetShould
+{
+	public sealed class BeOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MaxValue;
+			DateTimeOffset? expected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MinValue;
+			DateTimeOffset? expected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateTimeOffset? subject = EarlierTime();
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateTimeOffset? subject = LaterTime();
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? expected = EarlierTime(-4);
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = EarlierTime(4);
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or after {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset? subject = EarlierTime(3);
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrAfter(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeOnOrAfterTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MaxValue;
+			DateTimeOffset? unexpected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be on or after 9999-12-31T23:59:59.9999999+00:00,
+				             but found 9999-12-31T23:59:59.9999999+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MinValue;
+			DateTimeOffset? unexpected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be on or after 0001-01-01T00:00:00.0000000+00:00,
+				             but found 0001-01-01T00:00:00.0000000+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateTimeOffset? subject = LaterTime();
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateTimeOffset? subject = EarlierTime();
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenUnexpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? unexpected = EarlierTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = LaterTime(3);
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset? subject = LaterTime(2);
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/NullableDateTimeOffsetShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/NullableDateTimeOffsetShould.BeOnOrBeforeTests.cs
@@ -1,0 +1,289 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.DateTimeOffsets;
+
+public sealed partial class NullableDateTimeOffsetShould
+{
+	public sealed class BeOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before <null>,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MaxValue;
+			DateTimeOffset? expected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldSucceed()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MinValue;
+			DateTimeOffset? expected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsLater_ShouldFail()
+		{
+			DateTimeOffset? subject = LaterTime();
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldSucceed()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? expected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsEarlier_ShouldSucceed()
+		{
+			DateTimeOffset? subject = EarlierTime();
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Within_WhenExpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? expected = LaterTime(-4);
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = LaterTime(4);
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be on or before {Formatter.Format(expected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset? subject = LaterTime(3);
+			DateTimeOffset? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().BeOnOrBefore(expected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeOnOrBeforeTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMaxValue_ShouldFail()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MaxValue;
+			DateTimeOffset? unexpected = DateTimeOffset.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be on or before 9999-12-31T23:59:59.9999999+00:00,
+				             but found 9999-12-31T23:59:59.9999999+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedAreMinValue_ShouldFail()
+		{
+			DateTimeOffset? subject = DateTimeOffset.MinValue;
+			DateTimeOffset? unexpected = DateTimeOffset.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be on or before 0001-01-01T00:00:00.0000000+00:00,
+				             but found 0001-01-01T00:00:00.0000000+00:00
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsEarlier_ShouldFail()
+		{
+			DateTimeOffset? subject = EarlierTime();
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsSame_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? unexpected = subject;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)},
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectsIsLater_ShouldSucceed()
+		{
+			DateTimeOffset? subject = LaterTime();
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before <null>, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenUnexpectedValueIsOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = CurrentTime();
+			DateTimeOffset? unexpected = LaterTime(4);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
+		{
+			DateTimeOffset? subject = EarlierTime(3);
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)} ± 0:03,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateTimeOffset? subject = EarlierTime(2);
+			DateTimeOffset? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}


### PR DESCRIPTION
from #129 
Add the following expectations for `DateTimeOffset`:
- `BeAfter` / `NotBeAfter`
- `BeBefore` / `NotBeBefore`
- `BeOnOrAfter` / `NotBeOnOrAfter`
- `BeOnOrBefore` / `NotBeOnOrBefore`