### PR TITLE
fix: tolerance for `NotBeAfter.Within`/`NotBeBefore.Within`

### DIFF
--- a/Source/Testably.Expectations/That/DateOnlys/ThatDateOnlyShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/DateOnlys/ThatDateOnlyShould.BeAfter.cs
@@ -42,7 +42,7 @@ public static partial class ThatDateOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be after {Formatter.Format(u)}{t.ToDayString()}",
-					(a, e, t) => a.AddDays((int)t.TotalDays) <= e,
+					(a, e, t) => a.AddDays(-1 * (int)t.TotalDays) <= e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/DateOnlys/ThatDateOnlyShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/DateOnlys/ThatDateOnlyShould.BeBefore.cs
@@ -42,7 +42,7 @@ public static partial class ThatDateOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be before {Formatter.Format(u)}{t.ToDayString()}",
-					(a, e, t) => a.AddDays(-1 * (int)t.TotalDays) >= e,
+					(a, e, t) => a.AddDays((int)t.TotalDays) >= e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/DateOnlys/ThatDateOnlyShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/DateOnlys/ThatDateOnlyShould.BeOnOrAfter.cs
@@ -42,7 +42,7 @@ public static partial class ThatDateOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be on or after {Formatter.Format(u)}{t.ToDayString()}",
-					(a, e, t) => a.AddDays((int)t.TotalDays) < e,
+					(a, e, t) => a.AddDays(-1 * (int)t.TotalDays) < e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/DateOnlys/ThatDateOnlyShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/DateOnlys/ThatDateOnlyShould.BeOnOrBefore.cs
@@ -42,7 +42,7 @@ public static partial class ThatDateOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be on or before {Formatter.Format(u)}{t.ToDayString()}",
-					(a, e, t) => a.AddDays(-1 * (int)t.TotalDays) > e,
+					(a, e, t) => a.AddDays((int)t.TotalDays) > e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/DateOnlys/ThatNullableDateOnlyShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/DateOnlys/ThatNullableDateOnlyShould.BeAfter.cs
@@ -42,7 +42,7 @@ public static partial class ThatNullableDateOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be after {Formatter.Format(u)}{t.ToDayString()}",
-					(a, e, t) => a?.AddDays((int)t.TotalDays) <= e,
+					(a, e, t) => a?.AddDays(-1 * (int)t.TotalDays) <= e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/DateOnlys/ThatNullableDateOnlyShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/DateOnlys/ThatNullableDateOnlyShould.BeBefore.cs
@@ -42,7 +42,7 @@ public static partial class ThatNullableDateOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be before {Formatter.Format(u)}{t.ToDayString()}",
-					(a, e, t) => a?.AddDays(-1 * (int)t.TotalDays) >= e,
+					(a, e, t) => a?.AddDays((int)t.TotalDays) >= e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/DateOnlys/ThatNullableDateOnlyShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/DateOnlys/ThatNullableDateOnlyShould.BeOnOrAfter.cs
@@ -42,7 +42,7 @@ public static partial class ThatNullableDateOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be on or after {Formatter.Format(u)}{t.ToDayString()}",
-					(a, e, t) => a?.AddDays((int)t.TotalDays) < e,
+					(a, e, t) => a?.AddDays(-1 * (int)t.TotalDays) < e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/DateOnlys/ThatNullableDateOnlyShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/DateOnlys/ThatNullableDateOnlyShould.BeOnOrBefore.cs
@@ -42,7 +42,7 @@ public static partial class ThatNullableDateOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be on or before {Formatter.Format(u)}{t.ToDayString()}",
-					(a, e, t) => a?.AddDays(-1 * (int)t.TotalDays) > e,
+					(a, e, t) => a?.AddDays((int)t.TotalDays) > e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/TimeOnlys/ThatNullableTimeOnlyShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/TimeOnlys/ThatNullableTimeOnlyShould.BeAfter.cs
@@ -42,7 +42,7 @@ public static partial class ThatNullableTimeOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be after {Formatter.Format(u)}{t}",
-					(a, e, t) => a?.Add(t) <= e,
+					(a, e, t) => a?.Add(t.Negate()) <= e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/TimeOnlys/ThatNullableTimeOnlyShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/TimeOnlys/ThatNullableTimeOnlyShould.BeBefore.cs
@@ -42,7 +42,7 @@ public static partial class ThatNullableTimeOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be before {Formatter.Format(u)}{t}",
-					(a, e, t) => a?.Add(t.Negate()) >= e,
+					(a, e, t) => a?.Add(t) >= e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/TimeOnlys/ThatNullableTimeOnlyShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/TimeOnlys/ThatNullableTimeOnlyShould.BeOnOrAfter.cs
@@ -1,6 +1,5 @@
 ﻿#if NET6_0_OR_GREATER
 using System;
-using System.Net.Sockets;
 using Testably.Expectations.Core;
 using Testably.Expectations.Formatting;
 using Testably.Expectations.Options;
@@ -43,7 +42,7 @@ public static partial class ThatNullableTimeOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be on or after {Formatter.Format(u)}{t}",
-					(a, e, t) => a?.Add(t) < e,
+					(a, e, t) => a?.Add(t.Negate()) < e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/TimeOnlys/ThatNullableTimeOnlyShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/TimeOnlys/ThatNullableTimeOnlyShould.BeOnOrBefore.cs
@@ -42,7 +42,7 @@ public static partial class ThatNullableTimeOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be on or before {Formatter.Format(u)}{t}",
-					(a, e, t) => a?.Add(t.Negate()) > e,
+					(a, e, t) => a?.Add(t) > e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/TimeOnlys/ThatNullableTimeOnlyShould.HaveMillisecond.cs
+++ b/Source/Testably.Expectations/That/TimeOnlys/ThatNullableTimeOnlyShould.HaveMillisecond.cs
@@ -11,7 +11,8 @@ public static partial class ThatNullableTimeOnlyShould
 	/// <summary>
 	///     Verifies that the millisecond of the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrResult<TimeOnly?, IThat<TimeOnly?>> HaveMillisecond(this IThat<TimeOnly?> source,
+	public static AndOrResult<TimeOnly?, IThat<TimeOnly?>> HaveMillisecond(
+		this IThat<TimeOnly?> source,
 		int? expected)
 	{
 		return new AndOrResult<TimeOnly?, IThat<TimeOnly?>>(source.ExpectationBuilder

--- a/Source/Testably.Expectations/That/TimeOnlys/ThatTimeOnlyShould.BeAfter.cs
+++ b/Source/Testably.Expectations/That/TimeOnlys/ThatTimeOnlyShould.BeAfter.cs
@@ -42,7 +42,7 @@ public static partial class ThatTimeOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be after {Formatter.Format(u)}{t}",
-					(a, e, t) => a.Add(t) <= e,
+					(a, e, t) => a.Add(t.Negate()) <= e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/TimeOnlys/ThatTimeOnlyShould.BeBefore.cs
+++ b/Source/Testably.Expectations/That/TimeOnlys/ThatTimeOnlyShould.BeBefore.cs
@@ -42,7 +42,7 @@ public static partial class ThatTimeOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be before {Formatter.Format(u)}{t}",
-					(a, e, t) => a.Add(t.Negate()) >= e,
+					(a, e, t) => a.Add(t) >= e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/TimeOnlys/ThatTimeOnlyShould.BeOnOrAfter.cs
+++ b/Source/Testably.Expectations/That/TimeOnlys/ThatTimeOnlyShould.BeOnOrAfter.cs
@@ -42,7 +42,7 @@ public static partial class ThatTimeOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be on or after {Formatter.Format(u)}{t}",
-					(a, e, t) => a.Add(t) < e,
+					(a, e, t) => a.Add(t.Negate()) < e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/TimeOnlys/ThatTimeOnlyShould.BeOnOrBefore.cs
+++ b/Source/Testably.Expectations/That/TimeOnlys/ThatTimeOnlyShould.BeOnOrBefore.cs
@@ -42,7 +42,7 @@ public static partial class ThatTimeOnlyShould
 				.AddConstraint(new ConditionConstraintWithTolerance(
 					unexpected,
 					(u, t) => $"not be on or before {Formatter.Format(u)}{t}",
-					(a, e, t) => a.Add(t.Negate()) > e,
+					(a, e, t) => a.Add(t) > e,
 					(a, _) => $"found {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/Testably.Expectations/That/TimeOnlys/ThatTimeOnlyShould.HaveMillisecond.cs
+++ b/Source/Testably.Expectations/That/TimeOnlys/ThatTimeOnlyShould.HaveMillisecond.cs
@@ -11,7 +11,8 @@ public static partial class ThatTimeOnlyShould
 	/// <summary>
 	///     Verifies that the millisecond of the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrResult<TimeOnly, IThat<TimeOnly>> HaveMillisecond(this IThat<TimeOnly> source,
+	public static AndOrResult<TimeOnly, IThat<TimeOnly>> HaveMillisecond(
+		this IThat<TimeOnly> source,
 		int? expected)
 	{
 		return new AndOrResult<TimeOnly, IThat<TimeOnly>>(source.ExpectationBuilder

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/DateOnlyShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/DateOnlyShould.BeAfterTests.cs
@@ -240,36 +240,28 @@ public sealed partial class DateOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateOnly subject = CurrentTime();
-			DateOnly? unexpected = LaterTime(3);
+			DateOnly? unexpected = EarlierTime(4);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeAfter(unexpected)
 					.Within(TimeSpan.FromDays(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			DateOnly subject = EarlierTime(3);
-			DateOnly unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeAfter(unexpected)
-					.Within(TimeSpan.FromDays(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
-		{
-			DateOnly subject = EarlierTime(2);
+			DateOnly subject = LaterTime(4);
 			DateOnly unexpected = CurrentTime();
 
 			async Task Act()
@@ -282,6 +274,19 @@ public sealed partial class DateOnlyShould
 				              not be after {Formatter.Format(unexpected)} ± 3 days,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = LaterTime(3);
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/DateOnlyShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/DateOnlyShould.BeBeforeTests.cs
@@ -240,36 +240,28 @@ public sealed partial class DateOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateOnly subject = CurrentTime();
-			DateOnly? unexpected = EarlierTime(4);
+			DateOnly? unexpected = LaterTime(4);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeBefore(unexpected)
 					.Within(TimeSpan.FromDays(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			DateOnly subject = LaterTime(3);
-			DateOnly unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeBefore(unexpected)
-					.Within(TimeSpan.FromDays(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
-		{
-			DateOnly subject = EarlierTime(2);
+			DateOnly subject = EarlierTime(4);
 			DateOnly unexpected = CurrentTime();
 
 			async Task Act()
@@ -282,6 +274,19 @@ public sealed partial class DateOnlyShould
 				              not be before {Formatter.Format(unexpected)} ± 3 days,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = EarlierTime(3);
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/DateOnlyShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/DateOnlyShould.BeOnOrAfterTests.cs
@@ -239,36 +239,28 @@ public sealed partial class DateOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateOnly subject = CurrentTime();
-			DateOnly? unexpected = LaterTime(4);
+			DateOnly? unexpected = EarlierTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
 					.Within(TimeSpan.FromDays(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			DateOnly subject = EarlierTime(4);
-			DateOnly unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
-					.Within(TimeSpan.FromDays(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
-		{
-			DateOnly subject = EarlierTime(3);
+			DateOnly subject = LaterTime(3);
 			DateOnly unexpected = CurrentTime();
 
 			async Task Act()
@@ -281,6 +273,19 @@ public sealed partial class DateOnlyShould
 				              not be on or after {Formatter.Format(unexpected)} ± 3 days,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = LaterTime(2);
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/DateOnlyShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/DateOnlyShould.BeOnOrBeforeTests.cs
@@ -239,34 +239,26 @@ public sealed partial class DateOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateOnly subject = CurrentTime();
-			DateOnly? unexpected = EarlierTime(4);
+			DateOnly? unexpected = LaterTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
 					.Within(TimeSpan.FromDays(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
-		{
-			DateOnly subject = LaterTime(4);
-			DateOnly unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
-					.Within(TimeSpan.FromDays(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
 			DateOnly subject = EarlierTime(3);
 			DateOnly unexpected = CurrentTime();
@@ -281,6 +273,19 @@ public sealed partial class DateOnlyShould
 				              not be on or before {Formatter.Format(unexpected)} ± 3 days,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly subject = EarlierTime(2);
+			DateOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeAfterTests.cs
@@ -240,36 +240,28 @@ public sealed partial class NullableDateOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateOnly? subject = CurrentTime();
-			DateOnly? unexpected = LaterTime(3);
+			DateOnly? unexpected = EarlierTime(4);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeAfter(unexpected)
 					.Within(TimeSpan.FromDays(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			DateOnly? subject = EarlierTime(3);
-			DateOnly? unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeAfter(unexpected)
-					.Within(TimeSpan.FromDays(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
-		{
-			DateOnly? subject = EarlierTime(2);
+			DateOnly? subject = LaterTime(4);
 			DateOnly? unexpected = CurrentTime();
 
 			async Task Act()
@@ -282,6 +274,19 @@ public sealed partial class NullableDateOnlyShould
 				              not be after {Formatter.Format(unexpected)} ± 3 days,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = LaterTime(3);
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeBeforeTests.cs
@@ -240,36 +240,28 @@ public sealed partial class NullableDateOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateOnly? subject = CurrentTime();
-			DateOnly? unexpected = EarlierTime(4);
+			DateOnly? unexpected = LaterTime(4);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeBefore(unexpected)
 					.Within(TimeSpan.FromDays(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			DateOnly? subject = LaterTime(3);
-			DateOnly? unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeBefore(unexpected)
-					.Within(TimeSpan.FromDays(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
-		{
-			DateOnly? subject = EarlierTime(2);
+			DateOnly? subject = EarlierTime(4);
 			DateOnly? unexpected = CurrentTime();
 
 			async Task Act()
@@ -282,6 +274,19 @@ public sealed partial class NullableDateOnlyShould
 				              not be before {Formatter.Format(unexpected)} ± 3 days,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = EarlierTime(3);
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeOnOrAfterTests.cs
@@ -239,36 +239,28 @@ public sealed partial class NullableDateOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateOnly? subject = CurrentTime();
-			DateOnly? unexpected = LaterTime(4);
+			DateOnly? unexpected = EarlierTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
 					.Within(TimeSpan.FromDays(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			DateOnly? subject = EarlierTime(4);
-			DateOnly? unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
-					.Within(TimeSpan.FromDays(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
-		{
-			DateOnly? subject = EarlierTime(3);
+			DateOnly? subject = LaterTime(3);
 			DateOnly? unexpected = CurrentTime();
 
 			async Task Act()
@@ -281,6 +273,19 @@ public sealed partial class NullableDateOnlyShould
 				              not be on or after {Formatter.Format(unexpected)} ± 3 days,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = LaterTime(2);
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeOnOrBeforeTests.cs
@@ -239,34 +239,26 @@ public sealed partial class NullableDateOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateOnly? subject = CurrentTime();
-			DateOnly? unexpected = EarlierTime(4);
+			DateOnly? unexpected = LaterTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
 					.Within(TimeSpan.FromDays(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)} ± 3 days, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
-		{
-			DateOnly? subject = LaterTime(4);
-			DateOnly? unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
-					.Within(TimeSpan.FromDays(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
 			DateOnly? subject = EarlierTime(3);
 			DateOnly? unexpected = CurrentTime();
@@ -281,6 +273,19 @@ public sealed partial class NullableDateOnlyShould
 				              not be on or before {Formatter.Format(unexpected)} ± 3 days,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			DateOnly? subject = EarlierTime(2);
+			DateOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromDays(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/DateTimeOffsetShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/DateTimeOffsetShould.BeOnOrAfterTests.cs
@@ -240,7 +240,7 @@ public sealed partial class DateTimeOffsetShould
 		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateTimeOffset subject = CurrentTime();
-			DateTimeOffset? unexpected = EarlierTime(4);
+			DateTimeOffset? unexpected = EarlierTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrAfter(unexpected)

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/DateTimeOffsetShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/DateTimeOffsetShould.BeOnOrBeforeTests.cs
@@ -240,7 +240,7 @@ public sealed partial class DateTimeOffsetShould
 		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateTimeOffset subject = CurrentTime();
-			DateTimeOffset? unexpected = LaterTime(4);
+			DateTimeOffset? unexpected = LaterTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrBefore(unexpected)

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/NullableDateTimeOffsetShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/NullableDateTimeOffsetShould.BeOnOrAfterTests.cs
@@ -240,7 +240,7 @@ public sealed partial class NullableDateTimeOffsetShould
 		public async Task Within_WhenUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateTimeOffset? subject = CurrentTime();
-			DateTimeOffset? unexpected = EarlierTime(4);
+			DateTimeOffset? unexpected = EarlierTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrAfter(unexpected)

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/NullableDateTimeOffsetShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimeOffsets/NullableDateTimeOffsetShould.BeOnOrBeforeTests.cs
@@ -240,7 +240,7 @@ public sealed partial class NullableDateTimeOffsetShould
 		public async Task Within_WhenUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateTimeOffset? subject = CurrentTime();
-			DateTimeOffset? unexpected = LaterTime(4);
+			DateTimeOffset? unexpected = LaterTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrBefore(unexpected)

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimes/DateTimeShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimes/DateTimeShould.BeAfterTests.cs
@@ -106,7 +106,7 @@ public sealed partial class DateTimeShould
 		public async Task Within_WhenNullableExpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateTime subject = CurrentTime();
-			DateTime? expected = EarlierTime(-3);
+			DateTime? expected = LaterTime(4);
 
 			async Task Act()
 				=> await That(subject).Should().BeAfter(expected)

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimes/DateTimeShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimes/DateTimeShould.BeOnOrAfterTests.cs
@@ -240,7 +240,7 @@ public sealed partial class DateTimeShould
 		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateTime subject = CurrentTime();
-			DateTime? unexpected = EarlierTime(4);
+			DateTime? unexpected = EarlierTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrAfter(unexpected)

--- a/Tests/Testably.Expectations.Tests/ThatTests/DateTimes/DateTimeShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/DateTimes/DateTimeShould.BeOnOrBeforeTests.cs
@@ -240,7 +240,7 @@ public sealed partial class DateTimeShould
 		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			DateTime subject = CurrentTime();
-			DateTime? unexpected = LaterTime(4);
+			DateTime? unexpected = LaterTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrBefore(unexpected)

--- a/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeAfterTests.cs
@@ -240,36 +240,28 @@ public sealed partial class NullableTimeOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			TimeOnly? subject = CurrentTime();
-			TimeOnly? unexpected = LaterTime(3);
+			TimeOnly? unexpected = EarlierTime(4);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeAfter(unexpected)
 					.Within(TimeSpan.FromSeconds(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			TimeOnly? subject = EarlierTime(3);
-			TimeOnly? unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeAfter(unexpected)
-					.Within(TimeSpan.FromSeconds(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
-		{
-			TimeOnly? subject = EarlierTime(2);
+			TimeOnly? subject = LaterTime(4);
 			TimeOnly? unexpected = CurrentTime();
 
 			async Task Act()
@@ -282,6 +274,19 @@ public sealed partial class NullableTimeOnlyShould
 				              not be after {Formatter.Format(unexpected)} ± 0:03,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = LaterTime(3);
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeBeforeTests.cs
@@ -240,36 +240,28 @@ public sealed partial class NullableTimeOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			TimeOnly? subject = CurrentTime();
-			TimeOnly? unexpected = EarlierTime(4);
+			TimeOnly? unexpected = LaterTime(4);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeBefore(unexpected)
 					.Within(TimeSpan.FromSeconds(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			TimeOnly? subject = LaterTime(3);
-			TimeOnly? unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeBefore(unexpected)
-					.Within(TimeSpan.FromSeconds(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
-		{
-			TimeOnly? subject = EarlierTime(2);
+			TimeOnly? subject = EarlierTime(4);
 			TimeOnly? unexpected = CurrentTime();
 
 			async Task Act()
@@ -282,6 +274,19 @@ public sealed partial class NullableTimeOnlyShould
 				              not be before {Formatter.Format(unexpected)} ± 0:03,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = EarlierTime(3);
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeOnOrAfterTests.cs
@@ -239,36 +239,28 @@ public sealed partial class NullableTimeOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			TimeOnly? subject = CurrentTime();
-			TimeOnly? unexpected = LaterTime(4);
+			TimeOnly? unexpected = EarlierTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
 					.Within(TimeSpan.FromSeconds(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			TimeOnly? subject = EarlierTime(4);
-			TimeOnly? unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
-					.Within(TimeSpan.FromSeconds(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
-		{
-			TimeOnly? subject = EarlierTime(3);
+			TimeOnly? subject = LaterTime(3);
 			TimeOnly? unexpected = CurrentTime();
 
 			async Task Act()
@@ -281,6 +273,19 @@ public sealed partial class NullableTimeOnlyShould
 				              not be on or after {Formatter.Format(unexpected)} ± 0:03,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = LaterTime(2);
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeOnOrBeforeTests.cs
@@ -239,34 +239,26 @@ public sealed partial class NullableTimeOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			TimeOnly? subject = CurrentTime();
-			TimeOnly? unexpected = EarlierTime(4);
+			TimeOnly? unexpected = LaterTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
 					.Within(TimeSpan.FromSeconds(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
-		{
-			TimeOnly? subject = LaterTime(4);
-			TimeOnly? unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
-					.Within(TimeSpan.FromSeconds(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
 			TimeOnly? subject = EarlierTime(3);
 			TimeOnly? unexpected = CurrentTime();
@@ -281,6 +273,19 @@ public sealed partial class NullableTimeOnlyShould
 				              not be on or before {Formatter.Format(unexpected)} ± 0:03,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly? subject = EarlierTime(2);
+			TimeOnly? unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeAfterTests.cs
@@ -240,36 +240,28 @@ public sealed partial class TimeOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			TimeOnly subject = CurrentTime();
-			TimeOnly? unexpected = LaterTime(3);
+			TimeOnly? unexpected = EarlierTime(4);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeAfter(unexpected)
 					.Within(TimeSpan.FromSeconds(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			TimeOnly subject = EarlierTime(3);
-			TimeOnly unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeAfter(unexpected)
-					.Within(TimeSpan.FromSeconds(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
-		{
-			TimeOnly subject = EarlierTime(2);
+			TimeOnly subject = LaterTime(4);
 			TimeOnly unexpected = CurrentTime();
 
 			async Task Act()
@@ -282,6 +274,19 @@ public sealed partial class TimeOnlyShould
 				              not be after {Formatter.Format(unexpected)} ± 0:03,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = LaterTime(3);
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeBeforeTests.cs
@@ -240,36 +240,28 @@ public sealed partial class TimeOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			TimeOnly subject = CurrentTime();
-			TimeOnly? unexpected = EarlierTime(4);
+			TimeOnly? unexpected = LaterTime(4);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeBefore(unexpected)
 					.Within(TimeSpan.FromSeconds(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			TimeOnly subject = LaterTime(3);
-			TimeOnly unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeBefore(unexpected)
-					.Within(TimeSpan.FromSeconds(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
-		{
-			TimeOnly subject = EarlierTime(2);
+			TimeOnly subject = EarlierTime(4);
 			TimeOnly unexpected = CurrentTime();
 
 			async Task Act()
@@ -282,6 +274,19 @@ public sealed partial class TimeOnlyShould
 				              not be before {Formatter.Format(unexpected)} ± 0:03,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = EarlierTime(3);
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeOnOrAfterTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeOnOrAfterTests.cs
@@ -239,36 +239,28 @@ public sealed partial class TimeOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			TimeOnly subject = CurrentTime();
-			TimeOnly? unexpected = LaterTime(4);
+			TimeOnly? unexpected = EarlierTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
 					.Within(TimeSpan.FromSeconds(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or after {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
-			TimeOnly subject = EarlierTime(4);
-			TimeOnly unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
-					.Within(TimeSpan.FromSeconds(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
-		{
-			TimeOnly subject = EarlierTime(3);
+			TimeOnly subject = LaterTime(3);
 			TimeOnly unexpected = CurrentTime();
 
 			async Task Act()
@@ -281,6 +273,19 @@ public sealed partial class TimeOnlyShould
 				              not be on or after {Formatter.Format(unexpected)} ± 0:03,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = LaterTime(2);
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrAfter(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeOnOrBeforeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeOnOrBeforeTests.cs
@@ -239,34 +239,26 @@ public sealed partial class TimeOnlyShould
 		}
 
 		[Fact]
-		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldSucceed()
+		public async Task Within_WhenNullableUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 		{
 			TimeOnly subject = CurrentTime();
-			TimeOnly? unexpected = EarlierTime(4);
+			TimeOnly? unexpected = LaterTime(3);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
 					.Within(TimeSpan.FromSeconds(3))
 					.Because("we want to test the failure");
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be on or before {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+				              but found {Formatter.Format(subject)}
+				              """);
 		}
 
 		[Fact]
-		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
-		{
-			TimeOnly subject = LaterTime(4);
-			TimeOnly unexpected = CurrentTime();
-
-			async Task Act()
-				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
-					.Within(TimeSpan.FromSeconds(3));
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 		{
 			TimeOnly subject = EarlierTime(3);
 			TimeOnly unexpected = CurrentTime();
@@ -281,6 +273,19 @@ public sealed partial class TimeOnlyShould
 				              not be on or before {Formatter.Format(unexpected)} ± 0:03,
 				              but found {Formatter.Format(subject)}
 				              """);
+		}
+
+		[Fact]
+		public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
+		{
+			TimeOnly subject = EarlierTime(2);
+			TimeOnly unexpected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeOnOrBefore(unexpected)
+					.Within(TimeSpan.FromSeconds(3));
+
+			await That(Act).Should().NotThrow();
 		}
 	}
 }


### PR DESCRIPTION
The tolerance for `NotBeAfter`/`NotBeBefore`/`NotBeOnOrAfter`/`NotBeOnOrBefore` is not applied correctly for `DateOnly` and `TimeOnly`.