### PR TITLE
feat: add `BePositive`/`BeNegative` for `TimeSpan`

### DIFF
--- a/Source/Testably.Expectations/That/TimeSpans/ThatNullableTimeSpanShould.BeNegative.cs
+++ b/Source/Testably.Expectations/That/TimeSpans/ThatNullableTimeSpanShould.BeNegative.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableTimeSpanShould
+{
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<TimeSpan?, IThat<TimeSpan?>> BeNegative(this IThat<TimeSpan?> source)
+		=> new(
+			source.ExpectationBuilder
+				.AddConstraint(new SimpleConstraint(
+					"be negative",
+					a => a < TimeSpan.Zero,
+					a => $"found {Formatter.Format(a)}")),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not negative.
+	/// </summary>
+	public static AndOrResult<TimeSpan?, IThat<TimeSpan?>> NotBeNegative(
+		this IThat<TimeSpan?> source)
+		=> new(
+			source.ExpectationBuilder
+				.AddConstraint(new SimpleConstraint(
+					"not be negative",
+					a => a >= TimeSpan.Zero,
+					a => $"found {Formatter.Format(a)}")),
+			source);
+}

--- a/Source/Testably.Expectations/That/TimeSpans/ThatNullableTimeSpanShould.BePositive.cs
+++ b/Source/Testably.Expectations/That/TimeSpans/ThatNullableTimeSpanShould.BePositive.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatNullableTimeSpanShould
+{
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<TimeSpan?, IThat<TimeSpan?>> BePositive(this IThat<TimeSpan?> source)
+		=> new(
+			source.ExpectationBuilder
+				.AddConstraint(new SimpleConstraint(
+					"be positive",
+					a => a > TimeSpan.Zero,
+					a => $"found {Formatter.Format(a)}")),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not positive.
+	/// </summary>
+	public static AndOrResult<TimeSpan?, IThat<TimeSpan?>> NotBePositive(
+		this IThat<TimeSpan?> source)
+		=> new(
+			source.ExpectationBuilder
+				.AddConstraint(new SimpleConstraint(
+					"not be positive",
+					a => a <= TimeSpan.Zero,
+					a => $"found {Formatter.Format(a)}")),
+			source);
+}

--- a/Source/Testably.Expectations/That/TimeSpans/ThatNullableTimeSpanShould.cs
+++ b/Source/Testably.Expectations/That/TimeSpans/ThatNullableTimeSpanShould.cs
@@ -48,4 +48,24 @@ public static partial class ThatNullableTimeSpanShould
 		public override string ToString()
 			=> expectation + tolerance;
 	}
+
+	private readonly struct SimpleConstraint(
+		string expectation,
+		Func<TimeSpan?, bool> condition,
+		Func<TimeSpan?, string> failureMessageFactory) : IValueConstraint<TimeSpan?>
+	{
+		public ConstraintResult IsMetBy(TimeSpan? actual)
+		{
+			if (condition(actual))
+			{
+				return new ConstraintResult.Success<TimeSpan?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(),
+				failureMessageFactory(actual));
+		}
+
+		public override string ToString()
+			=> expectation;
+	}
 }

--- a/Source/Testably.Expectations/That/TimeSpans/ThatTimeSpanShould.BeNegative.cs
+++ b/Source/Testably.Expectations/That/TimeSpans/ThatTimeSpanShould.BeNegative.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatTimeSpanShould
+{
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<TimeSpan, IThat<TimeSpan>> BeNegative(this IThat<TimeSpan> source)
+		=> new(
+			source.ExpectationBuilder
+				.AddConstraint(new SimpleConstraint(
+					"be negative",
+					a => a < TimeSpan.Zero,
+					a => $"found {Formatter.Format(a)}")),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not negative.
+	/// </summary>
+	public static AndOrResult<TimeSpan, IThat<TimeSpan>> NotBeNegative(this IThat<TimeSpan> source)
+		=> new(
+			source.ExpectationBuilder
+				.AddConstraint(new SimpleConstraint(
+					"not be negative",
+					a => a >= TimeSpan.Zero,
+					a => $"found {Formatter.Format(a)}")),
+			source);
+}

--- a/Source/Testably.Expectations/That/TimeSpans/ThatTimeSpanShould.BePositive.cs
+++ b/Source/Testably.Expectations/That/TimeSpans/ThatTimeSpanShould.BePositive.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Testably.Expectations.Core;
+using Testably.Expectations.Formatting;
+using Testably.Expectations.Results;
+
+namespace Testably.Expectations;
+
+public static partial class ThatTimeSpanShould
+{
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<TimeSpan, IThat<TimeSpan>> BePositive(this IThat<TimeSpan> source)
+		=> new(
+			source.ExpectationBuilder
+				.AddConstraint(new SimpleConstraint(
+					"be positive",
+					a => a > TimeSpan.Zero,
+					a => $"found {Formatter.Format(a)}")),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not positive.
+	/// </summary>
+	public static AndOrResult<TimeSpan, IThat<TimeSpan>> NotBePositive(this IThat<TimeSpan> source)
+		=> new(
+			source.ExpectationBuilder
+				.AddConstraint(new SimpleConstraint(
+					"not be positive",
+					a => a <= TimeSpan.Zero,
+					a => $"found {Formatter.Format(a)}")),
+			source);
+}

--- a/Source/Testably.Expectations/That/TimeSpans/ThatTimeSpanShould.cs
+++ b/Source/Testably.Expectations/That/TimeSpans/ThatTimeSpanShould.cs
@@ -54,4 +54,24 @@ public static partial class ThatTimeSpanShould
 		public override string ToString()
 			=> expectation + tolerance;
 	}
+
+	private readonly struct SimpleConstraint(
+		string expectation,
+		Func<TimeSpan, bool> condition,
+		Func<TimeSpan, string> failureMessageFactory) : IValueConstraint<TimeSpan>
+	{
+		public ConstraintResult IsMetBy(TimeSpan actual)
+		{
+			if (condition(actual))
+			{
+				return new ConstraintResult.Success<TimeSpan>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(),
+				failureMessageFactory(actual));
+		}
+
+		public override string ToString()
+			=> expectation;
+	}
 }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -486,11 +486,15 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BeGreaterThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BeLessThan(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BeLessThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BeNegative(this Testably.Expectations.Core.IThat<System.TimeSpan?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BePositive(this Testably.Expectations.Core.IThat<System.TimeSpan?> source) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBe(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeGreaterThan(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeGreaterThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeLessThan(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeLessThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeNegative(this Testably.Expectations.Core.IThat<System.TimeSpan?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBePositive(this Testably.Expectations.Core.IThat<System.TimeSpan?> source) { }
         public static Testably.Expectations.Core.IThat<System.TimeSpan?> Should(this Testably.Expectations.Core.IExpectSubject<System.TimeSpan?> subject) { }
     }
     public static class ThatNumberShould
@@ -900,11 +904,15 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BeGreaterThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BeLessThan(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BeLessThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BeNegative(this Testably.Expectations.Core.IThat<System.TimeSpan> source) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BePositive(this Testably.Expectations.Core.IThat<System.TimeSpan> source) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBe(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeGreaterThan(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeGreaterThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeLessThan(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeLessThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeNegative(this Testably.Expectations.Core.IThat<System.TimeSpan> source) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBePositive(this Testably.Expectations.Core.IThat<System.TimeSpan> source) { }
         public static Testably.Expectations.Core.IThat<System.TimeSpan> Should(this Testably.Expectations.Core.IExpectSubject<System.TimeSpan> subject) { }
     }
 }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -486,11 +486,15 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BeGreaterThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BeLessThan(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BeLessThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BeNegative(this Testably.Expectations.Core.IThat<System.TimeSpan?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BePositive(this Testably.Expectations.Core.IThat<System.TimeSpan?> source) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBe(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeGreaterThan(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeGreaterThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeLessThan(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeLessThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeNegative(this Testably.Expectations.Core.IThat<System.TimeSpan?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBePositive(this Testably.Expectations.Core.IThat<System.TimeSpan?> source) { }
         public static Testably.Expectations.Core.IThat<System.TimeSpan?> Should(this Testably.Expectations.Core.IExpectSubject<System.TimeSpan?> subject) { }
     }
     public static class ThatNumberShould
@@ -900,11 +904,15 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BeGreaterThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BeLessThan(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BeLessThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BeNegative(this Testably.Expectations.Core.IThat<System.TimeSpan> source) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BePositive(this Testably.Expectations.Core.IThat<System.TimeSpan> source) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBe(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeGreaterThan(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeGreaterThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeLessThan(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeLessThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeNegative(this Testably.Expectations.Core.IThat<System.TimeSpan> source) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBePositive(this Testably.Expectations.Core.IThat<System.TimeSpan> source) { }
         public static Testably.Expectations.Core.IThat<System.TimeSpan> Should(this Testably.Expectations.Core.IExpectSubject<System.TimeSpan> subject) { }
     }
 }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -385,11 +385,15 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BeGreaterThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BeLessThan(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BeLessThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BeNegative(this Testably.Expectations.Core.IThat<System.TimeSpan?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> BePositive(this Testably.Expectations.Core.IThat<System.TimeSpan?> source) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBe(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeGreaterThan(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeGreaterThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeLessThan(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeLessThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBeNegative(this Testably.Expectations.Core.IThat<System.TimeSpan?> source) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan?, Testably.Expectations.Core.IThat<System.TimeSpan?>> NotBePositive(this Testably.Expectations.Core.IThat<System.TimeSpan?> source) { }
         public static Testably.Expectations.Core.IThat<System.TimeSpan?> Should(this Testably.Expectations.Core.IExpectSubject<System.TimeSpan?> subject) { }
     }
     public static class ThatNumberShould
@@ -768,11 +772,15 @@ namespace Testably.Expectations
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BeGreaterThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BeLessThan(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BeLessThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BeNegative(this Testably.Expectations.Core.IThat<System.TimeSpan> source) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> BePositive(this Testably.Expectations.Core.IThat<System.TimeSpan> source) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBe(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeGreaterThan(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeGreaterThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeLessThan(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static Testably.Expectations.Results.TimeToleranceResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeLessThanOrEqualTo(this Testably.Expectations.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBeNegative(this Testably.Expectations.Core.IThat<System.TimeSpan> source) { }
+        public static Testably.Expectations.Results.AndOrResult<System.TimeSpan, Testably.Expectations.Core.IThat<System.TimeSpan>> NotBePositive(this Testably.Expectations.Core.IThat<System.TimeSpan> source) { }
         public static Testably.Expectations.Core.IThat<System.TimeSpan> Should(this Testably.Expectations.Core.IExpectSubject<System.TimeSpan> subject) { }
     }
 }

--- a/Tests/Testably.Expectations.Tests/ThatTests/TimeSpans/NullableTimeSpanShould.BeNegativeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/TimeSpans/NullableTimeSpanShould.BeNegativeTests.cs
@@ -1,0 +1,145 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.TimeSpans;
+
+public sealed partial class NullableTimeSpanShould
+{
+	public sealed class BeNegativeTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsMaxValue_ShouldFail()
+		{
+			TimeSpan? subject = TimeSpan.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found 10675199.02:48:05.477
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsMinValue_ShouldSucceed()
+		{
+			TimeSpan? subject = TimeSpan.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNegative_ShouldSucceed()
+		{
+			TimeSpan? subject = TimeSpan.FromSeconds(-1);
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsPositive_ShouldFail()
+		{
+			TimeSpan? subject = TimeSpan.FromSeconds(1);
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsZero_ShouldFail()
+		{
+			TimeSpan? subject = TimeSpan.Zero;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+
+	public sealed class NotBeNegativeTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsMaxValue_ShouldSucceed()
+		{
+			TimeSpan? subject = TimeSpan.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsMinValue_ShouldFail()
+		{
+			TimeSpan? subject = TimeSpan.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be negative,
+				             but found -10675199.02:48:05
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNegative_ShouldFail()
+		{
+			TimeSpan? subject = TimeSpan.FromSeconds(-1);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be negative,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsPositive_ShouldSucceed()
+		{
+			TimeSpan? subject = TimeSpan.FromSeconds(1);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsZero_ShouldSucceed()
+		{
+			TimeSpan? subject = TimeSpan.Zero;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/TimeSpans/NullableTimeSpanShould.BePositiveTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/TimeSpans/NullableTimeSpanShould.BePositiveTests.cs
@@ -1,0 +1,145 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.TimeSpans;
+
+public sealed partial class NullableTimeSpanShould
+{
+	public sealed class BePositiveTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsMaxValue_ShouldSucceed()
+		{
+			TimeSpan? subject = TimeSpan.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsMinValue_ShouldFail()
+		{
+			TimeSpan? subject = TimeSpan.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found -10675199.02:48:05
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNegative_ShouldFail()
+		{
+			TimeSpan? subject = TimeSpan.FromSeconds(-1);
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsPositive_ShouldSucceed()
+		{
+			TimeSpan? subject = TimeSpan.FromSeconds(1);
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsZero_ShouldFail()
+		{
+			TimeSpan? subject = TimeSpan.Zero;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+
+	public sealed class NotBePositiveTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsMaxValue_ShouldFail()
+		{
+			TimeSpan? subject = TimeSpan.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be positive,
+				             but found 10675199.02:48:05.477
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsMinValue_ShouldSucceed()
+		{
+			TimeSpan? subject = TimeSpan.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNegative_ShouldSucceed()
+		{
+			TimeSpan? subject = TimeSpan.FromSeconds(-1);
+
+			async Task Act()
+				=> await That(subject).Should().NotBePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsPositive_ShouldFail()
+		{
+			TimeSpan? subject = TimeSpan.FromSeconds(1);
+
+			async Task Act()
+				=> await That(subject).Should().NotBePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be positive,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsZero_ShouldSucceed()
+		{
+			TimeSpan? subject = TimeSpan.Zero;
+
+			async Task Act()
+				=> await That(subject).Should().NotBePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/TimeSpans/TimeSpanShould.BeNegativeTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/TimeSpans/TimeSpanShould.BeNegativeTests.cs
@@ -1,0 +1,145 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.TimeSpans;
+
+public sealed partial class TimeSpanShould
+{
+	public sealed class BeNegativeTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsMaxValue_ShouldFail()
+		{
+			TimeSpan subject = TimeSpan.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be negative,
+				             but found 10675199.02:48:05.477
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsMinValue_ShouldSucceed()
+		{
+			TimeSpan subject = TimeSpan.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNegative_ShouldSucceed()
+		{
+			TimeSpan subject = TimeSpan.FromSeconds(-1);
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsPositive_ShouldFail()
+		{
+			TimeSpan subject = TimeSpan.FromSeconds(1);
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsZero_ShouldFail()
+		{
+			TimeSpan subject = TimeSpan.Zero;
+
+			async Task Act()
+				=> await That(subject).Should().BeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be negative,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+
+	public sealed class NotBeNegativeTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsMaxValue_ShouldSucceed()
+		{
+			TimeSpan subject = TimeSpan.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsMinValue_ShouldFail()
+		{
+			TimeSpan subject = TimeSpan.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be negative,
+				             but found -10675199.02:48:05
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNegative_ShouldFail()
+		{
+			TimeSpan subject = TimeSpan.FromSeconds(-1);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNegative();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be negative,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsPositive_ShouldSucceed()
+		{
+			TimeSpan subject = TimeSpan.FromSeconds(1);
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsZero_ShouldSucceed()
+		{
+			TimeSpan subject = TimeSpan.Zero;
+
+			async Task Act()
+				=> await That(subject).Should().NotBeNegative();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/Testably.Expectations.Tests/ThatTests/TimeSpans/TimeSpanShould.BePositiveTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/TimeSpans/TimeSpanShould.BePositiveTests.cs
@@ -1,0 +1,145 @@
+﻿namespace Testably.Expectations.Tests.ThatTests.TimeSpans;
+
+public sealed partial class TimeSpanShould
+{
+	public sealed class BePositiveTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsMaxValue_ShouldSucceed()
+		{
+			TimeSpan subject = TimeSpan.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsMinValue_ShouldFail()
+		{
+			TimeSpan subject = TimeSpan.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             be positive,
+				             but found -10675199.02:48:05
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNegative_ShouldFail()
+		{
+			TimeSpan subject = TimeSpan.FromSeconds(-1);
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsPositive_ShouldSucceed()
+		{
+			TimeSpan subject = TimeSpan.FromSeconds(1);
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsZero_ShouldFail()
+		{
+			TimeSpan subject = TimeSpan.Zero;
+
+			async Task Act()
+				=> await That(subject).Should().BePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be positive,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+	}
+
+	public sealed class NotBePositiveTests
+	{
+		[Fact]
+		public async Task WhenSubjectIsMaxValue_ShouldFail()
+		{
+			TimeSpan subject = TimeSpan.MaxValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be positive,
+				             but found 10675199.02:48:05.477
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsMinValue_ShouldSucceed()
+		{
+			TimeSpan subject = TimeSpan.MinValue;
+
+			async Task Act()
+				=> await That(subject).Should().NotBePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsNegative_ShouldSucceed()
+		{
+			TimeSpan subject = TimeSpan.FromSeconds(-1);
+
+			async Task Act()
+				=> await That(subject).Should().NotBePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsPositive_ShouldFail()
+		{
+			TimeSpan subject = TimeSpan.FromSeconds(1);
+
+			async Task Act()
+				=> await That(subject).Should().NotBePositive();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              not be positive,
+				              but found {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectIsZero_ShouldSucceed()
+		{
+			TimeSpan subject = TimeSpan.Zero;
+
+			async Task Act()
+				=> await That(subject).Should().NotBePositive();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}


### PR DESCRIPTION
Fixes #128 
Add the following expectations for `TimeSpan`:
- `BePositive` / `NotBePositive`
- `BeNegative` / `NotBeNegative`