### PR TITLE
feat: enable duplicate `Which` expectations

### DIFF
--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -1156,7 +1156,12 @@ namespace Testably.Expectations.Results
         where TSelf : Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>
     {
         public AndOrWhichResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
-        public Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.WhichResult<TProperty, Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>> Which<TProperty>(System.Linq.Expressions.Expression<System.Func<TType, TProperty?>> selector) { }
+        public Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.WhichResult<TProperty, Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult> Which<TProperty>(System.Linq.Expressions.Expression<System.Func<TType, TProperty?>> selector) { }
+        public class AdditionalAndOrWhichResult : Testably.Expectations.Results.AndOrResult<TType, TThat, TSelf>
+        {
+            public AdditionalAndOrWhichResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
+            public Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.WhichResult<TProperty, Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult> AndWhich<TProperty>(System.Linq.Expressions.Expression<System.Func<TType, TProperty?>> selector) { }
+        }
         public class WhichResult<TProperty, TReturn>
         {
             public WhichResult(System.Func<System.Action<Testably.Expectations.Core.IThat<TProperty?>>, TReturn> resultCallback) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -1156,7 +1156,12 @@ namespace Testably.Expectations.Results
         where TSelf : Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>
     {
         public AndOrWhichResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
-        public Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.WhichResult<TProperty, Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>> Which<TProperty>(System.Linq.Expressions.Expression<System.Func<TType, TProperty?>> selector) { }
+        public Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.WhichResult<TProperty, Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult> Which<TProperty>(System.Linq.Expressions.Expression<System.Func<TType, TProperty?>> selector) { }
+        public class AdditionalAndOrWhichResult : Testably.Expectations.Results.AndOrResult<TType, TThat, TSelf>
+        {
+            public AdditionalAndOrWhichResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
+            public Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.WhichResult<TProperty, Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult> AndWhich<TProperty>(System.Linq.Expressions.Expression<System.Func<TType, TProperty?>> selector) { }
+        }
         public class WhichResult<TProperty, TReturn>
         {
             public WhichResult(System.Func<System.Action<Testably.Expectations.Core.IThat<TProperty?>>, TReturn> resultCallback) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -1024,7 +1024,12 @@ namespace Testably.Expectations.Results
         where TSelf : Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>
     {
         public AndOrWhichResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
-        public Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.WhichResult<TProperty, Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>> Which<TProperty>(System.Linq.Expressions.Expression<System.Func<TType, TProperty?>> selector) { }
+        public Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.WhichResult<TProperty, Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult> Which<TProperty>(System.Linq.Expressions.Expression<System.Func<TType, TProperty?>> selector) { }
+        public class AdditionalAndOrWhichResult : Testably.Expectations.Results.AndOrResult<TType, TThat, TSelf>
+        {
+            public AdditionalAndOrWhichResult(Testably.Expectations.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
+            public Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.WhichResult<TProperty, Testably.Expectations.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult> AndWhich<TProperty>(System.Linq.Expressions.Expression<System.Func<TType, TProperty?>> selector) { }
+        }
         public class WhichResult<TProperty, TReturn>
         {
             public WhichResult(System.Func<System.Action<Testably.Expectations.Core.IThat<TProperty?>>, TReturn> resultCallback) { }

--- a/Tests/Testably.Expectations.Internal.Tests/Core/Nodes/MappingNodeTests.cs
+++ b/Tests/Testably.Expectations.Internal.Tests/Core/Nodes/MappingNodeTests.cs
@@ -19,7 +19,7 @@ public class MappingNodeTests
 
 		await That(combined).Should().Be<ConstraintResult.Failure>()
 			.Which(f => f.ExpectationText).Should(f => f.Be("expect1 prop expect2"))
-			.Which(f => f.ResultText).Should(f => f.Be("foo"));
+			.AndWhich(f => f.ResultText).Should(f => f.Be("foo"));
 	}
 
 	[Fact]
@@ -34,7 +34,7 @@ public class MappingNodeTests
 
 		await That(combined).Should().Be<ConstraintResult.Failure>()
 			.Which(f => f.ExpectationText).Should(f => f.Be("expect1 prop expect2"))
-			.Which(f => f.ResultText).Should(f => f.Be("foo"));
+			.AndWhich(f => f.ResultText).Should(f => f.Be("foo"));
 	}
 
 	[Fact]
@@ -63,7 +63,7 @@ public class MappingNodeTests
 
 		await That(combined).Should().Be<ConstraintResult.Failure>()
 			.Which(f => f.ExpectationText).Should(f => f.Be("expect1 prop expect2"))
-			.Which(f => f.ResultText).Should(f => f.Be("foo"));
+			.AndWhich(f => f.ResultText).Should(f => f.Be("foo"));
 	}
 
 	[Fact]

--- a/Tests/Testably.Expectations.Tests/Core/ConstraintResultTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/ConstraintResultTests.cs
@@ -109,7 +109,7 @@ public sealed class ConstraintResultTests
 
 		await That(result).Should().Be<ConstraintResult.Failure>()
 			.Which(s => s.ExpectationText).Should(e => e.Be(expectationText))
-			.Which(s => s.ResultText).Should(e => e.Be("it did"));
+			.AndWhich(s => s.ResultText).Should(e => e.Be("it did"));
 	}
 
 	[Theory]
@@ -123,7 +123,7 @@ public sealed class ConstraintResultTests
 
 		await That(result).Should().Be<ConstraintResult.Failure>()
 			.Which(p => p.ExpectationText).Should(e => e.Be(expectationText))
-			.Which(p => p.ResultText).Should(e => e.Be(resultText));
+			.AndWhich(p => p.ResultText).Should(e => e.Be(resultText));
 	}
 
 	[Theory]
@@ -151,7 +151,7 @@ public sealed class ConstraintResultTests
 
 		await That(result).Should().Be<ConstraintResult.Failure<Dummy>>()
 			.Which(p => p.ExpectationText).Should(e => e.Be(expectationText))
-			.Which(p => p.ResultText).Should(e => e.Be("it did"));
+			.AndWhich(p => p.ResultText).Should(e => e.Be("it did"));
 	}
 
 	[Theory]
@@ -166,7 +166,7 @@ public sealed class ConstraintResultTests
 
 		await That(result).Should().Be<ConstraintResult.Failure<Dummy>>()
 			.Which(p => p.ExpectationText).Should(e => e.Be(expectationText))
-			.Which(p => p.ResultText).Should(e => e.Be(resultText));
+			.AndWhich(p => p.ResultText).Should(e => e.Be(resultText));
 	}
 
 	[Theory]

--- a/Tests/Testably.Expectations.Tests/Results/AndOrWhichResultTests.cs
+++ b/Tests/Testably.Expectations.Tests/Results/AndOrWhichResultTests.cs
@@ -1,0 +1,62 @@
+﻿namespace Testably.Expectations.Tests.Results;
+
+public class AndOrWhichResultTests
+{
+	[Fact]
+	public async Task MultipleWhich_ShouldAllowChaining()
+	{
+		MyClass sut = new();
+
+		async Task Act()
+		{
+			await That(sut).Should().Be<MyClass>()
+				.Which(f => f.Value1).Should(f => f.BeTrue())
+				.AndWhich(f => f.Value2).Should(f => f.BeTrue())
+				.And.BeSameAs(sut);
+		}
+
+		await That(Act).Should().ThrowException()
+			.WithMessage($$"""
+			               Expected sut to
+			               be type MyClass which .Value1 should be True and which .Value2 should be True and refer to sut MyClass {
+			                 Value1 = False,
+			                 Value2 = False
+			               },
+			               but found False
+			               """);
+	}
+
+	[Theory]
+	[InlineData(true, true, true)]
+	[InlineData(true, false, false)]
+	[InlineData(false, true, false)]
+	[InlineData(false, false, false)]
+	public async Task MultipleWhich_ShouldVerifyAll(bool value1, bool value2, bool expectSuccess)
+	{
+		MyClass sut = new()
+		{
+			Value1 = value1,
+			Value2 = value2
+		};
+
+		async Task Act()
+		{
+			await That(sut).Should().Be<MyClass>()
+				.Which(f => f.Value1).Should(f => f.BeTrue())
+				.AndWhich(f => f.Value2).Should(f => f.BeTrue());
+		}
+
+		await That(Act).Should().ThrowException().OnlyIf(!expectSuccess)
+			.WithMessage("""
+			             Expected sut to
+			             be type MyClass which .Value1 should be True and which .Value2 should be True,
+			             but found False
+			             """);
+	}
+
+	private sealed class MyClass
+	{
+		public bool Value1 { get; set; }
+		public bool Value2 { get; set; }
+	}
+}


### PR DESCRIPTION
Support for multiple `Which` statements that are combined via AND.