### PR TITLE
refactor: remove superfluous result texts in `NotThrow`

### DIFF
--- a/Source/Testably.Expectations/Core/Constraints/ConstraintResult.cs
+++ b/Source/Testably.Expectations/Core/Constraints/ConstraintResult.cs
@@ -18,17 +18,17 @@ public abstract class ConstraintResult
 	/// <summary>
 	///     Specifies if further processing of chained constraints should be ignored.
 	/// </summary>
-	public bool IgnoreFurtherProcessing { get; }
+	public FurtherProcessing FurtherProcessingStrategy { get; }
 
 	/// <summary>
 	///     Initializes a new instance of <see cref="ConstraintResult" />.
 	/// </summary>
 	protected ConstraintResult(
 		string expectationText,
-		bool ignoreFurtherProcessing)
+		FurtherProcessing furtherProcessingStrategy)
 	{
 		ExpectationText = expectationText;
-		IgnoreFurtherProcessing = ignoreFurtherProcessing;
+		FurtherProcessingStrategy = furtherProcessingStrategy;
 	}
 
 	/// <summary>
@@ -52,6 +52,30 @@ public abstract class ConstraintResult
 	internal abstract ConstraintResult UseValue<T>(T value);
 
 	/// <summary>
+	///     The strategy how to continue processing after the current result.
+	/// </summary>
+	public enum FurtherProcessing
+	{
+		/// <summary>
+		///     Continue processing.
+		/// </summary>
+		/// <remarks>
+		///     This is the default behaviour.
+		/// </remarks>
+		Continue,
+
+		/// <summary>
+		///     Completely ignore all future constraints.
+		/// </summary>
+		IgnoreCompletely,
+
+		/// <summary>
+		///     Ignore the result of future constraints, but include their expectations.
+		/// </summary>
+		IgnoreResult,
+	}
+
+	/// <summary>
 	///     The actual value met the expectation.
 	/// </summary>
 	public class Success : ConstraintResult
@@ -61,10 +85,10 @@ public abstract class ConstraintResult
 		/// </summary>
 		public Success(
 			string expectationText,
-			bool ignoreFurtherProcessing = false)
+			FurtherProcessing furtherProcessingStrategy = FurtherProcessing.Continue)
 			: base(
 				expectationText,
-				ignoreFurtherProcessing)
+				furtherProcessingStrategy)
 		{
 		}
 
@@ -102,7 +126,7 @@ public abstract class ConstraintResult
 		/// <inheritdoc />
 		internal override ConstraintResult UseValue<T>(T value)
 		{
-			return new Success<T>(value, ExpectationText, IgnoreFurtherProcessing);
+			return new Success<T>(value, ExpectationText, FurtherProcessingStrategy);
 		}
 	}
 
@@ -122,10 +146,10 @@ public abstract class ConstraintResult
 		public Success(
 			T value,
 			string expectationText,
-			bool ignoreFurtherProcessing = false)
+			FurtherProcessing furtherProcessingStrategy = FurtherProcessing.Continue)
 			: base(
 				expectationText,
-				ignoreFurtherProcessing)
+				furtherProcessingStrategy)
 		{
 			Value = value;
 		}
@@ -181,10 +205,10 @@ public abstract class ConstraintResult
 		public Failure(
 			string expectationText,
 			string resultText,
-			bool ignoreFurtherProcessing = false)
+			FurtherProcessing furtherProcessingStrategy = FurtherProcessing.Continue)
 			: base(
 				expectationText,
-				ignoreFurtherProcessing)
+				furtherProcessingStrategy)
 		{
 			ResultText = resultText;
 		}
@@ -216,7 +240,7 @@ public abstract class ConstraintResult
 		/// <inheritdoc />
 		internal override ConstraintResult UseValue<T>(T value)
 		{
-			return new Failure<T>(value, ExpectationText, ResultText, IgnoreFurtherProcessing);
+			return new Failure<T>(value, ExpectationText, ResultText, FurtherProcessingStrategy);
 		}
 	}
 
@@ -237,11 +261,11 @@ public abstract class ConstraintResult
 			T value,
 			string expectationText,
 			string resultText,
-			bool ignoreFurtherProcessing = false)
+			FurtherProcessing furtherProcessingStrategy = FurtherProcessing.Continue)
 			: base(
 				expectationText,
 				resultText,
-				ignoreFurtherProcessing)
+				furtherProcessingStrategy)
 		{
 			Value = value;
 		}

--- a/Source/Testably.Expectations/Core/Nodes/OrNode.cs
+++ b/Source/Testably.Expectations/Core/Nodes/OrNode.cs
@@ -11,8 +11,10 @@ namespace Testably.Expectations.Core.Nodes;
 
 internal class OrNode : Node
 {
+	private const string DefaultSeparator = " or ";
 	internal Node Current { get; set; }
-	private readonly List<Node> _nodes = new();
+	private string? _currentSeparator;
+	private readonly List<(string, Node)> _nodes = new();
 
 	public OrNode(Node node)
 	{
@@ -32,8 +34,9 @@ internal class OrNode : Node
 
 	public override void AddNode(Node node, string? separator = null)
 	{
-		_nodes.Add(Current);
+		_nodes.Add((_currentSeparator ?? DefaultSeparator, Current));
 		Current = node;
+		_currentSeparator = separator;
 	}
 
 	/// <inheritdoc />
@@ -41,13 +44,14 @@ internal class OrNode : Node
 		IEvaluationContext context,
 		CancellationToken cancellationToken) where TValue : default
 	{
-		_nodes.Add(Current);
+		_nodes.Add((_currentSeparator ?? DefaultSeparator, Current));
 		ConstraintResult? combinedResult = null;
-		foreach (Node node in _nodes)
+		foreach ((string separator, Node node) in _nodes)
 		{
 			ConstraintResult result = await node.IsMetBy(value, context, cancellationToken);
-			combinedResult = CombineResults(combinedResult, result);
-			if (result.IgnoreFurtherProcessing)
+			combinedResult = CombineResults(combinedResult, result, separator,
+				combinedResult?.FurtherProcessingStrategy);
+			if (result.FurtherProcessingStrategy == ConstraintResult.FurtherProcessing.IgnoreCompletely)
 			{
 				return combinedResult;
 			}
@@ -65,30 +69,36 @@ internal class OrNode : Node
 	{
 		if (_nodes.Any())
 		{
-			return string.Join(" or ", _nodes) + " or " + Current;
+			return string.Join(DefaultSeparator, _nodes.Select(x => x.Item2))
+			       + DefaultSeparator + Current;
 		}
 
 		return Current.ToString();
 	}
 
-	private ConstraintResult CombineResults(ConstraintResult? combinedResult,
-		ConstraintResult result)
+	private ConstraintResult CombineResults(
+		ConstraintResult? combinedResult,
+		ConstraintResult result,
+		string separator,
+		ConstraintResult.FurtherProcessing? furtherProcessingStrategy)
 	{
-		const string _textSeparator = " or ";
 		if (combinedResult == null)
 		{
 			return result;
 		}
 
 		string combinedExpectation =
-			$"{combinedResult.ExpectationText}{_textSeparator}{result.ExpectationText}";
+			$"{combinedResult.ExpectationText}{separator}{result.ExpectationText}";
 
 		if (combinedResult is ConstraintResult.Failure leftFailure &&
 		    result is ConstraintResult.Failure rightFailure)
 		{
 			return leftFailure.CombineWith(
 				combinedExpectation,
-				CombineResultTexts(leftFailure.ResultText, rightFailure.ResultText));
+				CombineResultTexts(
+					leftFailure.ResultText,
+					rightFailure.ResultText,
+					furtherProcessingStrategy ?? ConstraintResult.FurtherProcessing.Continue));
 		}
 
 		if (combinedResult is ConstraintResult.Failure)
@@ -99,9 +109,13 @@ internal class OrNode : Node
 		return combinedResult.CombineWith(combinedExpectation, "");
 	}
 
-	private static string CombineResultTexts(string leftResultText, string rightResultText)
+	private static string CombineResultTexts(
+		string leftResultText,
+		string rightResultText,
+		ConstraintResult.FurtherProcessing furtherProcessingStrategy)
 	{
-		if (leftResultText == rightResultText)
+		if (furtherProcessingStrategy == ConstraintResult.FurtherProcessing.IgnoreResult ||
+		    leftResultText == rightResultText)
 		{
 			return leftResultText;
 		}

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.Throw.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.Throw.cs
@@ -14,7 +14,7 @@ public static partial class ThatDelegateShould
 		ThrowsOption throwOptions = new();
 		return new ThatDelegateThrows<TException>(source.ExpectationBuilder
 				.ForWhich<DelegateValue, Exception?>(d => d.Exception)
-				.AddConstraint(new ThrowsCastConstraint<TException>(throwOptions))
+				.AddConstraint(new ThrowExceptionOfTypeConstraint<TException>(throwOptions))
 				.And(" "),
 			throwOptions);
 	}

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.ThrowException.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.ThrowException.cs
@@ -14,7 +14,7 @@ public static partial class ThatDelegateShould
 		ThrowsOption throwOptions = new();
 		return new ThatDelegateThrows<Exception>(source.ExpectationBuilder
 				.ForWhich<DelegateValue, Exception?>(d => d.Exception)
-				.AddConstraint(new ThrowsCastConstraint<Exception>(throwOptions))
+				.AddConstraint(new ThrowExceptionOfTypeConstraint<Exception>(throwOptions))
 				.And(" "),
 			throwOptions);
 	}

--- a/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.cs
+++ b/Source/Testably.Expectations/That/Delegates/ThatDelegateShould.cs
@@ -2,7 +2,6 @@
 using Testably.Expectations.Core;
 using Testably.Expectations.Core.Constraints;
 using Testably.Expectations.Core.Helpers;
-using Testably.Expectations.Core.Sources;
 
 namespace Testably.Expectations;
 
@@ -33,10 +32,12 @@ public static partial class ThatDelegateShould
 		if (exception is not null)
 		{
 			return new ConstraintResult.Failure<Exception?>(exception, DoesNotThrowExpectation,
-				$"it did throw {exception.FormatForMessage()}", true);
+				$"it did throw {exception.FormatForMessage()}",
+				ConstraintResult.FurtherProcessing.IgnoreCompletely);
 		}
 
-		return new ConstraintResult.Success<TException?>(default, DoesNotThrowExpectation, true);
+		return new ConstraintResult.Success<TException?>(default, DoesNotThrowExpectation,
+			ConstraintResult.FurtherProcessing.IgnoreCompletely);
 	}
 
 	private readonly struct ThrowsCastConstraint(Type exceptionType, ThrowsOption throwOptions)
@@ -75,7 +76,7 @@ public static partial class ThatDelegateShould
 		}
 	}
 
-	private readonly struct ThrowsCastConstraint<TException>(ThrowsOption throwOptions)
+	private readonly struct ThrowExceptionOfTypeConstraint<TException>(ThrowsOption throwOptions)
 		: IValueConstraint<Exception?>
 		where TException : Exception
 	{
@@ -94,7 +95,9 @@ public static partial class ThatDelegateShould
 
 			if (value is null)
 			{
-				return new ConstraintResult.Failure<TException?>(null, ToString(), "it did not");
+				return new ConstraintResult.Failure<TException?>(null, ToString(),
+					"it did not throw any exception",
+					ConstraintResult.FurtherProcessing.IgnoreResult);
 			}
 
 			return new ConstraintResult.Failure<TException?>(null, ToString(),

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net6.0.txt
@@ -920,14 +920,14 @@ namespace Testably.Expectations.Core.Constraints
 {
     public abstract class ConstraintResult
     {
-        protected ConstraintResult(string expectationText, bool ignoreFurtherProcessing) { }
+        protected ConstraintResult(string expectationText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
         public string ExpectationText { get; }
-        public bool IgnoreFurtherProcessing { get; }
+        public Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing FurtherProcessingStrategy { get; }
         public abstract Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText);
         public abstract Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null);
         public class Failure : Testably.Expectations.Core.Constraints.ConstraintResult
         {
-            public Failure(string expectationText, string resultText, bool ignoreFurtherProcessing = false) { }
+            public Failure(string expectationText, string resultText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public string ResultText { get; }
             public override Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null) { }
@@ -935,21 +935,27 @@ namespace Testably.Expectations.Core.Constraints
         }
         public class Failure<T> : Testably.Expectations.Core.Constraints.ConstraintResult.Failure
         {
-            public Failure(T value, string expectationText, string resultText, bool ignoreFurtherProcessing = false) { }
+            public Failure(T value, string expectationText, string resultText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public T Value { get; }
             public override Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null) { }
         }
+        public enum FurtherProcessing
+        {
+            Continue = 0,
+            IgnoreCompletely = 1,
+            IgnoreResult = 2,
+        }
         public class Success : Testably.Expectations.Core.Constraints.ConstraintResult
         {
-            public Success(string expectationText, bool ignoreFurtherProcessing = false) { }
+            public Success(string expectationText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null) { }
             public override string ToString() { }
         }
         public class Success<T> : Testably.Expectations.Core.Constraints.ConstraintResult.Success
         {
-            public Success(T value, string expectationText, bool ignoreFurtherProcessing = false) { }
+            public Success(T value, string expectationText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public T Value { get; }
             public override Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_net8.0.txt
@@ -920,14 +920,14 @@ namespace Testably.Expectations.Core.Constraints
 {
     public abstract class ConstraintResult
     {
-        protected ConstraintResult(string expectationText, bool ignoreFurtherProcessing) { }
+        protected ConstraintResult(string expectationText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
         public string ExpectationText { get; }
-        public bool IgnoreFurtherProcessing { get; }
+        public Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing FurtherProcessingStrategy { get; }
         public abstract Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText);
         public abstract Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null);
         public class Failure : Testably.Expectations.Core.Constraints.ConstraintResult
         {
-            public Failure(string expectationText, string resultText, bool ignoreFurtherProcessing = false) { }
+            public Failure(string expectationText, string resultText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public string ResultText { get; }
             public override Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null) { }
@@ -935,21 +935,27 @@ namespace Testably.Expectations.Core.Constraints
         }
         public class Failure<T> : Testably.Expectations.Core.Constraints.ConstraintResult.Failure
         {
-            public Failure(T value, string expectationText, string resultText, bool ignoreFurtherProcessing = false) { }
+            public Failure(T value, string expectationText, string resultText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public T Value { get; }
             public override Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null) { }
         }
+        public enum FurtherProcessing
+        {
+            Continue = 0,
+            IgnoreCompletely = 1,
+            IgnoreResult = 2,
+        }
         public class Success : Testably.Expectations.Core.Constraints.ConstraintResult
         {
-            public Success(string expectationText, bool ignoreFurtherProcessing = false) { }
+            public Success(string expectationText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null) { }
             public override string ToString() { }
         }
         public class Success<T> : Testably.Expectations.Core.Constraints.ConstraintResult.Success
         {
-            public Success(T value, string expectationText, bool ignoreFurtherProcessing = false) { }
+            public Success(T value, string expectationText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public T Value { get; }
             public override Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null) { }

--- a/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
+++ b/Tests/Api/Testably.Expectations.Api.Tests/Expected/Testably.Expectations_netstandard2.0.txt
@@ -788,14 +788,14 @@ namespace Testably.Expectations.Core.Constraints
 {
     public abstract class ConstraintResult
     {
-        protected ConstraintResult(string expectationText, bool ignoreFurtherProcessing) { }
+        protected ConstraintResult(string expectationText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
         public string ExpectationText { get; }
-        public bool IgnoreFurtherProcessing { get; }
+        public Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing FurtherProcessingStrategy { get; }
         public abstract Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText);
         public abstract Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null);
         public class Failure : Testably.Expectations.Core.Constraints.ConstraintResult
         {
-            public Failure(string expectationText, string resultText, bool ignoreFurtherProcessing = false) { }
+            public Failure(string expectationText, string resultText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public string ResultText { get; }
             public override Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null) { }
@@ -803,21 +803,27 @@ namespace Testably.Expectations.Core.Constraints
         }
         public class Failure<T> : Testably.Expectations.Core.Constraints.ConstraintResult.Failure
         {
-            public Failure(T value, string expectationText, string resultText, bool ignoreFurtherProcessing = false) { }
+            public Failure(T value, string expectationText, string resultText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public T Value { get; }
             public override Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null) { }
         }
+        public enum FurtherProcessing
+        {
+            Continue = 0,
+            IgnoreCompletely = 1,
+            IgnoreResult = 2,
+        }
         public class Success : Testably.Expectations.Core.Constraints.ConstraintResult
         {
-            public Success(string expectationText, bool ignoreFurtherProcessing = false) { }
+            public Success(string expectationText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null) { }
             public override string ToString() { }
         }
         public class Success<T> : Testably.Expectations.Core.Constraints.ConstraintResult.Success
         {
-            public Success(T value, string expectationText, bool ignoreFurtherProcessing = false) { }
+            public Success(T value, string expectationText, Testably.Expectations.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public T Value { get; }
             public override Testably.Expectations.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override Testably.Expectations.Core.Constraints.ConstraintResult Invert(System.Func<Testably.Expectations.Core.Constraints.ConstraintResult, string>? expectationText = null, System.Func<object?, string>? resultText = null) { }

--- a/Tests/Testably.Expectations.Tests/Core/Nodes/AndNodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Nodes/AndNodeTests.cs
@@ -7,8 +7,10 @@ public sealed class AndNodeTests
 	[Fact]
 	public async Task ToString_ShouldCombineAllNodes()
 	{
+		#pragma warning disable CS4014
 		IThat<bool> that = That(true).Should();
 		that.BeTrue().And.BeFalse().And.Imply(false);
+		#pragma warning restore CS4014
 
 		string expectedResult = "be True and be False and imply False";
 

--- a/Tests/Testably.Expectations.Tests/Core/Nodes/OrNodeTests.cs
+++ b/Tests/Testably.Expectations.Tests/Core/Nodes/OrNodeTests.cs
@@ -7,8 +7,10 @@ public sealed class OrNodeTests
 	[Fact]
 	public async Task ToString_ShouldCombineAllNodes()
 	{
+		#pragma warning disable CS4014
 		IThat<bool> that = That(true).Should();
 		that.BeTrue().Or.BeFalse().Or.Imply(false);
+		#pragma warning restore CS4014
 
 		string expectedResult = "be True or be False or imply False";
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.OnlyIfTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.OnlyIfTests.cs
@@ -87,7 +87,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected action to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowExceptionTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowExceptionTests.cs
@@ -39,7 +39,23 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected action to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenChained_ShouldOnlyDisplayInformationAboutNotThrownException()
+		{
+			Action action = () => { };
+
+			async Task<Exception> Act()
+				=> await That(action).Should().ThrowException().WithMessage("foo");
+
+			await That(Act).Should().ThrowException()
+				.WithMessage("""
+				             Expected action to
+				             throw an Exception with Message equal to "foo",
+				             but it did not throw any exception
 				             """);
 		}
 	}

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowTests.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.ThrowTests.cs
@@ -42,7 +42,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected action to
 				             throw a CustomException,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 		

--- a/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.cs
+++ b/Tests/Testably.Expectations.Tests/ThatTests/Delegates/DelegateShould.cs
@@ -66,7 +66,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 
@@ -114,7 +114,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 
@@ -147,7 +147,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 
@@ -195,7 +195,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 
@@ -228,7 +228,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 
@@ -276,7 +276,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 
@@ -310,7 +310,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 
@@ -361,7 +361,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 
@@ -394,7 +394,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 
@@ -427,7 +427,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 
@@ -461,7 +461,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 #endif
@@ -498,7 +498,7 @@ public sealed partial class DelegateShould
 				.WithMessage("""
 				             Expected @delegate to
 				             throw an Exception,
-				             but it did not
+				             but it did not throw any exception
 				             """);
 		}
 #endif


### PR DESCRIPTION
Fixes #173