### PR TITLE
refactor: add XML comments for hidden methods

### DIFF
--- a/Source/Testably.Expectations/Core/IExpectSubject.cs
+++ b/Source/Testably.Expectations/Core/IExpectSubject.cs
@@ -8,15 +8,33 @@ namespace Testably.Expectations.Core;
 /// </summary>
 public interface IExpectSubject<out T>
 {
-	/// <inheritdoc cref="object.Equals(object?)" />
+	/// <summary>
+	///     <i>Not supported!</i><br />
+	///     <see cref="object.Equals(object?)" /> is not supported. Did you mean <c>Be</c> instead?
+	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	bool Equals(object? obj);
 
-	/// <inheritdoc cref="object.GetHashCode()" />
+	/// <summary>
+	///     <i>Not supported!</i><br />
+	///     <see cref="object.GetHashCode()" /> is not supported.
+	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	int GetHashCode();
 
-	/// <inheritdoc cref="object.GetType()" />
+	/// <summary>
+	///     <i>Not supported!</i><br />
+	///     <see cref="object.GetType()" /> is not supported.
+	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	Type GetType();
 
@@ -25,7 +43,13 @@ public interface IExpectSubject<out T>
 	/// </summary>
 	IThat<T> Should(Action<ExpectationBuilder> builderOptions);
 
-	/// <inheritdoc cref="object.ToString()" />
+	/// <summary>
+	///     <i>Not supported!</i><br />
+	///     <see cref="object.ToString()" /> is not supported.
+	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	string? ToString();
 }

--- a/Source/Testably.Expectations/Core/IThat.cs
+++ b/Source/Testably.Expectations/Core/IThat.cs
@@ -10,24 +10,53 @@ namespace Testably.Expectations.Core;
 public interface IThat<out T>
 {
 	/// <summary>
-	///     The expectation builder.
+	///     The expectation builder.<br />
+	///     <b>This property is only intended for extensions.</b>
 	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> with state set to
+	///     <see cref="EditorBrowsableState.Advanced" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
 	ExpectationBuilder ExpectationBuilder { get; }
 
-	/// <inheritdoc cref="object.Equals(object?)" />
+	/// <summary>
+	///     <i>Not supported!</i><br />
+	///     <see cref="object.Equals(object?)" /> is not supported. Did you mean <c>Be</c> instead?
+	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	bool Equals(object? obj);
 
-	/// <inheritdoc cref="object.GetHashCode()" />
+	/// <summary>
+	///     <i>Not supported!</i><br />
+	///     <see cref="object.GetHashCode()" /> is not supported.
+	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	int GetHashCode();
 
-	/// <inheritdoc cref="object.GetType()" />
+	/// <summary>
+	///     <i>Not supported!</i><br />
+	///     <see cref="object.GetType()" /> is not supported.
+	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	Type GetType();
 
-	/// <inheritdoc cref="object.ToString()" />
+	/// <summary>
+	///     <i>Not supported!</i><br />
+	///     <see cref="object.ToString()" /> is not supported.
+	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	string? ToString();
 }

--- a/Source/Testably.Expectations/Results/Expectation.cs
+++ b/Source/Testably.Expectations/Results/Expectation.cs
@@ -18,22 +18,46 @@ namespace Testably.Expectations.Results;
 [StackTraceHidden]
 public abstract class Expectation
 {
-	/// <inheritdoc cref="object.Equals(object?)" />
+	/// <summary>
+	///     <i>Not supported!</i><br />
+	///     <see cref="object.Equals(object?)" /> is not supported. Did you mean <c>Be</c> instead?
+	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public override bool Equals(object? obj)
 		=> throw new NotSupportedException("Equals is not supported. Did you mean Be() instead?");
 
-	/// <inheritdoc cref="object.GetHashCode()" />
+	/// <summary>
+	///     <i>Not supported!</i><br />
+	///     <see cref="object.GetHashCode()" /> is not supported.
+	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public override int GetHashCode()
 		=> throw new NotSupportedException("GetHashCode is not supported.");
 
-	/// <inheritdoc cref="object.GetType()" />
+	/// <summary>
+	///     <i>Not supported!</i><br />
+	///     <see cref="object.GetType()" /> is not supported.
+	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public new Type GetType()
 		=> base.GetType();
 
-	/// <inheritdoc cref="object.ToString()" />
+	/// <summary>
+	///     <i>Not supported!</i><br />
+	///     <see cref="object.ToString()" /> is not supported.
+	/// </summary>
+	/// <remarks>
+	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public override string? ToString()
 		=> base.ToString();


### PR DESCRIPTION
Add XML-Doc comments for methods hidden with the `EditorBrowsableAttribute` to clarify, why this should not be visible in code suggestions.